### PR TITLE
Check if posts exists before trying to get the meta

### DIFF
--- a/includes/class-coblocks-accordion-ie-support.php
+++ b/includes/class-coblocks-accordion-ie-support.php
@@ -79,8 +79,11 @@ class CoBlocks_Accordion_IE_Support {
 
 		global $post;
 
-		if ( empty( $post->ID ) ) {
+		// Validate Post ID
+		if ( ! isset( $post->ID ) || empty( $post->ID ) ) {
+
 			return;
+
 		}
 
 		$legacy_support = get_post_meta( $post->ID, '_coblocks_accordion_ie_support', true );

--- a/includes/class-coblocks-accordion-ie-support.php
+++ b/includes/class-coblocks-accordion-ie-support.php
@@ -79,6 +79,10 @@ class CoBlocks_Accordion_IE_Support {
 
 		global $post;
 
+		if ( empty( $post->ID ) ) {
+			return;
+		}
+
 		$legacy_support = get_post_meta( $post->ID, '_coblocks_accordion_ie_support', true );
 
 		// Determine whether a $post contains an Accordion block.


### PR DESCRIPTION
Hey awesome people!

Just wanted to let you know that in some edge cases like the 404.php templates there is a PHP warning since there is no `global $post` set. Here's a screenshot with the Twentynineteen theme:

![ID](https://user-images.githubusercontent.com/1893980/55724973-3f0adb80-5a15-11e9-8219-44c234398d6a.png)

A simple "check and quit early if" can avoid that, and there is no side effect since these pages won't need the custom style anyway.

I love the plugin, I hope I can contribute more soon.