### PR TITLE
Coblocks should validate the activate_plugin nonce before redirecting to the welcome screen

### DIFF
--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -173,7 +173,7 @@ class CoBlocks_Getting_Started_Page {
 
 			WP_CLI::log(
 				WP_CLI::colorize(
-					'%b' . sprintf( '🎉 %s %s', __( 'Get started with CoBlocks here:', 'coblocks' ), admin_url( 'admin.php?page=coblocks-getting-started' ) ) . '%n'
+					'%b' . sprintf( '🎉 %s %s', __( 'Get started with CoBlocks here:', '@@textdomain' ), admin_url( 'admin.php?page=coblocks-getting-started' ) ) . '%n'
 				)
 			);
 

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -149,24 +149,48 @@ class CoBlocks_Getting_Started_Page {
 
 	/**
 	 * Redirect to the Getting Started page upon plugin activation.
-	 * @param string $plugin plugin name
+	 *
+	 * @param string $plugin The activate plugin name.
 	 */
 	public function redirect( $plugin ) {
+
 		if ( 'coblocks/class-coblocks.php' !== $plugin ) {
+
 			return;
+
 		}
 
-		if ( defined('WP_CLI') && WP_CLI ) {
+		$nonce          = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
+		$activate_multi = filter_input( INPUT_GET, 'activate-multi', FILTER_VALIDATE_BOOLEAN );
+
+		if ( ! $nonce ) {
+
+			return;
+
+		}
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+
 			WP_CLI::log(
-				WP_CLI::colorize( "%b" . sprintf("🎉 %s %s", __('Get started with CoBlocks here:', '@@textdomain'), admin_url( 'admin.php?page=coblocks-getting-started' ) ) . "%n" )
+				WP_CLI::colorize(
+					'%b' . sprintf( '🎉 %s %s', __( 'Get started with CoBlocks here:', 'coblocks' ), admin_url( 'admin.php?page=coblocks-getting-started' ) ) . '%n'
+				)
 			);
+
 			return;
+
 		}
 
-		if ( ! isset( $_GET['activate-multi'] ) ) {
-			wp_safe_redirect( admin_url( 'admin.php?page=coblocks-getting-started' ) );
-			die();
+		if ( $activate_multi ) {
+
+			return;
+
 		}
+
+		wp_safe_redirect( admin_url( 'admin.php?page=coblocks-getting-started' ) );
+
+		die();
+
 	}
 }
 


### PR DESCRIPTION
In preparation of the PHPCS implementation (#485) this PR checks the security nonce before redirecting the user to the welcome screen. This ensures that Coblocks was the activated plugin and the nonce security check passes.

Where possible we should avoid ignoring PHPCS warnings/errors (ie: `// phpcs:ignore`)

### Other minor tweaks such as:
- Single quotes instead of double
- Spacing tweaks
- Returning early under certain conditions (eg: Nonce security check does not pass, `$activate_multi` is true, the plugin was activated via `WP_CLI` etc.)