### PR TITLE
[tiny] Fixes #499

### DIFF
--- a/src/styles/style/_background-parallax.scss
+++ b/src/styles/style/_background-parallax.scss
@@ -1,3 +1,15 @@
 .has-parallax {
 	background-attachment: fixed;
+
+	// Mobile Safari does not support fixed background attachment properly.
+	// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios
+	// Chrome on Android does not appear to support the attachment at all: https://issuetracker.google.com/issues/36908439
+	@supports (-webkit-overflow-scrolling: touch) {
+		background-attachment: scroll;
+	}
+
+	// Remove the appearance of scrolling based on OS-level animation preferences.
+	@media (prefers-reduced-motion: reduce) {
+		background-attachment: scroll;
+	}
 }


### PR DESCRIPTION
Removes the appearance of scrolling based on OS-level animation preferences when the .has-parallax class is added to a block. Closes #499