### PR TITLE
Update plugin information

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,22 +14,22 @@ appearance, race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+-   Using welcoming and inclusive language
+-   Being respectful of differing viewpoints and experiences
+-   Gracefully accepting constructive criticism
+-   Focusing on what is best for the community
+-   Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+-   The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+-   Trolling, insulting/derogatory comments, and personal or political attacks
+-   Public or private harassment
+-   Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+-   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
 
 ## Our Responsibilities
 
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at hello@coblocks.com. All
+reported by contacting the project team at oss@godaddy.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at oss@godaddy.com. All
+reported by contacting the project team at plugins@godaddy.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ When contributing please ensure you follow the guidelines below so that we can k
 
 ## Getting Started
 
--   **Do not report potential security vulnerabilities here. Email them privately to me at [hello at coblocks dot com](mailto:hello@coblocks.com)**
+-   **Do not report potential security vulnerabilities here. Email them privately to our team at [oss@godaddy.com](mailto:oss@godaddy.com)**
 -   Before submitting a ticket, please be sure to replicate the behavior with no other plugins active and on a base theme like Twenty Seventeen.
 -   Submit a ticket for your issue, assuming one does not already exist.
     -   Raise it on our [Issue Tracker](https://github.com/coblocks/coblocks/issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ When contributing please ensure you follow the guidelines below so that we can k
 
 ## Getting Started
 
--   **Do not report potential security vulnerabilities here. Email them privately to our team at [oss@godaddy.com](mailto:oss@godaddy.com)**
+-   **Do not report potential security vulnerabilities here. Email them privately to our team at [plugins@godaddy.com](mailto:plugins@godaddy.com)**
 -   Before submitting a ticket, please be sure to replicate the behavior with no other plugins active and on a base theme like Twenty Seventeen.
 -   Submit a ticket for your issue, assuming one does not already exist.
     -   Raise it on our [Issue Tracker](https://github.com/godaddy/coblocks/issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ When contributing please ensure you follow the guidelines below so that we can k
 -   **Do not report potential security vulnerabilities here. Email them privately to our team at [oss@godaddy.com](mailto:oss@godaddy.com)**
 -   Before submitting a ticket, please be sure to replicate the behavior with no other plugins active and on a base theme like Twenty Seventeen.
 -   Submit a ticket for your issue, assuming one does not already exist.
-    -   Raise it on our [Issue Tracker](https://github.com/coblocks/coblocks/issues)
+    -   Raise it on our [Issue Tracker](https://github.com/godaddy/coblocks/issues)
     -   Clearly describe the issue including steps to reproduce the bug.
     -   Make sure you fill in the earliest version that you know has the issue as well as the version of WordPress you're using.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Easily toggle off any WordPress block in the Gutenberg editor with the new CoBlo
 
 ## Development
 
-1. Clone the GitHub repository: `https://github.com/coblocks/coblocks.git`
+1. Clone the GitHub repository: `https://github.com/godaddy/coblocks.git`
 2. Browse to the folder in the command line.
 3. Run the `npm install` command to install the plugin's dependencies within a /node_modules/ folder.
 4. Run the `npm start` command for development.
@@ -60,7 +60,7 @@ Easily toggle off any WordPress block in the Gutenberg editor with the new CoBlo
 
 ## Support
 
-Need help? This is a developer's portal for CoBlocks and should not be used for general support and queries. Please reach out via the contact form at the bottom right of [our website](https://coblocks.com) or visit the [CoBlocks support forum on WordPress.org](https://wordpress.org/support/plugin/coblocks).
+Need help? This is a developer's portal for CoBlocks and should not be used for general support and queries. Please visit the [CoBlocks support forum on WordPress.org](https://wordpress.org/support/plugin/coblocks) for assistance.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Need help? This is a developer's portal for CoBlocks and should not be used for 
 
 ## Contributions
 
-Please read the [guidelines for contributing](https://github.com/coblocks/coblocks/blob/master/CONTRIBUTING.md) to CoBlocks. Anyone is welcome to contribute. If you find a 🐞 or an issue, [create an issue](https://github.com/coblocks/coblocks/issues/new). Here are ways to contribute:
+Please read the [guidelines for contributing](https://github.com/godaddy/coblocks/blob/master/CONTRIBUTING.md) to CoBlocks. Anyone is welcome to contribute. If you find a 🐞 or an issue, [create an issue](https://github.com/godaddy/coblocks/issues/new). Here are ways to contribute:
 
-1. Raise an [issue](https://github.com/coblocks/coblocks/issues/new)
+1. Raise an [issue](https://github.com/godaddy/coblocks/issues/new)
 2. Send a pull request with your bug fixes and/or new features
 3. Provide feedback and suggestions
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,9 @@ Easily toggle off any WordPress block in the Gutenberg editor with the new CoBlo
 ### Connect
 
 -   [Download on WordPress.org](https://wordpress.org/plugins/coblocks/)
--   [Visit our website](https://coblocks.com?utm_medium=wp.org&utm_source=wordpressorg&utm_campaign=readme&utm_content=coblocks)
--   [Subscribe to updates](http://eepurl.com/gd1S8D)
 -   [Follow on Twitter](https://twitter.com/coblocks)
 -   [Join our Facebook Community](https://facebook.com/groups/coblocks)
 -   [Like us on Facebook](https://www.facebook.com/coblocks/)
--   [Follow us on Instagram](https://www.instagram.com/coblockswp/)
 
 ## Installation
 

--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://coblocks.com/
  * Description: CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress.
  * Author: GoDaddy
- * Author URI: https://godaddy.com
+ * Author URI: https://www.godaddy.com
  * Version: 1.9.4
  * Text Domain: coblocks
  * Domain Path: languages

--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -3,8 +3,8 @@
  * Plugin Name: CoBlocks
  * Plugin URI: https://coblocks.com/
  * Description: CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress.
- * Author: CoBlocks
- * Author URI: https://coblocks.com/
+ * Author: GoDaddy
+ * Author URI: https://godaddy.com
  * Version: 1.9.4
  * Text Domain: coblocks
  * Domain Path: languages

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Page Builder Gutenberg Blocks – CoBlocks ===
-Author URI: https://coblocks.com
+Author URI: https://godaddy.com
 Plugin URI: https://coblocks.com
 Contributors: coblocks, richtabor, phpbits
 Tags: page builder, Gutenberg blocks, WordPress blocks, gutenberg, blocks

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Page Builder Gutenberg Blocks – CoBlocks ===
-Author URI: https://godaddy.com
-Plugin URI: https://coblocks.com
+Author URI: https://www.godaddy.com
+Plugin URI: https://www.coblocks.com
 Contributors: coblocks, richtabor, phpbits
 Tags: page builder, Gutenberg blocks, WordPress blocks, gutenberg, blocks
 Requires at least: 5.0

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,7 @@ The vision for CoBlocks is to create a suite of Gutenberg blocks to help folks m
 * [Follow us on Instagram](https://www.instagram.com/coblockswp/)
 
 ## Built with developers in mind
-Extensible, adaptable, and open source — CoBlocks is created with theme and plugin developers in mind. If you're intersted to jump in the project, there are opportunities for developers at all levels to get involved. [Contribute to CoBlocks on GitHub](https://github.com/coblocks/coblocks) and join the party. 🎉
+Extensible, adaptable, and open source — CoBlocks is created with theme and plugin developers in mind. If you're intersted to jump in the project, there are opportunities for developers at all levels to get involved. [Contribute to CoBlocks on GitHub](https://github.com/godaddy/coblocks) and join the party. 🎉
 
 
 == Screenshots ==


### PR DESCRIPTION
This PR replaces CoBlocks as the plugin author, updates the associated email addresses with GoDaddy's, and cleans up unnecessary bits in the readmes.