### PR TITLE
Resolve Hero block layout positioning issue

### DIFF
--- a/src/blocks/hero/styles/style.scss
+++ b/src/blocks/hero/styles/style.scss
@@ -82,8 +82,14 @@
 		&.hero-center-center-align {
 			> .wp-block-coblocks-hero__box {
 				grid-column: 2;
-				grid-row: 2;
+				grid-row: 1;
 				margin: auto;
+			}
+		}
+
+		&.hero-center-center-align.is-fullscreen {
+			> .wp-block-coblocks-hero__box {
+				grid-row: 2;
 			}
 		}
 
@@ -132,5 +138,9 @@
 				grid-template-rows: auto;
 			}
 		}
+	}
+
+	.wp-block-button {
+		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
This PR resolves an issue where the Hero block content would not properly center, as reported via this [WordPress.org support ticket](https://wordpress.org/support/topic/hero-content-not-center/#post-11562250). 