### PR TITLE
Resolve Pricing Table outlines issue in Gutenberg 5.7+

### DIFF
--- a/src/blocks/pricing-table/styles/editor.scss
+++ b/src/blocks/pricing-table/styles/editor.scss
@@ -2,6 +2,11 @@
 	margin-bottom: -15px;
 	margin-top: -15px;
 
+	[data-block] {
+		margin-bottom: 0;
+		margin-top: 0;
+	}
+
 	.wp-block-coblocks-pricing-table {
 		&__inner {
 			margin-left: 0 !important;


### PR DESCRIPTION
This PR resolves an issue where the pricing table is-selected outlines are not properly displaying, due to additional styling Gutenberg 5.7+ adds to every block. 