### PR TITLE
Fix text transform normal issue

### DIFF
--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -128,7 +128,7 @@ class TypographyControls extends Component {
 				label: __( 'Capitalize' ),
 			},
 			{
-				value: 'normal',
+				value: 'initial',
 				label: __( 'Normal' ),
 			},
 		];


### PR DESCRIPTION
This PR closes #516 by setting the default value of the text transform SelectControl to `initial` instead of `normal`.