### PR TITLE
Remove the block mover from the Media Card row block

### DIFF
--- a/src/blocks/media-card/styles/editor.scss
+++ b/src/blocks/media-card/styles/editor.scss
@@ -170,6 +170,10 @@
 		outline: 4px solid $blue;
 	}
 
+	.wp-block[data-type="coblocks/row"] .editor-block-mover {
+		display: none;
+	}
+
 	.wp-block[data-type="coblocks/row"] .editor-block-list__block-edit::before {
 		outline-style: solid !important;
 	}


### PR DESCRIPTION
This PR removes the block mover from the card within the Media Card block (which is a Row block). There's only one top-level block nested, so displaying the mover is not necessary (as it doesn't move). 

**Before:** 

<img width="1006" alt="Screen Shot 2019-05-23 at 12 57 19 PM" src="https://user-images.githubusercontent.com/1813435/58271591-66fe9600-7d5a-11e9-9520-579f699582ac.png">

**After:** 

<img width="971" alt="Screen Shot 2019-05-23 at 12 57 05 PM" src="https://user-images.githubusercontent.com/1813435/58271596-6b2ab380-7d5a-11e9-9d2e-7336282590ed.png">