### PR TITLE
Remove custom Color Settings for the heading block

### DIFF
--- a/src/extensions/colors/index.js
+++ b/src/extensions/colors/index.js
@@ -43,7 +43,7 @@ function ColorSettings( props, options ) {
 
 	let colorSettings = [];
 
-	if( ![ 'core/heading', 'core/list', 'core/quote' ].includes( name ) ){
+	if( ![ 'core/list', 'core/quote' ].includes( name ) ){
 		colorSettings.push({
 			value: customBackgroundColor,
 			onChange: ( nextcustomBackgroundColor ) => setAttributes( {  customBackgroundColor: nextcustomBackgroundColor } ),

--- a/src/extensions/colors/inspector.js
+++ b/src/extensions/colors/inspector.js
@@ -19,7 +19,7 @@ const { compose, createHigherOrderComponent } = wp.compose;
  */
 const Inspector = props => {
  	const { attributes, setAttributes } = props;
- 	const allowedBlocks = [ 'core/heading', 'core/cover', 'core/button', 'core/list', 'core/quote' ];
+ 	const allowedBlocks = [ 'core/cover', 'core/button', 'core/list', 'core/quote' ];
 
 	// Display on the allowedBlocks only.
 	if ( ! allowedBlocks.includes( props.name ) ){
@@ -29,7 +29,7 @@ const Inspector = props => {
 	}
 
 	// Show line height on appropriate blocks.
-	if ( ! [ 'core/heading', 'core/paragraph', 'core/cover', 'core/button' ].includes( props.name ) ) {
+	if ( ! [ 'core/paragraph', 'core/cover', 'core/button' ].includes( props.name ) ) {
 		props.attributes.textPanelLineHeight = true;
 	}
 
@@ -50,7 +50,7 @@ const Inspector = props => {
  * @return {Object} Filtered block settings.
  */
 function addAttributes( settings ) {
-	const allowedBlocks = [ 'core/heading', 'core/list', 'core/quote' ];
+	const allowedBlocks = [ 'core/list', 'core/quote' ];
 	// Use Lodash's assign to gracefully handle if attributes are undefined
 	if( allowedBlocks.includes( settings.name ) ){
 		settings.attributes = Object.assign( settings.attributes, ColorSettingsAttributes );
@@ -67,7 +67,7 @@ function addAttributes( settings ) {
  */
 const withInspectorControl = createHigherOrderComponent( (BlockEdit) => {
 	return ( props ) => {
-		const allowedBlocks = [ 'core/heading', 'core/list', 'core/quote' ];
+		const allowedBlocks = [ 'core/list', 'core/quote' ];
 		return (
 			<Fragment>
 				<BlockEdit {...props} />


### PR DESCRIPTION
Gutenberg 5.8 adds support for applying a text color to the the core Heading block. This PR removes our custom Color Settings PanelBody as its not needed any longer. 

This PR should be merged once Gutenberg 5.8 has been merged into WordPress core.