### PR TITLE
Move the Marker Size RangeControl below Height

### DIFF
--- a/src/blocks/map/components/inspector.js
+++ b/src/blocks/map/components/inspector.js
@@ -132,6 +132,16 @@ class Inspector extends Component {
 									max={ 20 }
 									step={ 1 }
 								/>
+								<RangeControl
+									label={ __( 'Height in pixels' ) }
+									aria-label={ __( 'Height for the map in pixels' ) }
+									value={ height }
+									onChange={ () => setAttributes( { height: parseInt( event.target.value, 10 ) } ) }
+									className="components-block-coblocks-height__custom-input"
+									min={ 200 }
+									max={ 1000 }
+									step={ 10 }
+								/>
 								{
 									!! apiKey &&
 									<RangeControl
@@ -144,16 +154,6 @@ class Inspector extends Component {
 										step={ 2 }
 									/>
 								}
-								<RangeControl
-									label={ __( 'Height in pixels' ) }
-									aria-label={ __( 'Height for the map in pixels' ) }
-									value={ height }
-									onChange={ () => setAttributes( { height: parseInt( event.target.value, 10 ) } ) }
-									className="components-block-coblocks-height__custom-input"
-									min={ 200 }
-									max={ 1000 }
-									step={ 10 }
-								/>
 								{
 									!! apiKey &&
 									<ToggleControl


### PR DESCRIPTION
This PR moves the Marker Size RangeControl to below the Height control, to ensure consistency in the UI when a Google Maps API key is added. 