### PR TITLE
Fix extra top and bottom spacing in Gutenberg 5.8

### DIFF
--- a/src/extensions/advanced-controls/styles/editor.scss
+++ b/src/extensions/advanced-controls/styles/editor.scss
@@ -64,8 +64,11 @@
 
 	// Remove top and bottom margin from Gutenberg 5.8+ [data-block] margin
 	.wp-block[data-coblocks-top-spacing="1"] .editor-block-list__block-edit > [data-block] {
-		margin-bottom: 0;
 		margin-top: 0;
+	}
+
+	.wp-block[data-coblocks-bottom-spacing="1"] .editor-block-list__block-edit > [data-block] {
+		margin-bottom: 0;
 	}
 
 	//Make sure block is on the top z-index.

--- a/src/extensions/advanced-controls/styles/editor.scss
+++ b/src/extensions/advanced-controls/styles/editor.scss
@@ -1,5 +1,4 @@
 .editor-styles-wrapper {
-
 	.wp-block.editor-block-list__block[data-coblocks-bottom-spacing="1"][data-type="core/image"] {
 		.editor-rich-text {
 			display: none;
@@ -63,7 +62,11 @@
 		}
 	}
 
-
+	// Remove top and bottom margin from Gutenberg 5.8+ [data-block] margin
+	.wp-block[data-coblocks-top-spacing="1"] .editor-block-list__block-edit > [data-block] {
+		margin-bottom: 0;
+		margin-top: 0;
+	}
 
 	//Make sure block is on the top z-index.
 	.wp-block {


### PR DESCRIPTION
This PR closes #567 by appropriately removing the auto-applied styles in Gutenberg 5.8+. 
