### PR TITLE
Change the Row block layout panelBody label from "Layout" to "Style" 

### DIFF
--- a/src/blocks/row/components/inspector.js
+++ b/src/blocks/row/components/inspector.js
@@ -116,7 +116,7 @@ class Inspector extends Component {
 					{ ( columns && selectedRows >= 1 ) &&
 						<Fragment>
 							{ selectedRows > 1 &&
-								<PanelBody title={ __( 'Style' ) } initialOpen={ false }>
+								<PanelBody title={ __( 'Styles' ) } initialOpen={ false }>
 									<div className="components-coblocks-visual-dropdown">
 										<ButtonGroup aria-label={ __( 'Select Row Layout' ) }>
 											{ map( layoutOptions[ selectedRows ], ( { name, key, icon } ) => (

--- a/src/blocks/row/components/inspector.js
+++ b/src/blocks/row/components/inspector.js
@@ -6,8 +6,7 @@ import map from 'lodash/map';
 /**
  * Internal dependencies
  */
-import { layoutOptions } from './layouts'
-import rowIcons from './icons';
+import { layoutOptions } from './layouts';
 import applyWithColors from './colors';
 import { BackgroundPanel } from '../../../components/background';
 import DimensionsControl from '../../../components/dimensions-control/';
@@ -18,8 +17,8 @@ import DimensionsControl from '../../../components/dimensions-control/';
 const { __ } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
-const { InspectorControls, PanelColorSettings, ContrastChecker } = wp.editor;
-const { PanelBody, RangeControl, SelectControl, ToggleControl, ButtonGroup, Button, Tooltip, Placeholder, withFallbackStyles } = wp.components;
+const { InspectorControls, PanelColorSettings } = wp.editor;
+const { PanelBody, SelectControl, ButtonGroup, Button, Tooltip, withFallbackStyles } = wp.components;
 
 /**
  * Fallback styles
@@ -27,10 +26,8 @@ const { PanelBody, RangeControl, SelectControl, ToggleControl, ButtonGroup, Butt
 const { getComputedStyle } = window;
 
 const FallbackStyles = withFallbackStyles( ( node, ownProps ) => {
-
 	const {
 		backgroundColor,
-		textColor,
 	} = ownProps.attributes;
 
 	const editableNode = node.querySelector( '[contenteditable="true"]' );
@@ -47,19 +44,11 @@ const FallbackStyles = withFallbackStyles( ( node, ownProps ) => {
  * Inspector controls
  */
 class Inspector extends Component {
-
-	constructor( props ) {
-		super( ...arguments );
-	}
-
 	render() {
-
 		const {
 			attributes,
 			backgroundColor,
 			clientId,
-			customBackgroundColor,
-			fallbackBackgroundColor,
 			setAttributes,
 			setBackgroundColor,
 			setTextColor,
@@ -70,7 +59,6 @@ class Inspector extends Component {
 			columns,
 			gutter,
 			layout,
-			stacked,
 			marginBottom,
 			marginLeft,
 			marginRight,
@@ -106,7 +94,6 @@ class Inspector extends Component {
 			paddingSyncUnitsMobile,
 			paddingUnit,
 			hasMarginControl,
-			hasStackedControl,
 		} = attributes;
 
 		const gutterOptions = [
@@ -120,7 +107,7 @@ class Inspector extends Component {
 		let selectedRows = 1;
 
 		if ( columns ) {
-			selectedRows = parseInt( columns.toString().split('-') );
+			selectedRows = parseInt( columns.toString().split( '-' ) );
 		}
 
 		return (
@@ -132,31 +119,31 @@ class Inspector extends Component {
 								<PanelBody title={ __( 'Style' ) } initialOpen={ false }>
 									<div className="components-coblocks-visual-dropdown">
 										<ButtonGroup aria-label={ __( 'Select Row Layout' ) }>
-										{ map( layoutOptions[ selectedRows ], ( { name, key, icon, cols } ) => (
-											<Tooltip text={ name }>
-												<div className={ ( key == layout ) ? 'components-coblocks-visual-dropdown__button-wrapper is-selected' : 'components-coblocks-visual-dropdown__button-wrapper' }>
-													<Button
-														className={ ( key == layout ) ? 'components-coblocks-visual-dropdown__button components-coblocks-visual-dropdown__button--selected' : 'components-coblocks-visual-dropdown__button' }
-														isSmall
-														onClick={ () => {
-															let selectedWidth = key.toString().split('-');
-															let children = wp.data.select( 'core/editor' ).getBlocksByClientId( clientId );
-															setAttributes( {
-																layout: key,
-															} );
+											{ map( layoutOptions[ selectedRows ], ( { name, key, icon } ) => (
+												<Tooltip text={ name }>
+													<div className={ ( key === layout ) ? 'components-coblocks-visual-dropdown__button-wrapper is-selected' : 'components-coblocks-visual-dropdown__button-wrapper' }>
+														<Button
+															className={ ( key === layout ) ? 'components-coblocks-visual-dropdown__button components-coblocks-visual-dropdown__button--selected' : 'components-coblocks-visual-dropdown__button' }
+															isSmall
+															onClick={ () => {
+																const selectedWidth = key.toString().split( '-' );
+																const children = wp.data.select( 'core/editor' ).getBlocksByClientId( clientId );
+																setAttributes( {
+																	layout: key,
+																} );
 
-															if ( typeof children[0].innerBlocks !== 'undefined' ) {
-																map( children[0].innerBlocks, ( { clientId }, index ) => (
-																	wp.data.dispatch( 'core/editor' ).updateBlockAttributes( clientId, { width : selectedWidth[ index ] } )
-																) );
-															}
-														} }
-													>
-														{ icon }
-													</Button>
-												</div>
-											</Tooltip>
-										) ) }
+																if ( typeof children[ 0 ].innerBlocks !== 'undefined' ) {
+																	map( children[ 0 ].innerBlocks, ( { childrenClientId }, index ) => (
+																		wp.data.dispatch( 'core/editor' ).updateBlockAttributes( childrenClientId, { width: selectedWidth[ index ] } )
+																	) );
+																}
+															} }
+														>
+															{ icon }
+														</Button>
+													</div>
+												</Tooltip>
+											) ) }
 										</ButtonGroup>
 									</div>
 								</PanelBody>
@@ -164,61 +151,61 @@ class Inspector extends Component {
 							{ layout &&
 								<Fragment>
 									<PanelBody title={ __( 'Row Settings' ) }>
-											{ hasMarginControl &&
-												<DimensionsControl { ...this.props }
-													type={ 'margin' }
-													label={ __( 'Margin' ) }
-													help={ __( 'Space around the container.' ) }
-													valueTop={ marginTop }
-													valueRight={ marginRight }
-													valueBottom={ marginBottom }
-													valueLeft={ marginLeft }
-													valueTopTablet={ marginTopTablet }
-													valueRightTablet={ marginRightTablet }
-													valueBottomTablet={ marginBottomTablet }
-													valueLeftTablet={ marginLeftTablet }
-													valueTopMobile={ marginTopMobile }
-													valueRightMobile={ marginRightMobile }
-													valueBottomMobile={ marginBottomMobile }
-													valueLeftMobile={ marginLeftMobile }
-													unit={ marginUnit }
-													syncUnits={ marginSyncUnits }
-													syncUnitsTablet={ marginSyncUnitsTablet }
-													syncUnitsMobile={ marginSyncUnitsMobile }
-													dimensionSize={ marginSize }
-												/>
-											}
+										{ hasMarginControl &&
 											<DimensionsControl { ...this.props }
-												type={ 'padding' }
-												label={ __( 'Padding' ) }
-												help={ __( 'Space inside of the container.' ) }
-												valueTop={ paddingTop }
-												valueRight={ paddingRight }
-												valueBottom={ paddingBottom }
-												valueLeft={ paddingLeft }
-												valueTopTablet={ paddingTopTablet }
-												valueRightTablet={ paddingRightTablet }
-												valueBottomTablet={ paddingBottomTablet }
-												valueLeftTablet={ paddingLeftTablet }
-												valueTopMobile={ paddingTopMobile }
-												valueRightMobile={ paddingRightMobile }
-												valueBottomMobile={ paddingBottomMobile }
-												valueLeftMobile={ paddingLeftMobile }
-												unit={ paddingUnit }
-												syncUnits={ paddingSyncUnits }
-												syncUnitsTablet={ paddingSyncUnitsTablet }
-												syncUnitsMobile={ paddingSyncUnitsMobile }
-												dimensionSize={ paddingSize }
+												type={ 'margin' }
+												label={ __( 'Margin' ) }
+												help={ __( 'Space around the container.' ) }
+												valueTop={ marginTop }
+												valueRight={ marginRight }
+												valueBottom={ marginBottom }
+												valueLeft={ marginLeft }
+												valueTopTablet={ marginTopTablet }
+												valueRightTablet={ marginRightTablet }
+												valueBottomTablet={ marginBottomTablet }
+												valueLeftTablet={ marginLeftTablet }
+												valueTopMobile={ marginTopMobile }
+												valueRightMobile={ marginRightMobile }
+												valueBottomMobile={ marginBottomMobile }
+												valueLeftMobile={ marginLeftMobile }
+												unit={ marginUnit }
+												syncUnits={ marginSyncUnits }
+												syncUnitsTablet={ marginSyncUnitsTablet }
+												syncUnitsMobile={ marginSyncUnitsMobile }
+												dimensionSize={ marginSize }
 											/>
-											{ selectedRows >= 2 &&
-												<SelectControl
-													label={ __( 'Gutter' ) }
-													value={ gutter }
-													options={ gutterOptions }
-													help={ __( 'Space between each column.' ) }
-													onChange={ ( value ) => setAttributes( { gutter: value } ) }
-												/>
-											}
+										}
+										<DimensionsControl { ...this.props }
+											type={ 'padding' }
+											label={ __( 'Padding' ) }
+											help={ __( 'Space inside of the container.' ) }
+											valueTop={ paddingTop }
+											valueRight={ paddingRight }
+											valueBottom={ paddingBottom }
+											valueLeft={ paddingLeft }
+											valueTopTablet={ paddingTopTablet }
+											valueRightTablet={ paddingRightTablet }
+											valueBottomTablet={ paddingBottomTablet }
+											valueLeftTablet={ paddingLeftTablet }
+											valueTopMobile={ paddingTopMobile }
+											valueRightMobile={ paddingRightMobile }
+											valueBottomMobile={ paddingBottomMobile }
+											valueLeftMobile={ paddingLeftMobile }
+											unit={ paddingUnit }
+											syncUnits={ paddingSyncUnits }
+											syncUnitsTablet={ paddingSyncUnitsTablet }
+											syncUnitsMobile={ paddingSyncUnitsMobile }
+											dimensionSize={ paddingSize }
+										/>
+										{ selectedRows >= 2 &&
+											<SelectControl
+												label={ __( 'Gutter' ) }
+												value={ gutter }
+												options={ gutterOptions }
+												help={ __( 'Space between each column.' ) }
+												onChange={ ( value ) => setAttributes( { gutter: value } ) }
+											/>
+										}
 									</PanelBody>
 									<PanelColorSettings
 										title={ __( 'Color Settings' ) }
@@ -227,16 +214,13 @@ class Inspector extends Component {
 											{
 												value: backgroundColor.color,
 												onChange: ( nextBackgroundColor ) => {
-
 													setBackgroundColor( nextBackgroundColor );
 
-													//add padding if there's none
-													if( !paddingSize || paddingSize == 'no' ){
-														setAttributes({ paddingSize: 'medium' });
+													if ( ! paddingSize || paddingSize === 'no' ) {
+														setAttributes( { paddingSize: 'medium' } );
 													}
 
-													//reset when cleared
-													if( !nextBackgroundColor ){
+													if ( ! nextBackgroundColor ) {
 														setAttributes( { paddingSize: 'no' } );
 													}
 												},
@@ -251,8 +235,8 @@ class Inspector extends Component {
 									>
 									</PanelColorSettings>
 									<BackgroundPanel { ...this.props }
-						 				hasOverlay={ true }
-						 			/>
+										hasOverlay={ true }
+									/>
 								</Fragment>
 							}
 						</Fragment>

--- a/src/blocks/row/components/inspector.js
+++ b/src/blocks/row/components/inspector.js
@@ -129,7 +129,7 @@ class Inspector extends Component {
 					{ ( columns && selectedRows >= 1 ) &&
 						<Fragment>
 							{ selectedRows > 1 &&
-								<PanelBody title={ __( 'Layout' ) } initialOpen={ false }>
+								<PanelBody title={ __( 'Style' ) } initialOpen={ false }>
 									<div className="components-coblocks-visual-dropdown">
 										<ButtonGroup aria-label={ __( 'Select Row Layout' ) }>
 										{ map( layoutOptions[ selectedRows ], ( { name, key, icon, cols } ) => (


### PR DESCRIPTION
This PR changes the "Layout" label of the Row block PanelBody component to "Style", which abides by the design patterns set by core. 

**Screenshot:** 
<img width="281" alt="Screen Shot 2019-06-09 at 8 52 34 PM" src="https://user-images.githubusercontent.com/1813435/59166514-863a4900-8af8-11e9-9994-8d7e82945549.png">
