### PR TITLE
Add "Gallery" to gallery block names

### DIFF
--- a/src/blocks/gallery-carousel/index.js
+++ b/src/blocks/gallery-carousel/index.js
@@ -26,7 +26,7 @@ const { getColorClassName, RichText } = wp.editor;
  */
 const name = 'gallery-carousel';
 
-const title = __( 'Carousel' );
+const title = __( 'Carousel Gallery' );
 
 const icon = icons.carousel;
 

--- a/src/blocks/gallery-masonry/index.js
+++ b/src/blocks/gallery-masonry/index.js
@@ -26,7 +26,7 @@ const { RichText } = wp.editor;
  */
 const name = 'gallery-masonry';
 
-const title = __( 'Masonry' );
+const title = __( 'Masonry Gallery' );
 
 const icon = icons.masonry;
 

--- a/src/blocks/gallery-stacked/index.js
+++ b/src/blocks/gallery-stacked/index.js
@@ -25,7 +25,7 @@ const { RichText, getFontSizeClass, getColorClassName } = wp.editor;
  */
 const name = 'gallery-stacked';
 
-const title = __( 'Stacked' );
+const title = __( 'Stacked Gallery' );
 
 const icon = icons.stacked;
 


### PR DESCRIPTION
This PR is the alternate experiment of the #581 issue, appending "Gallery" to the gallery block names, to make them much more recognizable - instead of having a separate Gallery Blocks category within the block inserter (which is this #584 PR).

<img width="876" alt="Screen Shot 2019-06-13 at 3 19 16 PM" src="https://user-images.githubusercontent.com/1813435/59462250-52f60380-8df1-11e9-8f9f-5ad90bd30a37.png">