### PR TITLE
Introduce filter to nest Getting Started page in a parent menu item

### DIFF
--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -37,7 +37,7 @@ class CoBlocks_Getting_Started_Page {
 		 *
 		 * @var string
 		 */
-		$submenu_parent_slug = (string) apply_filters( 'coblocks_getting_submenu_slug', '' );
+		$submenu_parent_slug = (string) apply_filters( 'coblocks_getting_submenu_parent_slug', '' );
 
 		if ( '' !== $submenu_parent_slug ) {
 

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -37,7 +37,7 @@ class CoBlocks_Getting_Started_Page {
 		 *
 		 * @var string
 		 */
-		$submenu_parent_slug = (string) apply_filters( 'coblocks_getting_submenu_parent_slug', '' );
+		$submenu_parent_slug = (string) apply_filters( 'coblocks_getting_started_submenu_parent_slug', '' );
 
 		if ( '' !== $submenu_parent_slug ) {
 

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -32,6 +32,28 @@ class CoBlocks_Getting_Started_Page {
 		// Menu icon.
 		$svg = '<svg fill="#a0a5aa" height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg"><path d="m4.26414583.01915857 7.65399957-.01909461c1.4476957-.0036116 1.9730418.14581421 2.5030049.42754356.5299632.28172936.9463642.69605707 1.2307358 1.22460786.2843716.5285508.4364185 1.0531452.4400359 2.50084368l.019125 7.65401434c.0036173 1.4476985-.1458061 1.973045-.4275329 2.503008-.2817267.5299631-.6960519.9463632-1.2246006 1.2307333-.5285486.28437-1.0531414.4364151-2.5008371.4400267l-7.6539996.0190946c-1.44769568.0036116-1.97304176-.1458142-2.50300491-.4275435-.52996316-.2817294-.94636416-.6960571-1.23073576-1.2246079s-.43641852-1.0531452-.44003586-2.5008437l-.019125-7.65401429c-.00361735-1.44769847.1458061-1.97304496.4275328-2.50300802.28172671-.52996305.69605197-.9463632 1.22460063-1.23073324.52854865-.28437005 1.05314144-.43641517 2.50083713-.44002678zm-.15303472 2.98084143c-.55228475 0-1 .44771525-1 1v8c0 .5522847.44771525 1 1 1h2c.55228475 0 1-.4477153 1-1v-8c0-.55228475-.44771525-1-1-1zm5.99999999 6c-.55228474 0-.99999999.44771525-.99999999 1v2c0 .5522847.44771525 1 .99999999 1h2c.5522848 0 1-.4477153 1-1v-2c0-.55228475-.4477152-1-1-1zm0-6c-.55228474 0-.99999999.44771525-.99999999 1v2c0 .55228475.44771525 1 .99999999 1h2c.5522848 0 1-.44771525 1-1v-2c0-.55228475-.4477152-1-1-1z" fill-rule="evenodd" transform="translate(1.888889 2)"/></svg>';
 
+		/**
+		 * Allow users to nest the CoBlocks menu page
+		 *
+		 * @var string
+		 */
+		$submenu_parent_slug = (string) apply_filters( 'coblocks_getting_submenu_slug', '' );
+
+		if ( '' !== $submenu_parent_slug ) {
+
+			add_submenu_page(
+				$submenu_parent_slug,
+				__( 'CoBlocks', 'coblocks' ),
+				__( 'CoBlocks', 'coblocks' ),
+				apply_filters( 'coblocks_getting_started_screen_capability', 'manage_options' ),
+				'coblocks-getting-started',
+				array( $this, 'content' ),
+			);
+
+			return;
+
+		}
+
 		add_menu_page(
 			__( 'CoBlocks', 'coblocks' ),
 			__( 'CoBlocks', 'coblocks' ),
@@ -56,18 +78,20 @@ class CoBlocks_Getting_Started_Page {
 		$screen    = get_current_screen();
 		$screen_id = $screen ? $screen->id : '';
 
-		// Define where the assets are loaded from.
-		$dir         = CoBlocks()->asset_source( 'styles' );
-		$vendors_dir = CoBlocks()->asset_source( 'js', 'vendors' );
-
 		// Only enqueue admin scripts and styles on relevant pages.
-		if ( in_array( $screen_id, array( 'toplevel_page_coblocks-getting-started', 'coblocks_page_coblocks-getting-started' ), true ) ) {
+		if ( false !== strpos( $screen_id, 'coblocks-getting-started' ) ) {
+
+			// Define where the assets are loaded from.
+			$dir         = CoBlocks()->asset_source( 'styles' );
+			$vendors_dir = CoBlocks()->asset_source( 'js', 'vendors' );
+
 			wp_enqueue_style(
 				'coblocks-getting-started',
 				$dir . 'coblocks-getting-started' . COBLOCKS_ASSET_SUFFIX . '.css',
 				COBLOCKS_VERSION,
 				true
 			);
+
 			wp_enqueue_script(
 				'coblocks-lity',
 				$vendors_dir . '/lity' . COBLOCKS_ASSET_SUFFIX . '.js',
@@ -75,7 +99,9 @@ class CoBlocks_Getting_Started_Page {
 				COBLOCKS_VERSION,
 				true
 			);
+
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
Resolves #603 

Introduce a new filter, `coblocks_getting_started_submenu_parent_slug `, which allows the CoBlocks Getting Started page to be nested in a parent menu item, if the user chooses.

#### Example Usage
```php
/**
 * Nest the CoBlocks Getting Started page inside the Tools admin menu
 *
 *
 */
function nest_coblocks_getting_started_menu_item( $parent_slug ) {

   return 'tools.php';

}
add_filter( 'coblocks_getting_started_submenu_parent_slug', 'nest_coblocks_getting_started_menu_item' );
```

#### Result
<img src="https://cldup.com/FC80IQLeM2.png" width="200" />