### PR TITLE
Remove columns control for the Food & Drinks

### DIFF
--- a/src/blocks/food-and-drinks/inspector.js
+++ b/src/blocks/food-and-drinks/inspector.js
@@ -56,14 +56,8 @@ const Inspector = props => {
 					) ) }
 				</div>
 			</PanelBody>
+
 			<PanelBody title={ __( 'Food & Drinks Settings' ) } initialOpen={ true }>
-				<RangeControl
-					label={ __( 'Columns' ) }
-					value={ attributes.columns }
-					onChange={ onSetColumns }
-					min={ 2 }
-					max={ 3 }
-				/>
 				<ToggleControl
 					label={ __( 'Images' ) }
 					help={


### PR DESCRIPTION
There's a good bit of heavy lifting still needed on the css side of things, but now the framework is in place to add columns support in the future without deprecating the block.