### PR TITLE
Removed Icon Keyword From Share and Features Blocks

### DIFF
--- a/src/blocks/features/index.js
+++ b/src/blocks/features/index.js
@@ -31,7 +31,6 @@ const title = __( 'Features' );
 const icon = icons.features;
 
 const keywords = [
-	__( 'icons' ),
 	__( 'services' ),
 	__( 'coblocks' ),
 ];

--- a/src/blocks/share/index.js
+++ b/src/blocks/share/index.js
@@ -23,7 +23,6 @@ const icon = icons.social;
 
 const keywords = [
 	__( 'social' ),
-	__( 'icons' ),
 	__( 'coblocks' ),
 ];
 


### PR DESCRIPTION
The blocks already appear for their own names and I could not think of any other keywords to use that would not seem excessive. What are your thoughts?