### PR TITLE
Deleted removed files from SVN during WordPress.org deployment

### DIFF
--- a/.dev/bin/deploy-plugin.sh
+++ b/.dev/bin/deploy-plugin.sh
@@ -9,7 +9,7 @@ cp -a build/coblocks/* $HOME/coblocks/trunk/
 
 # Copy the WordPress.org assets over
 rm -rf $HOME/coblocks/assets/*
-cp -a wordpress-org/* $HOME/coblocks/assets/
+cp -a .wordpress-org/* $HOME/coblocks/assets/
 
 # Deploy Coblocks to WordPress.org
 cd $HOME/coblocks

--- a/.dev/bin/deploy-plugin.sh
+++ b/.dev/bin/deploy-plugin.sh
@@ -9,11 +9,13 @@ cp -a build/coblocks/* $HOME/coblocks/trunk/
 
 # Copy the WordPress.org assets over
 rm -rf $HOME/coblocks/assets/*
-cp -a .wordpress-org/* $HOME/coblocks/assets/
+cp -a wordpress-org/* $HOME/coblocks/assets/
 
 # Deploy Coblocks to WordPress.org
 cd $HOME/coblocks
 svn add * --force
+# Delete removed files
+svn status | grep '^!' | awk '{print $2}' | xargs svn delete
 svn ci --no-auth-cache --username ${WP_ORG_USERNAME} --password ${WP_ORG_PASSWORD} -m "Deploy new version of Coblocks"
 
 # Deploy a Coblocks Github release


### PR DESCRIPTION
Resolves the issue where removed files here on Github are not removed from the WordPress.org SVG repo during the deployment.