### PR TITLE
Update Google Maps localization script

### DIFF
--- a/includes/class-coblocks-google-map-block.php
+++ b/includes/class-coblocks-google-map-block.php
@@ -104,7 +104,7 @@ class CoBlocks_Google_Map_Block {
 
 			}
 
-			wp_localize_script( $this->_slug . '-google-maps', 'baAtts', array( 'url' => $this->_url ) );
+			wp_localize_script( $this->_slug . '-google-maps', 'coblocksGoogleMaps', array( 'url' => $this->_url ) );
 		}
 	}
 

--- a/src/js/coblocks-google-maps.js
+++ b/src/js/coblocks-google-maps.js
@@ -79,7 +79,7 @@ var coblocks_maps = {
 			new google.maps.Marker( {
 				position: new google.maps.LatLng( gmapAttr.lat, gmapAttr.lng ),
 				map: map,
-				icon: { url: baAtts.url + '/dist/images/markers/' + gmapAttr.skin + '.svg', scaledSize: new google.maps.Size( gmapAttr.iconSize, gmapAttr.iconSize ), },
+				icon: { url: coblocksGoogleMaps.url + '/dist/images/markers/' + gmapAttr.skin + '.svg', scaledSize: new google.maps.Size( gmapAttr.iconSize, gmapAttr.iconSize ), },
 			} );
 
 			map.setCenter(  new google.maps.LatLng( gmapAttr.lat, gmapAttr.lng ) );


### PR DESCRIPTION
Appropriately rename `baAtts` to `coblocksGoogleMaps`in `wp_localize_script()`.