### PR TITLE
WIP: Moving column implementation to a block supports feature

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -31,6 +31,9 @@ import './extensions/button-controls';
 // Formats
 import './formats/';
 
+// Hooks
+import './hooks/columns';
+
 // Sidebars
 import './sidebars/block-manager';
 import './sidebars/block-manager/deprecated';

--- a/src/blocks/features/components/controls.js
+++ b/src/blocks/features/components/controls.js
@@ -27,7 +27,6 @@ class Controls extends Component {
 
 		const {
 			contentAlign,
-			columns,
 		} = attributes;
 
 		return (

--- a/src/blocks/features/components/edit.js
+++ b/src/blocks/features/components/edit.js
@@ -62,9 +62,9 @@ class Edit extends Component {
 		const {
 			coblocks,
 			backgroundImg,
-			columns,
+			coblockColumns,
 			contentAlign,
-			gutter,
+			coblockGutter,
 			paddingTop,
 			paddingRight,
 			paddingBottom,
@@ -98,7 +98,7 @@ class Edit extends Component {
 		const innerClasses = classnames(
 			'wp-block-coblocks-features__inner',
 			...BackgroundClasses( attributes ), {
-				[ `has-${ gutter }-gutter` ] : gutter,
+				[ `has-${ coblockGutter }-gutter` ] : coblockGutter,
 				'has-padding': paddingSize && paddingSize != 'no',
 				[ `has-${ paddingSize }-padding` ] : paddingSize && paddingSize != 'advanced',
 				'has-margin': marginSize && marginSize != 'no',
@@ -141,7 +141,7 @@ class Edit extends Component {
 						{ isBlobURL( backgroundImg ) && <Spinner /> }
 						{ BackgroundVideo( attributes ) }
 						<InnerBlocks
-							template={ getCount( columns ) }
+							template={ getCount( coblockColumns ) }
 							allowedBlocks={ ALLOWED_BLOCKS }
 							templateLock="all"
 							templateInsertUpdatesSelection={ false } />

--- a/src/blocks/features/components/inspector.js
+++ b/src/blocks/features/components/inspector.js
@@ -53,8 +53,6 @@ class Inspector extends Component {
 		} = this.props;
 
 		const {
-			columns,
-			gutter,
 			marginBottom,
 			marginLeft,
 			marginRight,
@@ -91,41 +89,10 @@ class Inspector extends Component {
 			paddingUnit,
 		} = attributes;
 
-		const gutterOptions = [
-			{ value: 'small', label: __( 'Small' ) },
-			{ value: 'medium', label: __( 'Medium' ) },
-			{ value: 'large', label: __( 'Large' ) },
-		];
-
 		return (
 			<Fragment>
 				<InspectorControls>
 					<PanelBody title={ __( 'Features Settings' ) } className='components-coblocks-block-sidebar--features'>
-						<RangeControl
-							label={ __( 'Columns' ) }
-							value={ columns }
-							onChange={ ( nextCount ) => {
-								setAttributes( {
-									columns: parseInt( nextCount ),
-								} );
-
-								if( parseInt( nextCount ) < 2 ){
-									setAttributes( {
-										gutter: 'no',
-									} );
-								}else{
-									if( gutter == 'no' ){
-										setAttributes( {
-											gutter: 'large',
-										} );
-									}
-								}
-
-								wp.data.dispatch( 'core/editor' ).selectBlock( clientId );
-							} }
-							min={ 1 }
-							max={ 3 }
-						/>
 						<DimensionsControl { ...this.props }
 							type={ 'margin' }
 							label={ __( 'Margin' ) }
@@ -168,15 +135,6 @@ class Inspector extends Component {
 							syncUnitsMobile={ paddingSyncUnitsMobile }
 							dimensionSize={ paddingSize }
 						/>
-						{ columns >= 2 &&
-							<SelectControl
-								label={ __( 'Gutter' ) }
-								value={ gutter }
-								options={ gutterOptions }
-								help={ __( 'Space between each column.' ) }
-								onChange={ ( value ) => setAttributes( { gutter: value } ) }
-							/>
-						}
 					</PanelBody>
 					<PanelColorSettings
 						title={ __( 'Color Settings' ) }

--- a/src/blocks/features/index.js
+++ b/src/blocks/features/index.js
@@ -36,14 +36,6 @@ const keywords = [
 ];
 
 const blockAttributes = {
-	gutter: {
-		type: 'string',
-		default: 'large',
-	},
-	columns: {
-		type: 'number',
-		default: 2,
-	},
 	contentAlign: {
 		type: 'string',
 		default: 'center',
@@ -65,6 +57,7 @@ const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 		coBlocksSpacing: true,
+		coblockColumns: true,
 	},
 
 	transforms: {
@@ -104,14 +97,14 @@ const settings = {
 	edit: Edit,
 
 	getEditWrapperProps( attributes ) {
-		const { id, layout, columns } = attributes;
+		const { id, layout, coblockColumns } = attributes;
 
 		// If no layout is seleted, return the following.
 		if ( ! layout ) {
-			return { 'data-id': id, 'data-columns': columns, };
+			return { 'data-id': id, 'data-columns': coblockColumns };
 		}
 
-		return { 'data-id': id, 'data-columns': columns };
+		return { 'data-id': id, 'data-columns': coblockColumns };
 	},
 
 	save( { attributes, className } ) {
@@ -120,12 +113,12 @@ const settings = {
 			coblocks,
 			backgroundColor,
 			backgroundImg,
-			columns,
+			coblockColumns,
 			contentAlign,
 			customBackgroundColor,
 			customTextColor,
 			textColor,
-			gutter,
+			coblockGutter,
 			marginSize,
 			paddingSize,
 			focalPoint,
@@ -152,7 +145,7 @@ const settings = {
 			[ `has-${ paddingSize }-padding` ] : paddingSize && ( paddingSize != 'advanced' ),
 			'has-margin': marginSize && marginSize != 'no',
 			[ `has-${ marginSize }-margin` ] : marginSize && ( marginSize != 'advanced' ),
-			[ `has-${ gutter }-gutter` ] : gutter,
+			[ `has-${ coblockGutter }-gutter` ] : coblockGutter,
 			[ `has-${ contentAlign }-content` ]: contentAlign,
 		} );
 
@@ -162,7 +155,7 @@ const settings = {
 		};
 
 		return (
-			<div className={ classes } data-columns={ columns } >
+			<div className={ classes } data-columns={ coblockColumns } >
 				<div className={ innerClasses } style={ innerStyles }>
 					{ BackgroundVideo( attributes ) }
 					<InnerBlocks.Content />

--- a/src/blocks/gallery-masonry/edit.js
+++ b/src/blocks/gallery-masonry/edit.js
@@ -71,6 +71,34 @@ class GalleryMasonryEdit extends Component {
 				captionSelected: false,
 			} );
 		}
+
+		const { attributes, setAttributes } = this.props;
+		if ( ! attributes.coblockColumns !== prevProps.attributes.coblockColumns ) {
+			if ( attributes.coblockColumns === 2 ) {
+				setAttributes( { gridSize: 'xlrg' } );
+			}
+			if ( attributes.coblockColumns === 3 ) {
+				setAttributes( { gridSize: 'lrg' } );
+			}
+			if ( attributes.coblockColumns === 4 ) {
+				setAttributes( { gridSize: 'med' } );
+			}
+		}
+
+		if ( ! attributes.coblockGutter !== prevProps.attributes.coblockGutter ) {
+			if ( attributes.coblockGutter === 'none' ) {
+				setAttributes( { gutter: 0 } );
+			}
+			if ( attributes.coblockGutter === 'small' ) {
+				setAttributes( { gutter: 15 } );
+			}
+			if ( attributes.coblockGutter === 'medium' ) {
+				setAttributes( { gutter: 25 } );
+			}
+			if ( attributes.coblockGutter === 'large' ) {
+				setAttributes( { gutter: 50 } );
+			}
+		}
 	}
 
 	onSelectImage( index ) {

--- a/src/blocks/gallery-masonry/index.js
+++ b/src/blocks/gallery-masonry/index.js
@@ -59,6 +59,7 @@ const settings = {
 
 	supports: {
 		align: [ 'wide', 'full' ],
+		coblockColumns: { min: 2, max: 4 },
 	},
 
 	transforms,

--- a/src/blocks/gallery-masonry/inspector.js
+++ b/src/blocks/gallery-masonry/inspector.js
@@ -126,14 +126,6 @@ class Inspector extends Component {
 		return (
 			<InspectorControls>
 				<PanelBody title={ sprintf( __( '%s Settings' ), title ) }>
-					<SizeControl { ...this.props }
-						type={ 'grid' }
-						label={ __( 'Column Size' ) }
-						onChange={ this.setSizeControl }
-						value={ gridSize }
-						resetValue={ 'xlrg' }
-					/>
-					<ResponsiveTabsControl { ...this.props } />
 					{ gutter > 0 && <RangeControl
 						label={ __( 'Rounded Corners' ) }
 						aria-label={ __( 'Add rounded corners to the gallery items.' ) }

--- a/src/hooks/columns.js
+++ b/src/hooks/columns.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { assign } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/editor';
+import { PanelBody, RangeControl, SelectControl } from '@wordpress/components';
+
+/**
+ * Constants
+ */
+const SUPPORTS_NAME = 'coblockColumns';
+
+const GUTTER_OPTIONS = [
+	{ value: 'none', label: __( 'None' ) },
+	{ value: 'small', label: __( 'Small' ) },
+	{ value: 'medium', label: __( 'Medium' ) },
+	{ value: 'large', label: __( 'Large' ) },
+];
+
+export function addAttribute( settings ) {
+	if ( hasBlockSupport( settings, SUPPORTS_NAME ) ) {
+		settings.attributes = assign(
+			{
+				coblockColumns: { type: 'integer', default: 2 },
+				coblockGutter: { type: 'string', default: 'large' },
+			},
+			settings.attributes
+		);
+	}
+
+	return settings;
+}
+
+export const withInspectorControls = createHigherOrderComponent(
+	BlockEdit => props => {
+		const { name: blockName, attributes, setAttributes } = props;
+		return [
+			getBlockSupport( blockName, SUPPORTS_NAME ) && (
+				<InspectorControls>
+					<PanelBody title={ __( 'Column Settings' ) }>
+						<RangeControl
+							label={ __( 'Columns' ) }
+							value={ attributes.coblockColumns }
+							min={ 1 }
+							max={ 3 }
+							onChange={ coblockColumns => setAttributes( { coblockColumns } ) }
+						/>
+						{ attributes.coblockColumns > 1 && (
+							<SelectControl
+								label={ __( 'Gutter' ) }
+								value={ attributes.coblockGutter }
+								options={ GUTTER_OPTIONS }
+								help={ __( 'Space between each column.' ) }
+								onChange={ coblockGutter => setAttributes( { coblockGutter } ) }
+							/>
+						) }
+					</PanelBody>
+				</InspectorControls>
+			),
+			<BlockEdit key="edit" { ...props } />,
+		];
+	},
+	'withInspectorControls'
+);
+
+addFilter(
+	'blocks.registerBlockType',
+	'coblocks/columns/addAttribute',
+	addAttribute
+);
+addFilter(
+	'editor.BlockEdit',
+	'coblocks/columns/with-inspector-controls',
+	withInspectorControls
+);

--- a/src/hooks/columns.js
+++ b/src/hooks/columns.js
@@ -42,15 +42,16 @@ export function addAttribute( settings ) {
 export const withInspectorControls = createHigherOrderComponent(
 	BlockEdit => props => {
 		const { name: blockName, attributes, setAttributes } = props;
+		const blockSupport = getBlockSupport( blockName, SUPPORTS_NAME );
 		return [
-			getBlockSupport( blockName, SUPPORTS_NAME ) && (
+			blockSupport && (
 				<InspectorControls>
 					<PanelBody title={ __( 'Column Settings' ) }>
 						<RangeControl
 							label={ __( 'Columns' ) }
 							value={ attributes.coblockColumns }
-							min={ 1 }
-							max={ 3 }
+							min={ blockSupport.min || 1 }
+							max={ blockSupport.max || 3 }
 							onChange={ coblockColumns => setAttributes( { coblockColumns } ) }
 						/>
 						{ attributes.coblockColumns > 1 && (


### PR DESCRIPTION
This branch is exploring a way to apply specific features to different blocks, preventing re-implementation in each block.

Some benefits to this:
1. Standardization of the UI/UX for individual features.
2. Adding support to a block is as easy as adding [block supports](https://developer.wordpress.org/block-editor/developers/block-api/block-registration/#supports-optional) on block registration.
3. No need to add attributes for the feature in the individual block attribute definition. Although they can be overridden in this way.
4. Removes any duplication of features which cleans up the codebase.
5. Exposes the feature to any third-party blocks that want to use these features so long as CoBlocks is installed and active.

In this PR I've created a `coblockColumns` feature and applied it to the Features block. The new feature adds a new "Column Settings" Panel with a controls for the number of columns and the gutter size within the InspectorControls.

**New Panel on the Features block**

![Screenshot from 2019-07-10 16-00-36](https://user-images.githubusercontent.com/375788/61000692-fcb2ac80-a32b-11e9-9586-03a2c963dc78.png)

**Masonry Block controls are inconsistent**

![Screenshot from 2019-07-10 16-18-25](https://user-images.githubusercontent.com/375788/61001966-9e3afd80-a32e-11e9-9ebc-bb79e936a591.png)

The `coblockColumns` attribute is passed into our block so we can use it normally. We need to explore automatically appending related CSS classes to the block as well as centralizing the CSS styles.

The next pieces I think we can simplify this way are the dimensions control, typography controls, background, and grid controls.