### PR TITLE
Add placeholder and ascending plan titles to the Pricing Table block

### DIFF
--- a/src/blocks/pricing-table/components/edit.js
+++ b/src/blocks/pricing-table/components/edit.js
@@ -14,6 +14,7 @@ import Inspector from './inspector';
 /**
  * WordPress dependencies
  */
+const { __, sprintf } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { InnerBlocks } = wp.blockEditor;
 
@@ -35,7 +36,7 @@ const ALLOWED_BLOCKS = [ 'coblocks/pricing-table-item' ];
  * @return {Object[]} Columns layout configuration.
  */
 const getCount = memoize( ( count ) => {
-	return times( count, () => [ 'coblocks/pricing-table-item' ] );
+	return times( count, ( index ) => [ 'coblocks/pricing-table-item', { placeholder: sprintf( __( 'Plan %s' ), index + 1 ) } ] );
 } );
 
 /**

--- a/src/blocks/pricing-table/pricing-table-item/components/edit.js
+++ b/src/blocks/pricing-table/pricing-table-item/components/edit.js
@@ -27,7 +27,7 @@ const { RichText, InnerBlocks } = wp.blockEditor;
  * @type {string[]}
 */
 const ALLOWED_BLOCKS = [ 'core/button' ];
-const TEMPLATE = [ [ 'core/button', { text: __( 'Buy Now' ) } ] ];
+const TEMPLATE = [ [ 'core/button', { placeholder: __( 'Buy Now' ) } ] ];
 
 /**
  * Block edit function
@@ -48,6 +48,7 @@ class Edit extends Component {
 			currency,
 			features,
 			title,
+			placeholder,
 		} = attributes;
 
 		const formattingControls = [ 'bold', 'italic', 'strikethrough' ];
@@ -78,7 +79,7 @@ class Edit extends Component {
 						className="wp-block-coblocks-pricing-table-item__title"
 						onChange={ ( nextTitle ) => setAttributes( { title: nextTitle } ) }
 						value={ title }
-						placeholder={ __( 'Plan A' ) }
+						placeholder={ placeholder || __( 'Plan A' ) }
 						formattingControls={ formattingControls }
 						keepPlaceholderOnFocus
 					/>
@@ -110,6 +111,7 @@ class Edit extends Component {
 						value={ features }
 						placeholder={ __( 'Add features' ) }
 						keepPlaceholderOnFocus
+						formattingControls={ [] }
 					/>
 					<InnerBlocks
 						template={ TEMPLATE }

--- a/src/blocks/pricing-table/pricing-table-item/components/edit.js
+++ b/src/blocks/pricing-table/pricing-table-item/components/edit.js
@@ -111,7 +111,6 @@ class Edit extends Component {
 						value={ features }
 						placeholder={ __( 'Add features' ) }
 						keepPlaceholderOnFocus
-						formattingControls={ [] }
 					/>
 					<InnerBlocks
 						template={ TEMPLATE }

--- a/src/blocks/pricing-table/pricing-table-item/index.js
+++ b/src/blocks/pricing-table/pricing-table-item/index.js
@@ -63,6 +63,9 @@ const blockAttributes = {
 	customTextColor: {
 		type: 'string',
 	},
+	placeholder: {
+		type: 'string',
+	},
 };
 
 const settings = {

--- a/src/components/background/styles.js
+++ b/src/components/background/styles.js
@@ -7,6 +7,7 @@ const { getColorClassName } = wp.blockEditor;
  * Background Classes
  *
  * @param {Object} attributes The attributes.
+ * @param {Object} backgroundColor The background color.
  * @returns {Object} styles.
  */
 const BackgroundStyles = ( attributes, backgroundColor ) => {


### PR DESCRIPTION
Before: 
<img width="850" alt="Screen Shot 2019-07-22 at 10 35 38 AM" src="https://user-images.githubusercontent.com/1813435/61652295-77ed5a00-ac6c-11e9-8c69-d9b618435edc.png">

After: 
<img width="867" alt="Screen Shot 2019-07-22 at 10 36 08 AM" src="https://user-images.githubusercontent.com/1813435/61652337-889dd000-ac6c-11e9-9ced-e39cd92e0489.png">
