### PR TITLE
add css to change display on button wrapper - Gutenberg 6.3 fix

### DIFF
--- a/src/blocks/features/styles/editor.scss
+++ b/src/blocks/features/styles/editor.scss
@@ -262,6 +262,10 @@
 			}
 		}
 	}
+
+	.wp-block-button-wrapper {
+		display: inline-flex;
+	}
 }
 
 .components-coblocks-block-sidebar--features {

--- a/src/blocks/services/styles/editor.scss
+++ b/src/blocks/services/styles/editor.scss
@@ -101,6 +101,10 @@ $gutter: 0.3em;
 	.block-list-appender {
 		display: none !important;
 	}
+
+	.wp-block-button-wrapper {
+		display: inline-flex;
+	}
 }
 
 .components-toggle-control--services-action-button {


### PR DESCRIPTION
- Closes #754 
- Handles fix for Services block and for Features block.
- Issue seems to stem from this commit https://github.com/WordPress/gutenberg/commit/68dc4f7f5708d30fe18e070241b4a52401d1b251#diff-48774fc728094a4cbd45abc1d467ee70

### Services Alignment
![gutenbergAllignmentControls](https://user-images.githubusercontent.com/30462574/63368757-6b275900-c333-11e9-9a50-4a8e42c8b3bb.gif)


### Features Alignment
![gutenbergAllignmentControlsFeatures](https://user-images.githubusercontent.com/30462574/63368850-a0cc4200-c333-11e9-8e21-24b0e5529c9e.gif)
