### PR TITLE
Move getDividerFromStyle to a new utils.js file

### DIFF
--- a/src/blocks/shape-divider/deprecated.js
+++ b/src/blocks/shape-divider/deprecated.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import getDividerFromStyle from './';
+import { getDividerFromStyle } from './utils';
 
 /**
  * WordPress dependencies

--- a/src/blocks/shape-divider/edit.js
+++ b/src/blocks/shape-divider/edit.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import Controls from './controls';
 import Inspector from './inspector';
 import applyWithColors from './colors';
-import { getDividerFromStyle } from '.';
+import { getDividerFromStyle } from './utils';
 import InlineColorPicker from '../../components/inline-color-picker';
 
 /**

--- a/src/blocks/shape-divider/index.js
+++ b/src/blocks/shape-divider/index.js
@@ -1,16 +1,10 @@
 /**
- * External dependencies
- */
-import includes from 'lodash/includes';
-
-/**
  * Internal dependencies
  */
 import './styles/editor.scss';
 import './styles/style.scss';
 import edit from './edit';
 import icons from './icons';
-import dividers from './dividers';
 import save from './save';
 import transforms from './transforms';
 import deprecated from './deprecated';

--- a/src/blocks/shape-divider/index.js
+++ b/src/blocks/shape-divider/index.js
@@ -22,42 +22,6 @@ import metadata from './block.json';
 const { __, _x } = wp.i18n;
 
 /**
- * Return the appropriate SVG for the block style.
- *
- * @param {Array} className The class names.
- * @returns {String} The divider.
- */
-export function getDividerFromStyle( className ) {
-	const angled = includes( className, 'is-style-angled' );
-	const hills = includes( className, 'is-style-hills' );
-	const pointed = includes( className, 'is-style-pointed' );
-	const rounded = includes( className, 'is-style-rounded' );
-	const sloped = includes( className, 'is-style-sloped' );
-	const triangle = includes( className, 'is-style-triangle' );
-	const waves = includes( className, 'is-style-waves' );
-
-	let divider = dividers.wavy;
-
-	if ( angled ) {
-		divider = dividers.angled;
-	} else if ( sloped ) {
-		divider = dividers.sloped;
-	} else if ( triangle ) {
-		divider = dividers.triangle;
-	} else if ( rounded ) {
-		divider = dividers.rounded;
-	} else if ( waves ) {
-		divider = dividers.waves;
-	} else if ( pointed ) {
-		divider = dividers.pointed;
-	} else if ( hills ) {
-		divider = dividers.hills;
-	}
-
-	return divider;
-}
-
-/**
  * Block constants
  */
 const { attributes, name } = metadata;

--- a/src/blocks/shape-divider/save.js
+++ b/src/blocks/shape-divider/save.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import getDividerFromStyle from './';
+import { getDividerFromStyle } from './utils';
 
 /**
  * WordPress dependencies

--- a/src/blocks/shape-divider/utils.js
+++ b/src/blocks/shape-divider/utils.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import includes from 'lodash/includes';
+
+/**
+ * Internal dependencies
+ */
+import dividers from './dividers';
+
+/**
+ * Return the appropriate SVG for the block style.
+ *
+ * @param {Array} className The class names.
+ * @returns {String} The divider.
+ */
+export function getDividerFromStyle( className ) {
+	const angled = includes( className, 'is-style-angled' );
+	const hills = includes( className, 'is-style-hills' );
+	const pointed = includes( className, 'is-style-pointed' );
+	const rounded = includes( className, 'is-style-rounded' );
+	const sloped = includes( className, 'is-style-sloped' );
+	const triangle = includes( className, 'is-style-triangle' );
+	const waves = includes( className, 'is-style-waves' );
+
+	let divider = dividers.wavy;
+
+	if ( angled ) {
+		divider = dividers.angled;
+	} else if ( sloped ) {
+		divider = dividers.sloped;
+	} else if ( triangle ) {
+		divider = dividers.triangle;
+	} else if ( rounded ) {
+		divider = dividers.rounded;
+	} else if ( waves ) {
+		divider = dividers.waves;
+	} else if ( pointed ) {
+		divider = dividers.pointed;
+	} else if ( hills ) {
+		divider = dividers.hills;
+	}
+
+	return divider;
+}


### PR DESCRIPTION
Resolves an issue with multiple exports within the `index.js` file for the Shape Divider block. This was causing block validation errors in the editor and preventing the block from rendering on the front-end.