### PR TITLE
Add missing styles for <Gutenberg 6.3 inline form

### DIFF
--- a/src/blocks/social-profiles/styles/editor.scss
+++ b/src/blocks/social-profiles/styles/editor.scss
@@ -37,4 +37,8 @@
 	.components-base-control__field {
 		margin-bottom: 0;
 	}
+
+	svg {
+		margin: 0px 8px 0px 8px;
+	}
 }

--- a/src/blocks/social-profiles/styles/editor.scss
+++ b/src/blocks/social-profiles/styles/editor.scss
@@ -23,6 +23,13 @@
 }
 
 .block-library-button__inline-link--coblocks {
+	align-items: center;
+	background: #fff;
+	display: flex;
+	flex-wrap: wrap;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	line-height: 1.4;
 	margin-bottom: 0;
 	margin-top: 0;
 	width: 338px;


### PR DESCRIPTION
This PR adds back the missing styles to the inline form we're using in the Social Profiles popover component, that were removed in Gutenberg 6.3. 

Closes #779