### PR TITLE
Fix issue where icon sizes were not saved

### DIFF
--- a/src/blocks/icon/icon-size-select.js
+++ b/src/blocks/icon/icon-size-select.js
@@ -56,7 +56,7 @@ export default class IconSizeSelect extends Component {
 	onChangeValue = event => {
 		const selectedUtil = this.state.utilitySizes.find( util => util.slug === event );
 		if ( selectedUtil ) {
-			this.props.setAttributes( { width: selectedUtil.size } );
+			this.props.setAttributes( { width: selectedUtil.size, height: selectedUtil.size } );
 			this.setCurrentSelectValue(
 				this.getSelectValuesFromUtilitySizes( this.state.utilitySizes, selectedUtil.slug )
 			);


### PR DESCRIPTION
This PR fixes #813, where the `height` attribute was not being saved when a size is applied.