### PR TITLE
Improve Icon block custom size UI 

### DIFF
--- a/src/blocks/icon/inspector.js
+++ b/src/blocks/icon/inspector.js
@@ -165,7 +165,7 @@ class Inspector extends Component {
 										} }
 										isSmall
 										isDefault
-										aria-label={ sprintf( __( 'Turn off advanced %s settings' ), label.toLowerCase() ) }
+										aria-label={ __( 'Reset icon size' ) }
 									>
 										{ __( 'Reset' ) }
 									</Button>
@@ -194,10 +194,11 @@ class Inspector extends Component {
 										type="button"
 										onClick={ () => this.onChangeSize( 'advanced', '' ) }
 										isDefault
-										aria-label={ sprintf( __( 'Advanced %s settings' ), label.toLowerCase() ) }
+										isSmall
+										aria-label={ __( 'Apply custom size' ) }
 										isPrimary={ iconSize === 'advanced' }
 									>
-										{ __( 'Advanced' ) }
+										{ __( 'Custom' ) }
 									</Button>
 								</div>
 							</BaseControl>

--- a/src/blocks/icon/inspector.js
+++ b/src/blocks/icon/inspector.js
@@ -16,7 +16,7 @@ import IconSizeSelect from './icon-size-select';
 /**
  * WordPress dependencies
  */
-const { __, sprintf } = wp.i18n;
+const { __ } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
 const { InspectorControls, ContrastChecker, PanelColorSettings } = wp.blockEditor;


### PR DESCRIPTION
This PR updates the existing advanced/custom size controls for the Icon block, bringing it more inline with core settings. 

Also worth noting that I've changed the "Advanced" label to simply "Custom" which indicates what that button toggles (custom size) - "Advanced" does not imply anything concrete.

Before: 
![ScreenFlows](https://user-images.githubusercontent.com/1813435/64078557-3065df00-ccaa-11e9-93ee-b208f7882ea0.gif)

This PR: 
![ScreenFlow](https://user-images.githubusercontent.com/1813435/64078561-352a9300-ccaa-11e9-9711-941220aeb9e2.gif)