### PR TITLE
Fix Hero white-screen when deprecating

### DIFF
--- a/src/blocks/features/edit.js
+++ b/src/blocks/features/edit.js
@@ -79,11 +79,11 @@ class Edit extends Component {
 			/>
 		);
 
-		const classes = classnames(
-			className, {
-				[ `coblocks-features-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
-			}
-		);
+		let classes = className;
+
+		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+			classes = classnames( classes, [ `coblocks-features-${ coblocks.id }` ] );
+		}
 
 		const innerClasses = classnames(
 			'wp-block-coblocks-features__inner',

--- a/src/blocks/features/edit.js
+++ b/src/blocks/features/edit.js
@@ -82,7 +82,7 @@ class Edit extends Component {
 		let classes = className;
 
 		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-			classes = classnames( classes, [ `coblocks-features-${ coblocks.id }` ] );
+			classes = classnames( classes, `coblocks-features-${ coblocks.id }` );
 		}
 
 		const innerClasses = classnames(

--- a/src/blocks/features/feature/edit.js
+++ b/src/blocks/features/feature/edit.js
@@ -64,11 +64,11 @@ class Edit extends Component {
 			/>
 		);
 
-		const classes = classnames(
-			className, {
-				[ `coblocks-feature-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
-			}
-		);
+		let classes = className;
+
+		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+			classes = classnames( classes, [ `coblocks-feature-${ coblocks.id }` ] );
+		}
 
 		const innerClasses = classnames(
 			'wp-block-coblocks-feature__inner',

--- a/src/blocks/features/feature/edit.js
+++ b/src/blocks/features/feature/edit.js
@@ -67,7 +67,7 @@ class Edit extends Component {
 		let classes = className;
 
 		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-			classes = classnames( classes, [ `coblocks-feature-${ coblocks.id }` ] );
+			classes = classnames( classes, `coblocks-feature-${ coblocks.id }` );
 		}
 
 		const innerClasses = classnames(

--- a/src/blocks/features/feature/save.js
+++ b/src/blocks/features/feature/save.js
@@ -25,11 +25,14 @@ const save = ( { attributes, className } ) => {
 	// Body color class and styles.
 	const textClass = getColorClassName( 'color', textColor );
 
-	const classes = classnames(
+	let classes = classnames(
 		className, {
 			[ `has-${ contentAlign }-content` ]: contentAlign,
-			[ `coblocks-feature-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
 		} );
+
+	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+		classes = classnames( classes, [ `coblocks-feature-${ coblocks.id }` ] );
+	}
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-feature__inner',

--- a/src/blocks/features/feature/save.js
+++ b/src/blocks/features/feature/save.js
@@ -31,7 +31,7 @@ const save = ( { attributes, className } ) => {
 		} );
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-		classes = classnames( classes, [ `coblocks-feature-${ coblocks.id }` ] );
+		classes = classnames( classes, `coblocks-feature-${ coblocks.id }` );
 	}
 
 	const innerClasses = classnames(

--- a/src/blocks/features/save.js
+++ b/src/blocks/features/save.js
@@ -31,7 +31,7 @@ const save = ( { attributes, className } ) => {
 	let classes = className;
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-		classes = classnames( classes, [ `coblocks-features-${ coblocks.id }` ] );
+		classes = classnames( classes, `coblocks-features-${ coblocks.id }` );
 	}
 
 	const innerClasses = classnames(

--- a/src/blocks/features/save.js
+++ b/src/blocks/features/save.js
@@ -28,11 +28,11 @@ const save = ( { attributes, className } ) => {
 	// Body color class and styles.
 	const textClass = getColorClassName( 'color', textColor );
 
-	const classes = classnames(
-		className, {
-			[ `coblocks-features-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
-		}
-	);
+	let classes = className;
+
+	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+		classes = classnames( classes, [ `coblocks-features-${ coblocks.id }` ] );
+	}
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-features__inner',

--- a/src/blocks/hero/deprecated.js
+++ b/src/blocks/hero/deprecated.js
@@ -10,6 +10,8 @@ import { BackgroundClasses, BackgroundVideo, BackgroundAttributes } from '../../
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 import CSSGridAttributes from '../../components/grid-control/attributes';
 import ResponsiveBaseControlAttributes from '../../components/responsive-base-control/attributes';
+import metadata from './block.json';
+import { type } from 'os';
 
 /**
  * WordPress dependencies
@@ -21,59 +23,7 @@ const blockAttributes = {
 	...DimensionsAttributes,
 	...BackgroundAttributes,
 	...ResponsiveBaseControlAttributes,
-	align: {
-		type: 'string',
-		default: 'full',
-	},
-	contentAlign: {
-		type: 'string',
-	},
-	textColor: {
-		type: 'string',
-	},
-	customTextColor: {
-		type: 'string',
-	},
-	maxWidth: {
-		type: 'number',
-		default: 560,
-	},
-	saveCoBlocksMeta: {
-		type: 'boolean',
-		default: true,
-	},
-	paddingSize: {
-		type: 'string',
-		default: 'huge',
-	},
-	paddingUnit: {
-		type: 'string',
-		default: 'px',
-	},
-	paddingTop: {
-		type: 'number',
-		default: 60,
-	},
-	paddingBottom: {
-		type: 'number',
-		default: 60,
-	},
-	paddingLeft: {
-		type: 'number',
-		default: 60,
-	},
-	paddingRight: {
-		type: 'number',
-		default: 60,
-	},
-	customBackgroundColor: {
-		type: 'string',
-		default: '#f3f3f3',
-	},
-	height: {
-		type: 'number',
-		default: 500,
-	},
+	...metadata.attributes,
 };
 
 const deprecated = [
@@ -103,13 +53,21 @@ const deprecated = [
 			const textClass = getColorClassName( 'color', textColor );
 			const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-			const classlist = {
-				'has-text-color': textColor || customTextColor,
-				[ textClass ]: textClass,
-				[ `coblocks-hero-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
+			const classlist = () => {
+				if ( typeof coblocks !== 'undefined' ) {
+					return {
+						'has-text-color': textColor || customTextColor,
+						[ textClass ]: textClass,
+						[ `coblocks-hero-${ coblocks.id }` ]: ( typeof coblocks !== 'undefined' ) && ( typeof coblocks.id !== 'undefined' ),
+					};
+				}
+				return {
+					'has-text-color': textColor || customTextColor,
+					[ textClass ]: textClass,
+				};
 			};
 
-			const classes = classnames( classlist );
+			const classes = classnames( classlist() );
 
 			const styles = {
 				color: textClass ? undefined : customTextColor,

--- a/src/blocks/hero/deprecated.js
+++ b/src/blocks/hero/deprecated.js
@@ -11,7 +11,6 @@ import DimensionsAttributes from '../../components/dimensions-control/attributes
 import CSSGridAttributes from '../../components/grid-control/attributes';
 import ResponsiveBaseControlAttributes from '../../components/responsive-base-control/attributes';
 import metadata from './block.json';
-import { type } from 'os';
 
 /**
  * WordPress dependencies

--- a/src/blocks/hero/deprecated.js
+++ b/src/blocks/hero/deprecated.js
@@ -10,7 +10,6 @@ import { BackgroundClasses, BackgroundVideo, BackgroundAttributes } from '../../
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 import CSSGridAttributes from '../../components/grid-control/attributes';
 import ResponsiveBaseControlAttributes from '../../components/responsive-base-control/attributes';
-import metadata from './block.json';
 
 /**
  * WordPress dependencies
@@ -22,7 +21,59 @@ const blockAttributes = {
 	...DimensionsAttributes,
 	...BackgroundAttributes,
 	...ResponsiveBaseControlAttributes,
-	...metadata.attributes,
+	align: {
+		type: 'string',
+		default: 'full',
+	},
+	contentAlign: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	customTextColor: {
+		type: 'string',
+	},
+	maxWidth: {
+		type: 'number',
+		default: 560,
+	},
+	saveCoBlocksMeta: {
+		type: 'boolean',
+		default: true,
+	},
+	paddingSize: {
+		type: 'string',
+		default: 'huge',
+	},
+	paddingUnit: {
+		type: 'string',
+		default: 'px',
+	},
+	paddingTop: {
+		type: 'number',
+		default: 60,
+	},
+	paddingBottom: {
+		type: 'number',
+		default: 60,
+	},
+	paddingLeft: {
+		type: 'number',
+		default: 60,
+	},
+	paddingRight: {
+		type: 'number',
+		default: 60,
+	},
+	customBackgroundColor: {
+		type: 'string',
+		default: '#f3f3f3',
+	},
+	height: {
+		type: 'number',
+		default: 500,
+	},
 };
 
 const deprecated = [

--- a/src/blocks/hero/deprecated.js
+++ b/src/blocks/hero/deprecated.js
@@ -52,19 +52,14 @@ const deprecated = [
 			const textClass = getColorClassName( 'color', textColor );
 			const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-			const classlist = () => {
-				if ( typeof coblocks !== 'undefined' ) {
-					return {
-						'has-text-color': textColor || customTextColor,
-						[ textClass ]: textClass,
-						[ `coblocks-hero-${ coblocks.id }` ]: ( typeof coblocks !== 'undefined' ) && ( typeof coblocks.id !== 'undefined' ),
-					};
-				}
-				return {
-					'has-text-color': textColor || customTextColor,
-					[ textClass ]: textClass,
-				};
+			let classlist = {
+				'has-text-color': textColor || customTextColor,
+				[ textClass ]: textClass,
 			};
+
+			if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+				classlist = Object.assign( classlist, [ `coblocks-hero-${ coblocks.id }` ] );
+			}
 
 			const classes = classnames( classlist() );
 

--- a/src/blocks/hero/deprecated.js
+++ b/src/blocks/hero/deprecated.js
@@ -103,16 +103,14 @@ const deprecated = [
 			const textClass = getColorClassName( 'color', textColor );
 			const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-			let classlist = {
+			let classes = classnames( {
 				'has-text-color': textColor || customTextColor,
 				[ textClass ]: textClass,
-			};
+			} );
 
 			if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-				classlist = Object.assign( classlist, [ `coblocks-hero-${ coblocks.id }` ] );
+				classes = classnames( classnames, `coblocks-hero-${ coblocks.id }` );
 			}
-
-			const classes = classnames( classlist );
 
 			const styles = {
 				color: textClass ? undefined : customTextColor,

--- a/src/blocks/hero/deprecated.js
+++ b/src/blocks/hero/deprecated.js
@@ -61,7 +61,7 @@ const deprecated = [
 				classlist = Object.assign( classlist, [ `coblocks-hero-${ coblocks.id }` ] );
 			}
 
-			const classes = classnames( classlist() );
+			const classes = classnames( classlist );
 
 			const styles = {
 				color: textClass ? undefined : customTextColor,

--- a/src/blocks/hero/edit.js
+++ b/src/blocks/hero/edit.js
@@ -156,11 +156,11 @@ class Edit extends Component {
 			/>
 		);
 
-		const classes = classnames(
-			'wp-block-coblocks-hero', {
-				[ `coblocks-hero-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
-			}
-		);
+		let classes = 'wp-block-coblocks-hero';
+
+		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+			classes = classnames( classes, [ `coblocks-hero-${ coblocks.id }` ] );
+		}
 
 		const innerClasses = classnames(
 			'wp-block-coblocks-hero__inner',

--- a/src/blocks/hero/edit.js
+++ b/src/blocks/hero/edit.js
@@ -159,7 +159,7 @@ class Edit extends Component {
 		let classes = 'wp-block-coblocks-hero';
 
 		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-			classes = classnames( classes, [ `coblocks-hero-${ coblocks.id }` ] );
+			classes = classnames( classes, `coblocks-hero-${ coblocks.id }` );
 		}
 
 		const innerClasses = classnames(

--- a/src/blocks/hero/save.js
+++ b/src/blocks/hero/save.js
@@ -36,11 +36,14 @@ const save = ( { attributes } ) => {
 	const textClass = getColorClassName( 'color', textColor );
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-	const classlist = {
+	let classlist = {
 		'has-text-color': textColor || customTextColor,
 		[ textClass ]: textClass,
-		[ `coblocks-hero-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
 	};
+
+	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+		classlist = Object.assign( classlist, [ `coblocks-hero-${ coblocks.id }` ] );
+	}
 
 	const classes = classnames( classlist );
 

--- a/src/blocks/hero/save.js
+++ b/src/blocks/hero/save.js
@@ -36,16 +36,14 @@ const save = ( { attributes } ) => {
 	const textClass = getColorClassName( 'color', textColor );
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-	let classlist = {
+	let classes = classnames( {
 		'has-text-color': textColor || customTextColor,
 		[ textClass ]: textClass,
-	};
+	} );
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-		classlist = Object.assign( classlist, [ `coblocks-hero-${ coblocks.id }` ] );
+		classes = classnames( classnames, `coblocks-hero-${ coblocks.id }` );
 	}
-
-	const classes = classnames( classlist );
 
 	const styles = {
 		color: textClass ? undefined : customTextColor,

--- a/src/blocks/media-card/edit.js
+++ b/src/blocks/media-card/edit.js
@@ -198,6 +198,16 @@ class Edit extends Component {
 			maxWidth: maxWidth ? ( 'full' === align || 'wide' === align ) && maxWidth : undefined,
 		};
 
+		let classes = classnames( className, { [ `is-style-${ mediaPosition }` ]: mediaPosition,
+			'has-no-media': ! mediaUrl || null,
+			'is-selected': isSelected,
+			'is-stacked-on-mobile': isStackedOnMobile }
+		);
+
+		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+			classes = classnames( classes, [ `coblocks-media-card-${ coblocks.id }` ] );
+		}
+
 		return (
 			<Fragment>
 				{ dropZone }
@@ -212,15 +222,7 @@ class Edit extends Component {
 					/>
 				) }
 				<div
-					className={ classnames(
-						className, {
-							[ `coblocks-media-card-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
-							[ `is-style-${ mediaPosition }` ]: mediaPosition,
-							'has-no-media': ! mediaUrl || null,
-							'is-selected': isSelected,
-							'is-stacked-on-mobile': isStackedOnMobile,
-						}
-					) }
+					className={ classes }
 				>
 					<div className={ innerClasses } style={ innerStyles } >
 						{ isBlobURL( backgroundImg ) && <Spinner /> }

--- a/src/blocks/media-card/edit.js
+++ b/src/blocks/media-card/edit.js
@@ -205,7 +205,7 @@ class Edit extends Component {
 		);
 
 		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-			classes = classnames( classes, [ `coblocks-media-card-${ coblocks.id }` ] );
+			classes = classnames( classes, `coblocks-media-card-${ coblocks.id }` );
 		}
 
 		return (

--- a/src/blocks/media-card/save.js
+++ b/src/blocks/media-card/save.js
@@ -50,7 +50,7 @@ const save = ( { attributes } ) => {
 	} );
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-		classes = classnames( classes, [ `coblocks-media-card-${ coblocks.id }` ] );
+		classes = classnames( classes, `coblocks-media-card-${ coblocks.id }` );
 	}
 
 	const innerClasses = classnames(

--- a/src/blocks/media-card/save.js
+++ b/src/blocks/media-card/save.js
@@ -43,12 +43,15 @@ const save = ( { attributes } ) => {
 		gridTemplateColumns = mediaPosition === 'right' ? `auto ${ mediaWidth }%` : `${ mediaWidth }% auto`;
 	}
 
-	const classes = classnames( {
-		[ `coblocks-media-card-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
+	let classes = classnames( {
 		[ `is-style-${ mediaPosition }` ]: mediaPosition,
 		'has-no-media': ! mediaUrl || null,
 		'is-stacked-on-mobile': isStackedOnMobile,
 	} );
+
+	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+		classes = classnames( classes, [ `coblocks-media-card-${ coblocks.id }` ] );
+	}
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-media-card__inner',

--- a/src/blocks/row/column/edit.js
+++ b/src/blocks/row/column/edit.js
@@ -99,7 +99,7 @@ class Edit extends Component {
 		} );
 
 		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-			classes = classnames( classes, [ `coblocks-column-${ coblocks.id }` ] );
+			classes = classnames( classes, `coblocks-column-${ coblocks.id }` );
 		}
 
 		const innerClasses = classnames(

--- a/src/blocks/row/column/edit.js
+++ b/src/blocks/row/column/edit.js
@@ -91,14 +91,16 @@ class Edit extends Component {
 			/>
 		);
 
-		const classes = classnames( 'wp-block-coblocks-column', {
-			[ `coblocks-column-${ coblocks.id }` ]:
-				coblocks && typeof coblocks.id !== 'undefined',
+		let classes = classnames( 'wp-block-coblocks-column', {
 			'wp-block-coblocks-column-placeholder':
 				columnBlocks &&
 				columnBlocks.innerBlocks &&
 				Object.keys( columnBlocks.innerBlocks ).length < 1,
 		} );
+
+		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+			classes = classnames( classes, [ `coblocks-column-${ coblocks.id }` ] );
+		}
 
 		const innerClasses = classnames(
 			'wp-block-coblocks-column__inner',

--- a/src/blocks/row/column/save.js
+++ b/src/blocks/row/column/save.js
@@ -27,7 +27,7 @@ const save = ( { attributes } ) => {
 	let classes = '';
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-		classes = classnames( classes, [ `coblocks-column-${ coblocks.id }` ] );
+		classes = classnames( classes, `coblocks-column-${ coblocks.id }` );
 	}
 
 	const innerClasses = classnames(

--- a/src/blocks/row/column/save.js
+++ b/src/blocks/row/column/save.js
@@ -24,9 +24,11 @@ const save = ( { attributes } ) => {
 	} = attributes;
 	const textClass = getColorClassName( 'color', textColor );
 
-	const classes = classnames( {
-		[ `coblocks-column-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
-	} );
+	let classes = '';
+
+	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+		classes = classnames( classes, [ `coblocks-column-${ coblocks.id }` ] );
+	}
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-column__inner',

--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -268,12 +268,15 @@ class Edit extends Component {
 			);
 		}
 
-		const classes = classnames(
+		let classes = classnames(
 			className, {
 				[ `coblocks-row--${ id }` ]: id,
-				[ `coblocks-row-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
 			}
 		);
+
+		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+			classes = classnames( classes, [ `coblocks-row-${ coblocks.id }` ] );
+		}
 
 		const innerClasses = classnames(
 			'wp-block-coblocks-row__inner',

--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -275,7 +275,7 @@ class Edit extends Component {
 		);
 
 		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-			classes = classnames( classes, [ `coblocks-row-${ coblocks.id }` ] );
+			classes = classnames( classes, `coblocks-row-${ coblocks.id }` );
 		}
 
 		const innerClasses = classnames(

--- a/src/blocks/row/save.js
+++ b/src/blocks/row/save.js
@@ -41,7 +41,7 @@ function Save( { attributes } ) {
 	} );
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-		classes = classnames( classes, [ `coblocks-row-${ coblocks.id }` ] );
+		classes = classnames( classes, `coblocks-row-${ coblocks.id }` );
 	}
 
 	const innerClasses = classnames(

--- a/src/blocks/row/save.js
+++ b/src/blocks/row/save.js
@@ -36,10 +36,13 @@ function Save( { attributes } ) {
 	const textClass = getColorClassName( 'color', textColor );
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-	const classes = classnames( {
+	let classes = classnames( {
 		[ `coblocks-row--${ id }` ]: id,
-		[ `coblocks-row-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
 	} );
+
+	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+		classes = classnames( classes, [ `coblocks-row-${ coblocks.id }` ] );
+	}
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-row__inner',

--- a/src/blocks/shape-divider/edit.js
+++ b/src/blocks/shape-divider/edit.js
@@ -170,7 +170,7 @@ class Edit extends Component {
 			} );
 
 		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-			classes = classnames( classes, [ `coblocks-shape-divider-${ coblocks.id }` ] );
+			classes = classnames( classes, `coblocks-shape-divider-${ coblocks.id }` );
 		}
 
 		return (

--- a/src/blocks/shape-divider/edit.js
+++ b/src/blocks/shape-divider/edit.js
@@ -163,12 +163,15 @@ class Edit extends Component {
 			setAttributes( { justAdded: false } );
 		}
 
-		const classes = classnames(
+		let classes = classnames(
 			className, {
-				[ `coblocks-shape-divider-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
 				'is-vertically-flipped': verticalFlip,
 				'is-horizontally-flipped': horizontalFlip,
 			} );
+
+		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+			classes = classnames( classes, [ `coblocks-shape-divider-${ coblocks.id }` ] );
+		}
 
 		return (
 			<Fragment>

--- a/src/blocks/shape-divider/save.js
+++ b/src/blocks/shape-divider/save.js
@@ -38,7 +38,7 @@ const save = ( { attributes, className } ) => {
 		} );
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-		classes = classnames( classes, [ `coblocks-shape-divider-${ coblocks.id }` ] );
+		classes = classnames( classes, `coblocks-shape-divider-${ coblocks.id }` );
 	}
 
 	const styles = {

--- a/src/blocks/shape-divider/save.js
+++ b/src/blocks/shape-divider/save.js
@@ -29,14 +29,17 @@ const save = ( { attributes, className } ) => {
 	const shapeClass = getColorClassName( 'color', color );
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-	const classes = classnames(
+	let classes = classnames(
 		className, {
-			[ `coblocks-shape-divider-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
 			'is-vertically-flipped': verticalFlip,
 			'is-horizontally-flipped': horizontalFlip,
 			[ shapeClass ]: shapeClass,
 			[ backgroundClass ]: backgroundClass,
 		} );
+
+	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+		classes = classnames( classes, [ `coblocks-shape-divider-${ coblocks.id }` ] );
+	}
 
 	const styles = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,


### PR DESCRIPTION
- Closes #822
- The issue seemed to have been a JavaScript error. 
  * `coblocks` attribute was coming into deprecated function as undefined.
  * By handling the `coblocks` attribute, the deprecation continues to run which allows typical access to editor.
  * Upon page update the hero block works as expected. 

**Editing + Updating a page after fix in place**
![heroBlockDeprecation](https://user-images.githubusercontent.com/30462574/64192829-66cd6680-ce30-11e9-87df-b5884e7f4bdc.gif)
