### PR TITLE
Convert Alert class is-{type}-alert to is-style-{type}

### DIFF
--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -22,6 +22,20 @@ const { RichText } = wp.blockEditor;
  * Block edit function
  */
 class Edit extends Component {
+	componentDidMount() {
+		const { attributes, setAttributes } = this.props;
+
+		// Convert is-{type}-alert to is-style-{type}.
+		// See: https://github.com/godaddy/coblocks/pull/781
+		if ( /is-\w+-alert/.test( attributes.className ) ) {
+			let newClassName = attributes.className;
+
+			newClassName = newClassName.replace( 'is-default-alert', 'is-style-info' );
+			newClassName = newClassName.replace( /is-(\w+)-alert/, 'is-style-$1' );
+			setAttributes( { className: newClassName } );
+		}
+	}
+
 	render() {
 		const {
 			attributes,

--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -36,6 +36,16 @@ class Edit extends Component {
 		}
 	}
 
+	componentDidUpdate( prevProps ) {
+		const { attributes, setAttributes } = this.props;
+
+		// Reset color selections when a new style has been selected.
+		// If the legacy alert class is detected, we want to retain the custom color selections.
+		if ( ! /is-\w+-alert/.test( prevProps.attributes.className ) && prevProps.attributes.className !== attributes.className ) {
+			setAttributes( { backgroundColor: '', customBackgroundColor: '', textColor: '', customTextColor: '' } );
+		}
+	}
+
 	render() {
 		const {
 			attributes,

--- a/src/blocks/alert/index.js
+++ b/src/blocks/alert/index.js
@@ -1,6 +1,7 @@
 /**
  * Styles.
  */
+import './styles/editor.scss';
 import './styles/style.scss';
 
 /**

--- a/src/blocks/alert/styles/editor.scss
+++ b/src/blocks/alert/styles/editor.scss
@@ -1,0 +1,19 @@
+.block-editor-block-styles .wp-block-coblocks-alert {
+	background-color: $alert-default-background-color !important;
+	color: $alert-default-color !important;
+
+	&.is-style-warning {
+		background-color: $alert-warning-background-color !important;
+		color: $alert-warning-color !important;
+	}
+
+	&.is-style-error {
+		background-color: $alert-error-background-color !important;
+		color: $alert-error-color !important;
+	}
+
+	&.is-style-success {
+		background-color: $alert-success-background-color !important;
+		color: $alert-success-color !important;
+	}
+}

--- a/src/blocks/alert/styles/style.scss
+++ b/src/blocks/alert/styles/style.scss
@@ -1,34 +1,34 @@
 .wp-block-coblocks-alert {
-	background-color: #d6efee;
+	background-color: $alert-default-background-color;
 	border-radius: 3px;
-	color: #094264;
+	color: $alert-default-color;
 	padding: 2em;
 
 	&:not(.has-background) {
 		&.is-style-warning {
-			background-color: #fbe7dd;
+			background-color: $alert-warning-background-color;
 		}
 
 		&.is-style-error {
-			background-color: #ffdede;
+			background-color: $alert-error-background-color;
 		}
 
 		&.is-style-success {
-			background-color: #d0eac4;
+			background-color: $alert-success-background-color;
 		}
 	}
 
 	&:not(.has-text-color) {
 		&.is-style-warning {
-			color: #8a4b30;
+			color: $alert-warning-color;
 		}
 
 		&.is-style-error {
-			color: #8b343c;
+			color: $alert-error-color;
 		}
 
 		&.is-style-success {
-			color: #154a28;
+			color: $alert-success-color;
 		}
 	}
 

--- a/src/common.scss
+++ b/src/common.scss
@@ -17,6 +17,16 @@ $gutter--huge: 60px;
 $accordion-border-radius: 4px;
 $accordion-background: #f2f2f2;
 
+// Alert
+$alert-default-background-color: #d6efee;
+$alert-default-color: #094264;
+$alert-warning-background-color: #fbe7dd;
+$alert-warning-color: #8a4b30;
+$alert-error-background-color: #ffdede;
+$alert-error-color: #8b343c;
+$alert-success-background-color: #d0eac4;
+$alert-success-color: #154a28;
+
 // Click to Tweet
 $twitter: #1da1f2;
 


### PR DESCRIPTION
Related: #781 

The above PR was merged in before a deprecation was available. This PR resolves any issues with the `className` switch for the alert block styles. The conversion happens within the `componentDidMount` method of the Alert block's `Edit` component.

Because this is a `className` change and the removed attribute did not effect the rendered HTML, a block validation error is not thrown. An attempt was made to force a failure using the `isEligible` check within the deprecation, which worked except that we could not replace the old `is-{type}-alert` class with the new `is-style-{type}`. I believe this is because the `customClassName` block support hooks into the `edit` function of the block.

Existing deprecations were tested and passed without issues.

In my opinion, the behavior of this kind of hook makes this the only correct route to accomplish what we want. I left an inline comment with a link to #781 for developer reference.