### PR TITLE
Introduce a filter to prevent wp_mail from firing in the form block

### DIFF
--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -426,7 +426,20 @@ class CoBlocks_Form {
 
 		$form_submission = filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING );
 
-		if ( ! $form_submission || 'coblocks-form-submit' !== $form_submission ) {
+		/**
+		 * Filter to disable the CoBlocks form emails.
+		 *
+		 * @param bool false Whether or not the emails should be disabled.
+		 */
+		$disable_emails = (string) apply_filters( 'coblocks_form_disable_emails', false );
+
+		if ( ! $form_submission || 'coblocks-form-submit' !== $form_submission || $disable_emails ) {
+
+			if ( $disable_emails ) {
+
+				return true;
+
+			}
 
 			return;
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -420,7 +420,7 @@ class CoBlocks_Form {
 	/**
 	 * Process the form submission
 	 *
-	 * @return null
+	 * @return bool True when an email is sent, else false.
 	 */
 	public function process_form_submission( $atts ) {
 
@@ -466,9 +466,9 @@ class CoBlocks_Form {
 		 *
 		 * @param bool false Whether or not the emails should be disabled.
 		 */
-		$disable_emails = (string) apply_filters( 'coblocks_form_disable_emails', false );
+		$send_email = (bool) apply_filters( 'coblocks_form_email_send', true );
 
-		if ( $disable_emails ) {
+		if ( ! $send_email ) {
 
 			return true;
 
@@ -488,7 +488,7 @@ class CoBlocks_Form {
 
 				$this->remove_url_form_hash();
 
-				return;
+				return false;
 
 			}
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -426,20 +426,7 @@ class CoBlocks_Form {
 
 		$form_submission = filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING );
 
-		/**
-		 * Filter to disable the CoBlocks form emails.
-		 *
-		 * @param bool false Whether or not the emails should be disabled.
-		 */
-		$disable_emails = (string) apply_filters( 'coblocks_form_disable_emails', false );
-
-		if ( ! $form_submission || 'coblocks-form-submit' !== $form_submission || $disable_emails ) {
-
-			if ( $disable_emails ) {
-
-				return true;
-
-			}
+		if ( ! $form_submission || 'coblocks-form-submit' !== $form_submission ) {
 
 			return;
 
@@ -463,6 +450,27 @@ class CoBlocks_Form {
 			$this->remove_url_form_hash();
 
 			return;
+
+		}
+
+		/**
+		 * Fires before a form is submitted.
+		 *
+		 * @param array $_POST User submitted form data.
+		 * @param array $atts  Form block attributes.
+		 */
+		do_action( 'coblocks_before_form_submit', $_POST, $atts );
+
+		/**
+		 * Filter to disable the CoBlocks form emails.
+		 *
+		 * @param bool false Whether or not the emails should be disabled.
+		 */
+		$disable_emails = (string) apply_filters( 'coblocks_form_disable_emails', false );
+
+		if ( $disable_emails ) {
+
+			return true;
 
 		}
 


### PR DESCRIPTION
Introduce a new filter (`coblocks_form_disable_emails`) which allows users to short circuit the form submission and prevent `wp_mail()` from firing.

Additionally introduced a new action (`coblocks_before_form_submit`) that allows users to catch the form data before the emails are disabled. The thought here is that users can disable the email functionality, but still hook in and capture/utilize the submitted form data as they need.

### Usage
```php
/**
 * Disable form submission emails
 */
add_filter( 'coblocks_form_disable_emails', '__return_true' );

/**
 * Set a custom success message to mimic a successful form submission
 *
 * @return string Form submission success message
 */
function coblocks_form_sent_message() {

	return __( 'Your message was sent.', 'textdomain' );

}
add_filter( 'coblocks_form_sent_notice', 'coblocks_form_sent_message' );
```