### PR TITLE
Change z-index to 60 for hero block controls.

### DIFF
--- a/src/blocks/hero/styles/editor.scss
+++ b/src/blocks/hero/styles/editor.scss
@@ -17,7 +17,7 @@
 
 	&[data-align="full"],
 	&[data-align="wide"] {
-		z-index: 0;
+		z-index: 60;
 	}
 
 	.wp-block-coblocks-hero {


### PR DESCRIPTION
- Closes #826.
- I found that z-index of 60 was the minimum index that works in this case. 
- Tested block as user and found no negative side effect. 

![heroToolbarBelowGroup](https://user-images.githubusercontent.com/30462574/64537439-ad5b0f00-d2cf-11e9-9af7-c163b66a34b1.gif)
