### PR TITLE
Remove margin bottom on the last item within the Feature block

### DIFF
--- a/src/blocks/features/styles/style.scss
+++ b/src/blocks/features/styles/style.scss
@@ -56,14 +56,6 @@
 			&:not(.has-background) {
 				padding-top: 0;
 			}
-
-			&:last-child {
-				margin-bottom: 0;
-			}
-		}
-
-		> *:last-child {
-			margin-bottom: 0;
 		}
 	}
 
@@ -95,6 +87,10 @@
 
 		> * {
 			position: relative;
+		}
+
+		> *:last-child {
+			margin-bottom: 0 !important;
 		}
 	}
 }


### PR DESCRIPTION
Previously, the last paragraph would have it's margin bottom removed. This PR makes the last "anything" have its margin bottom removed. For example, if a user adds a button to the Feature block, it'll now also have it's margin removed. 