### PR TITLE
Add context to translation strings

### DIFF
--- a/includes/admin/class-coblocks-action-links.php
+++ b/includes/admin/class-coblocks-action-links.php
@@ -38,7 +38,7 @@ class CoBlocks_Action_Links {
 
 		if ( COBLOCKS_PLUGIN_BASE === $plugin_file ) {
 			$row_meta = [
-				'review' => '<a href="' . esc_url( COBLOCKS_REVIEW_URL ) . '" aria-label="' . esc_attr( __( 'Review CoBlocks on WordPress.org', '@@textdomain' ) ) . '" target="_blank">' . __( 'Leave a Review', '@@textdomain' ) . '</a>',
+				'review' => '<a href="' . esc_url( COBLOCKS_REVIEW_URL ) . '" aria-label="' . esc_attr( __( 'Review CoBlocks on WordPress.org', 'coblocks' ) ) . '" target="_blank">' . __( 'Leave a Review', 'coblocks' ) . '</a>',
 			];
 
 			$plugin_meta = array_merge( $plugin_meta, $row_meta );

--- a/includes/admin/class-coblocks-feedback.php
+++ b/includes/admin/class-coblocks-feedback.php
@@ -89,7 +89,7 @@ class CoBlocks_Feedback {
 		$years = ( intval( $seconds ) / YEAR_IN_SECONDS ) % 100;
 		if ( $years > 1 ) {
 			/* translators: Number of years */
-			return sprintf( __( '%s years', 'coblocks' ), $years );
+			return sprintf( __( '%d years', 'coblocks' ), $years );
 		} elseif ( $years > 0 ) {
 			return __( 'a year', 'coblocks' );
 		}
@@ -98,7 +98,7 @@ class CoBlocks_Feedback {
 		$weeks = ( intval( $seconds ) / WEEK_IN_SECONDS ) % 52;
 		if ( $weeks > 1 ) {
 			/* translators: Number of weeks */
-			return sprintf( __( '%s weeks', 'coblocks' ), $weeks );
+			return sprintf( __( '%d weeks', 'coblocks' ), $weeks );
 		} elseif ( $weeks > 0 ) {
 			return __( 'a week', 'coblocks' );
 		}
@@ -107,7 +107,7 @@ class CoBlocks_Feedback {
 		$days = ( intval( $seconds ) / DAY_IN_SECONDS ) % 7;
 		if ( $days > 1 ) {
 			/* translators: Number of days */
-			return sprintf( __( '%s days', 'coblocks' ), $days );
+			return sprintf( __( '%d days', 'coblocks' ), $days );
 		} elseif ( $days > 0 ) {
 			return __( 'a day', 'coblocks' );
 		}
@@ -116,7 +116,7 @@ class CoBlocks_Feedback {
 		$hours = ( intval( $seconds ) / HOUR_IN_SECONDS ) % 24;
 		if ( $hours > 1 ) {
 			/* translators: Number of hours */
-			return sprintf( __( '%s hours', 'coblocks' ), $hours );
+			return sprintf( __( '%d hours', 'coblocks' ), $hours );
 		} elseif ( $hours > 0 ) {
 			return __( 'an hour', 'coblocks' );
 		}
@@ -125,7 +125,7 @@ class CoBlocks_Feedback {
 		$minutes = ( intval( $seconds ) / MINUTE_IN_SECONDS ) % 60;
 		if ( $minutes > 1 ) {
 			/* translators: Number of minutes */
-			return sprintf( __( '%s minutes', 'coblocks' ), $minutes );
+			return sprintf( __( '%d minutes', 'coblocks' ), $minutes );
 		} elseif ( $minutes > 0 ) {
 			return __( 'a minute', 'coblocks' );
 		}
@@ -134,7 +134,7 @@ class CoBlocks_Feedback {
 		$seconds = intval( $seconds ) % 60;
 		if ( $seconds > 1 ) {
 			/* translators: Number of seconds */
-			return sprintf( __( '%s seconds', 'coblocks' ), $seconds );
+			return sprintf( __( '%d seconds', 'coblocks' ), $seconds );
 		} elseif ( $seconds > 0 ) {
 			return __( 'a second', 'coblocks' );
 		}
@@ -267,14 +267,14 @@ class CoBlocks_Feedback {
 		<div class="notice updated coblocks-notice">
 			<div class="coblocks-notice-inner">
 				<div class="coblocks-notice-icon">
-					<?php /* translators: 1. Name */ ?>
+					<?php /* translators: 1. Plugin Name */ ?>
 					<img src="<?php echo esc_url( COBLOCKS_PLUGIN_URL . 'dist/images/admin/icon-notice.jpg' ); ?>" alt="<?php printf( esc_attr__( '%s WordPress Plugin', 'coblocks' ), esc_attr( $this->name ) ); ?>" />
 				</div>
 				<div class="coblocks-notice-content">
-					<?php /* translators: 1. Name */ ?>
+					<?php /* translators: 1. Plugin Name */ ?>
 					<h3><?php printf( esc_html__( 'Are you enjoying %s?', 'coblocks' ), esc_html( $this->name ) ); ?></h3>
 					<p>
-						<?php /* translators: 1. Name, 2. Time */ ?>
+						<?php /* translators: 1. Plugin Name, 2. Time */ ?>
 						<?php printf( esc_html__( 'You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We\'d really appreciate it!', 'coblocks' ), esc_html( $this->name ), esc_html( $time ) ); ?>
 					</p>
 				</div>

--- a/includes/admin/class-coblocks-feedback.php
+++ b/includes/admin/class-coblocks-feedback.php
@@ -274,7 +274,7 @@ class CoBlocks_Feedback {
 					<?php /* translators: %s: Plugin Name */ ?>
 					<h3><?php printf( esc_html__( 'Are you enjoying %s?', 'coblocks' ), esc_html( $this->name ) ); ?></h3>
 					<p>
-						<?php /* translators: %s: Plugin Name, 2. Time */ ?>
+						<?php /* translators: %s: Plugin Name, 2. Time which the plugin has been in use for */ ?>
 						<?php printf( esc_html__( 'You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We\'d really appreciate it!', 'coblocks' ), esc_html( $this->name ), esc_html( $time ) ); ?>
 					</p>
 				</div>

--- a/includes/admin/class-coblocks-feedback.php
+++ b/includes/admin/class-coblocks-feedback.php
@@ -88,7 +88,7 @@ class CoBlocks_Feedback {
 		// Get the years.
 		$years = ( intval( $seconds ) / YEAR_IN_SECONDS ) % 100;
 		if ( $years > 1 ) {
-			/* translators: Number of years */
+			/* translators: %d: Number of years */
 			return sprintf( __( '%d years', 'coblocks' ), $years );
 		} elseif ( $years > 0 ) {
 			return __( 'a year', 'coblocks' );
@@ -97,7 +97,7 @@ class CoBlocks_Feedback {
 		// Get the weeks.
 		$weeks = ( intval( $seconds ) / WEEK_IN_SECONDS ) % 52;
 		if ( $weeks > 1 ) {
-			/* translators: Number of weeks */
+			/* translators: %d: Number of weeks */
 			return sprintf( __( '%d weeks', 'coblocks' ), $weeks );
 		} elseif ( $weeks > 0 ) {
 			return __( 'a week', 'coblocks' );
@@ -106,7 +106,7 @@ class CoBlocks_Feedback {
 		// Get the days.
 		$days = ( intval( $seconds ) / DAY_IN_SECONDS ) % 7;
 		if ( $days > 1 ) {
-			/* translators: Number of days */
+			/* translators: %d: Number of days */
 			return sprintf( __( '%d days', 'coblocks' ), $days );
 		} elseif ( $days > 0 ) {
 			return __( 'a day', 'coblocks' );
@@ -115,7 +115,7 @@ class CoBlocks_Feedback {
 		// Get the hours.
 		$hours = ( intval( $seconds ) / HOUR_IN_SECONDS ) % 24;
 		if ( $hours > 1 ) {
-			/* translators: Number of hours */
+			/* translators: %d: Number of hours */
 			return sprintf( __( '%d hours', 'coblocks' ), $hours );
 		} elseif ( $hours > 0 ) {
 			return __( 'an hour', 'coblocks' );
@@ -124,7 +124,7 @@ class CoBlocks_Feedback {
 		// Get the minutes.
 		$minutes = ( intval( $seconds ) / MINUTE_IN_SECONDS ) % 60;
 		if ( $minutes > 1 ) {
-			/* translators: Number of minutes */
+			/* translators: %d: Number of minutes */
 			return sprintf( __( '%d minutes', 'coblocks' ), $minutes );
 		} elseif ( $minutes > 0 ) {
 			return __( 'a minute', 'coblocks' );
@@ -133,7 +133,7 @@ class CoBlocks_Feedback {
 		// Get the seconds.
 		$seconds = intval( $seconds ) % 60;
 		if ( $seconds > 1 ) {
-			/* translators: Number of seconds */
+			/* translators: %d: Number of seconds */
 			return sprintf( __( '%d seconds', 'coblocks' ), $seconds );
 		} elseif ( $seconds > 0 ) {
 			return __( 'a second', 'coblocks' );
@@ -267,14 +267,14 @@ class CoBlocks_Feedback {
 		<div class="notice updated coblocks-notice">
 			<div class="coblocks-notice-inner">
 				<div class="coblocks-notice-icon">
-					<?php /* translators: 1. Plugin Name */ ?>
+					<?php /* translators: %s: Plugin Name */ ?>
 					<img src="<?php echo esc_url( COBLOCKS_PLUGIN_URL . 'dist/images/admin/icon-notice.jpg' ); ?>" alt="<?php printf( esc_attr__( '%s WordPress Plugin', 'coblocks' ), esc_attr( $this->name ) ); ?>" />
 				</div>
 				<div class="coblocks-notice-content">
-					<?php /* translators: 1. Plugin Name */ ?>
+					<?php /* translators: %s: Plugin Name */ ?>
 					<h3><?php printf( esc_html__( 'Are you enjoying %s?', 'coblocks' ), esc_html( $this->name ) ); ?></h3>
 					<p>
-						<?php /* translators: 1. Plugin Name, 2. Time */ ?>
+						<?php /* translators: %s: Plugin Name, 2. Time */ ?>
 						<?php printf( esc_html__( 'You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We\'d really appreciate it!', 'coblocks' ), esc_html( $this->name ), esc_html( $time ) ); ?>
 					</p>
 				</div>

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -204,6 +204,7 @@ class CoBlocks_Getting_Started_Page {
 
 			WP_CLI::log(
 				WP_CLI::colorize(
+					/* translators: 1: Getting started wtih Coblocks here: , 2: Link to coblocks admin page */
 					'%b' . sprintf( '🎉 %s %s', __( 'Get started with CoBlocks here:', 'coblocks' ), admin_url( 'admin.php?page=coblocks-getting-started' ) ) . '%n'
 				)
 			);

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -204,7 +204,7 @@ class CoBlocks_Getting_Started_Page {
 
 			WP_CLI::log(
 				WP_CLI::colorize(
-					/* translators: 1: Getting started wtih Coblocks here: , 2: Link to coblocks admin page */
+					/* translators: %s1: Getting started wtih Coblocks here: , %s2: Link to coblocks admin page */
 					'%b' . sprintf( '🎉 %s %s', __( 'Get started with CoBlocks here:', 'coblocks' ), admin_url( 'admin.php?page=coblocks-getting-started' ) ) . '%n'
 				)
 			);

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -204,7 +204,6 @@ class CoBlocks_Getting_Started_Page {
 
 			WP_CLI::log(
 				WP_CLI::colorize(
-					/* translators: %s1: Getting started wtih Coblocks here: , %s2: Link to coblocks admin page */
 					'%b' . sprintf( '🎉 %s %s', __( 'Get started with CoBlocks here:', 'coblocks' ), admin_url( 'admin.php?page=coblocks-getting-started' ) ) . '%n'
 				)
 			);

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -110,6 +110,7 @@ class CoBlocks_Block_Assets {
 		);
 
 		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		/* translators: s: The title of a specific blog post  */
 		$post_title = get_bloginfo( 'name' ) . ( ( false === $post_id ) ? '' : sprintf( ' - %s', get_the_title( $post_id ) ) );
 
 		/**

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -109,8 +109,7 @@ class CoBlocks_Block_Assets {
 			true
 		);
 
-		$post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
-		/* translators: %s: The title of a specific blog post  */
+		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 		$post_title = get_bloginfo( 'name' ) . ( ( false === $post_id ) ? '' : sprintf( ' - %s', get_the_title( $post_id ) ) );
 
 		/**

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -109,8 +109,8 @@ class CoBlocks_Block_Assets {
 			true
 		);
 
-		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
-		/* translators: s: The title of a specific blog post  */
+		$post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		/* translators: %s: The title of a specific blog post  */
 		$post_title = get_bloginfo( 'name' ) . ( ( false === $post_id ) ? '' : sprintf( ' - %s', get_the_title( $post_id ) ) );
 
 		/**

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -359,6 +359,7 @@ class CoBlocks_Form {
 		 */
 		$required_text  = (string) apply_filters( 'coblocks_form_label_required_text', '&#42;', $field_label );
 		$required_attr  = ( isset( $atts['required'] ) && $atts['required'] ) ? 'required' : '';
+		/* translators: s: Custom text label for form input*/
 		$required_label = empty( $required_attr ) ? '' : sprintf( ' <span class="required">%s</span>', $required_text );
 
 		/*
@@ -454,6 +455,7 @@ class CoBlocks_Form {
 		}
 
 		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		/* translators: s: A specific post title. */
 		$post_title = get_bloginfo( 'name' ) . ( ( false === $post_id ) ? '' : sprintf( ' - %s', get_the_title( $post_id ) ) );
 
 		$to      = isset( $atts['to'] ) ? sanitize_email( $atts['to'] ) : get_option( 'admin_email' );
@@ -570,6 +572,7 @@ class CoBlocks_Form {
 		$success_message = (string) apply_filters(
 			'coblocks_form_success_message',
 			sprintf(
+				/* translators: s1: Confirmation of email sent. s2: Placeholder for content from the completed contact from.  */
 				'<div class="coblocks-form__submitted">%s %s</div>',
 				wp_kses_post( $sent_notice ),
 				wp_kses_post( $this->email_content )

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -454,7 +454,7 @@ class CoBlocks_Form {
 
 		}
 
-		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		$post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 		/* translators: %s: A specific post title. */
 		$post_title = get_bloginfo( 'name' ) . ( ( false === $post_id ) ? '' : sprintf( ' - %s', get_the_title( $post_id ) ) );
 

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -357,9 +357,8 @@ class CoBlocks_Form {
 		 *
 		 * @param string $field_label Form field label text.
 		 */
-		$required_text = (string) apply_filters( 'coblocks_form_label_required_text', '&#42;', $field_label );
-		$required_attr = ( isset( $atts['required'] ) && $atts['required'] ) ? 'required' : '';
-		/* translators: %s: Custom text label for form input*/
+		$required_text  = (string) apply_filters( 'coblocks_form_label_required_text', '&#42;', $field_label );
+		$required_attr  = ( isset( $atts['required'] ) && $atts['required'] ) ? 'required' : '';
 		$required_label = empty( $required_attr ) ? '' : sprintf( ' <span class="required">%s</span>', $required_text );
 
 		/*
@@ -454,8 +453,7 @@ class CoBlocks_Form {
 
 		}
 
-		$post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
-		/* translators: %s: A specific post title. */
+		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 		$post_title = get_bloginfo( 'name' ) . ( ( false === $post_id ) ? '' : sprintf( ' - %s', get_the_title( $post_id ) ) );
 
 		$to      = isset( $atts['to'] ) ? sanitize_email( $atts['to'] ) : get_option( 'admin_email' );
@@ -572,7 +570,6 @@ class CoBlocks_Form {
 		$success_message = (string) apply_filters(
 			'coblocks_form_success_message',
 			sprintf(
-				/* translators: %s1: Confirmation of email sent. %s2: Placeholder for content from the completed contact from.  */
 				'<div class="coblocks-form__submitted">%s %s</div>',
 				wp_kses_post( $sent_notice ),
 				wp_kses_post( $this->email_content )

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -357,9 +357,9 @@ class CoBlocks_Form {
 		 *
 		 * @param string $field_label Form field label text.
 		 */
-		$required_text  = (string) apply_filters( 'coblocks_form_label_required_text', '&#42;', $field_label );
-		$required_attr  = ( isset( $atts['required'] ) && $atts['required'] ) ? 'required' : '';
-		/* translators: s: Custom text label for form input*/
+		$required_text = (string) apply_filters( 'coblocks_form_label_required_text', '&#42;', $field_label );
+		$required_attr = ( isset( $atts['required'] ) && $atts['required'] ) ? 'required' : '';
+		/* translators: %s: Custom text label for form input*/
 		$required_label = empty( $required_attr ) ? '' : sprintf( ' <span class="required">%s</span>', $required_text );
 
 		/*
@@ -455,7 +455,7 @@ class CoBlocks_Form {
 		}
 
 		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
-		/* translators: s: A specific post title. */
+		/* translators: %s: A specific post title. */
 		$post_title = get_bloginfo( 'name' ) . ( ( false === $post_id ) ? '' : sprintf( ' - %s', get_the_title( $post_id ) ) );
 
 		$to      = isset( $atts['to'] ) ? sanitize_email( $atts['to'] ) : get_option( 'admin_email' );
@@ -572,7 +572,7 @@ class CoBlocks_Form {
 		$success_message = (string) apply_filters(
 			'coblocks_form_success_message',
 			sprintf(
-				/* translators: s1: Confirmation of email sent. s2: Placeholder for content from the completed contact from.  */
+				/* translators: %s1: Confirmation of email sent. %s2: Placeholder for content from the completed contact from.  */
 				'<div class="coblocks-form__submitted">%s %s</div>',
 				wp_kses_post( $sent_notice ),
 				wp_kses_post( $this->email_content )

--- a/src/blocks/accordion/accordion-item/controls.js
+++ b/src/blocks/accordion/accordion-item/controls.js
@@ -25,7 +25,7 @@ class Controls extends Component {
 		const customControls = [
 			{
 				icon: icons.open,
-				title: _x( 'Display open', 'Visually display open as opposed to closed.' ),
+				title: _x( 'Display open', 'Toggle label to display the accordion open' ),
 				onClick: () => setAttributes( { open: ! open } ),
 				isActive: open === true,
 			},

--- a/src/blocks/accordion/accordion-item/controls.js
+++ b/src/blocks/accordion/accordion-item/controls.js
@@ -6,7 +6,7 @@ import icons from './../../../utils/icons';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { BlockControls } = wp.blockEditor;
 const { Toolbar } = wp.components;
@@ -25,7 +25,7 @@ class Controls extends Component {
 		const customControls = [
 			{
 				icon: icons.open,
-				title: __( 'Display open' ),
+				title: _x( 'Display open', 'Visually display open as opposed to closed.' ),
 				onClick: () => setAttributes( { open: ! open } ),
 				isActive: open === true,
 			},

--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -13,7 +13,7 @@ import Controls from './controls';
 /**
  * WordPress dependencies
  */
-const { __, _x } = wp.i18n;
+const { _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
 const { InnerBlocks, RichText } = wp.blockEditor;

--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -13,7 +13,7 @@ import Controls from './controls';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
 const { InnerBlocks, RichText } = wp.blockEditor;
@@ -64,7 +64,7 @@ class Edit extends Component {
 				>
 					<RichText
 						tagName="p"
-						placeholder={ __( 'Add accordion title...' ) }
+						placeholder={ _x( 'Add accordion title...', 'Accordion is the block name' ) }
 						value={ title }
 						className={ classnames(
 							`${ className }__title`, {

--- a/src/blocks/accordion/accordion-item/index.js
+++ b/src/blocks/accordion/accordion-item/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Accordion Item', 'This is an inner block for the Accordion Block.' ),
 	description: __( 'Add collapsable accordion items to accordions.' ),
 	icon,
-	keywords: [ __( 'tabs' ), __( 'faq' ), 'coblocks' ],
+	keywords: [ _x( 'tabs', 'block search keyword' ), _x( 'faq', 'block search keyword' ), 'coblocks' ],
 	parent: [ 'coblocks/accordion' ],
 	supports: {
 		reusable: false,

--- a/src/blocks/accordion/accordion-item/index.js
+++ b/src/blocks/accordion/accordion-item/index.js
@@ -15,7 +15,7 @@ import save from './save';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -23,7 +23,7 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Accordion Item' ),
+	title: _x( 'Accordion Item', 'This is an inner block for the Accordion Block.' ),
 	description: __( 'Add collapsable accordion items to accordions.' ),
 	icon,
 	keywords: [ __( 'tabs' ), __( 'faq' ), 'coblocks' ],

--- a/src/blocks/accordion/accordion-item/index.js
+++ b/src/blocks/accordion/accordion-item/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Accordion Item', 'This is an inner block for the Accordion Block.' ),
 	description: __( 'Add collapsable accordion items to accordions.' ),
 	icon,
-	keywords: [ _x( 'tabs', 'block search keyword' ), _x( 'faq', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'tabs', 'block keyword' ), _x( 'faq', 'block keyword' ), 'coblocks' ],
 	parent: [ 'coblocks/accordion' ],
 	supports: {
 		reusable: false,

--- a/src/blocks/accordion/accordion-item/inspector.js
+++ b/src/blocks/accordion/accordion-item/inspector.js
@@ -6,7 +6,7 @@ import applyWithColors from './colors';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
 const { InspectorControls, ContrastChecker, PanelColorSettings } = wp.blockEditor;
@@ -62,7 +62,7 @@ class Inspector extends Component {
 				<InspectorControls>
 					<PanelBody title={ __( 'Accordion Item Settings' ) }>
 						<ToggleControl
-							label={ __( 'Display Open' ) }
+							label={ _x( 'Display Open', 'Visually display open as opposed to closed.' ) }
 							checked={ !! open }
 							help={ this.getDisplayOpenHelp }
 							onChange={ () => setAttributes( { open: ! open } ) }

--- a/src/blocks/accordion/edit.js
+++ b/src/blocks/accordion/edit.js
@@ -8,7 +8,7 @@ import Inspector from './inspector';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { InnerBlocks } = wp.blockEditor;
 const { IconButton } = wp.components;
@@ -70,7 +70,7 @@ class Edit extends Component {
 						<IconButton
 							isLarge
 							className="block-editor-button-block-appender components-coblocks-add-accordion-item__button"
-							label={ __( 'Add Accordion Item' ) }
+							label={ _x( 'Add Accordion Item', 'This is an inner block for the Accordion Block.' ) }
 							icon="insert"
 							onClick={ () => {
 								if ( items[ 0 ].innerBlocks ) {

--- a/src/blocks/accordion/edit.js
+++ b/src/blocks/accordion/edit.js
@@ -70,7 +70,7 @@ class Edit extends Component {
 						<IconButton
 							isLarge
 							className="block-editor-button-block-appender components-coblocks-add-accordion-item__button"
-							label={ _x( 'Add Accordion Item', 'This is an inner block for the Accordion Block.' ) }
+							label={ _x( 'Add Accordion Item', 'This is an child element for the Accordion Block.' ) }
 							icon="insert"
 							onClick={ () => {
 								if ( items[ 0 ].innerBlocks ) {

--- a/src/blocks/accordion/index.js
+++ b/src/blocks/accordion/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Accordion', 'block title' ),
 	description: __( 'Organize content within collapsable accordion items.' ),
 	icon,
-	keywords: [ _x( 'tabs', 'block search keyword' ), _x( 'faq', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'tabs', 'block keyword' ), _x( 'faq', 'block keyword' ), 'coblocks' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/src/blocks/accordion/index.js
+++ b/src/blocks/accordion/index.js
@@ -15,7 +15,7 @@ import transforms from './transforms';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { InnerBlocks } = wp.blockEditor;
 
 /**
@@ -24,7 +24,7 @@ const { InnerBlocks } = wp.blockEditor;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Accordion' ),
+	title: _x( 'Accordion', 'block title' ),
 	description: __( 'Organize content within collapsable accordion items.' ),
 	icon,
 	keywords: [ __( 'tabs' ), __( 'faq' ), 'coblocks' ],

--- a/src/blocks/accordion/index.js
+++ b/src/blocks/accordion/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Accordion', 'block title' ),
 	description: __( 'Organize content within collapsable accordion items.' ),
 	icon,
-	keywords: [ __( 'tabs' ), __( 'faq' ), 'coblocks' ],
+	keywords: [ _x( 'tabs', 'block search keyword' ), _x( 'faq', 'block search keyword' ), 'coblocks' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -13,7 +13,7 @@ import applyWithColors from './colors';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
 const { RichText } = wp.blockEditor;
@@ -92,7 +92,7 @@ class Edit extends Component {
 				>
 					{ ( ! RichText.isEmpty( title ) || isSelected ) && (
 						<RichText
-							placeholder={ __( 'Write title...' ) }
+							placeholder={ _x( 'Write title...', 'Placeholder text for input box' ) }
 							value={ title }
 							className="wp-block-coblocks-alert__title"
 							onChange={ ( value ) => setAttributes( { title: value } ) }
@@ -100,7 +100,7 @@ class Edit extends Component {
 						/>
 					) }
 					<RichText
-						placeholder={ __( 'Write text...' ) }
+						placeholder={ _x( 'Write text...', 'Placeholder text for input box' ) }
 						value={ value }
 						className="wp-block-coblocks-alert__text"
 						onChange={ ( value ) => setAttributes( { value: value } ) }

--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -13,7 +13,7 @@ import applyWithColors from './colors';
 /**
  * WordPress dependencies
  */
-const { __, _x } = wp.i18n;
+const { _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
 const { RichText } = wp.blockEditor;

--- a/src/blocks/alert/index.js
+++ b/src/blocks/alert/index.js
@@ -28,7 +28,7 @@ const settings = {
 	title: _x( 'Alert', 'block name' ),
 	description: __( 'Provide contextual feedback messages or notices.' ),
 	icon,
-	keywords: [ _x( 'notice', 'block search keyword' ), _x( 'message', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'notice', 'block keyword' ), _x( 'message', 'block keyword' ), 'coblocks' ],
 	styles: [
 		{ name: 'info', label: _x( 'Info', 'block style' ), isDefault: true },
 		{ name: 'success', label: _x( 'Success', 'block style' ) },

--- a/src/blocks/alert/index.js
+++ b/src/blocks/alert/index.js
@@ -25,7 +25,7 @@ const { __, _x } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Alert' ),
+	title: _x( 'Alert', 'block name' ),
 	description: __( 'Provide contextual feedback messages or notices.' ),
 	icon,
 	keywords: [ __( 'notice' ), __( 'message' ), 'coblocks' ],

--- a/src/blocks/alert/index.js
+++ b/src/blocks/alert/index.js
@@ -28,7 +28,7 @@ const settings = {
 	title: _x( 'Alert', 'block name' ),
 	description: __( 'Provide contextual feedback messages or notices.' ),
 	icon,
-	keywords: [ __( 'notice' ), __( 'message' ), 'coblocks' ],
+	keywords: [ _x( 'notice', 'block search keyword' ), _x( 'message', 'block search keyword' ), 'coblocks' ],
 	styles: [
 		{ name: 'info', label: _x( 'Info', 'block style' ), isDefault: true },
 		{ name: 'success', label: _x( 'Success', 'block style' ) },

--- a/src/blocks/author/edit.js
+++ b/src/blocks/author/edit.js
@@ -7,7 +7,7 @@ import Controls from './controls';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { mediaUpload } = wp.editor;
 const { RichText, InnerBlocks, MediaUpload, MediaUploadCheck } = wp.blockEditor;
@@ -99,7 +99,7 @@ class Edit extends Component {
 		const dropZone = (
 			<DropZone
 				onFilesDrop={ this.addImage }
-				label={ __( 'Drop to add as avatar' ) }
+				label={ _x( 'Drop to add as avatar', 'avatar meaning an image representing the user' ) }
 			/>
 		);
 

--- a/src/blocks/author/edit.js
+++ b/src/blocks/author/edit.js
@@ -99,7 +99,7 @@ class Edit extends Component {
 		const dropZone = (
 			<DropZone
 				onFilesDrop={ this.addImage }
-				label={ _x( 'Drop to add as avatar', 'avatar meaning an image representing the user' ) }
+				label={ _x( 'Drop to add as avatar', 'avatar is an image representing the user' ) }
 			/>
 		);
 

--- a/src/blocks/author/index.js
+++ b/src/blocks/author/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Author', 'block name' ),
 	description: __( 'Add an author biography to build credibility and authority.' ),
 	icon,
-	keywords: [ _x( 'biography', 'block search keyword' ), _x( 'profile', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'biography', 'block keyword' ), _x( 'profile', 'block keyword' ), 'coblocks' ],
 	example: {
 		attributes: {
 			name: 'Jane Doe',

--- a/src/blocks/author/index.js
+++ b/src/blocks/author/index.js
@@ -16,7 +16,7 @@ import transforms from './transforms';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -24,7 +24,7 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Author' ),
+	title: _x( 'Author', 'block name' ),
 	description: __( 'Add an author biography to build credibility and authority.' ),
 	icon,
 	keywords: [ __( 'biography' ), __( 'profile' ), 'coblocks' ],

--- a/src/blocks/author/index.js
+++ b/src/blocks/author/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Author', 'block name' ),
 	description: __( 'Add an author biography to build credibility and authority.' ),
 	icon,
-	keywords: [ __( 'biography' ), __( 'profile' ), 'coblocks' ],
+	keywords: [ _x( 'biography', 'block search keyword' ), _x( 'profile', 'block search keyword' ), 'coblocks' ],
 	example: {
 		attributes: {
 			name: 'Jane Doe',

--- a/src/blocks/buttons/index.js
+++ b/src/blocks/buttons/index.js
@@ -28,7 +28,7 @@ const settings = {
 	title: _x( 'Buttons', 'block name' ),
 	description: __( 'Prompt visitors to take action with multiple buttons, side by side.' ),
 	icon,
-	keywords: [ _x( 'link', 'block search keyword' ), _x( 'cta', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'link', 'block keyword' ), _x( 'cta', 'block keyword' ), 'coblocks' ],
 	attributes,
 	transforms,
 	edit,

--- a/src/blocks/buttons/index.js
+++ b/src/blocks/buttons/index.js
@@ -28,7 +28,7 @@ const settings = {
 	title: _x( 'Buttons', 'block name' ),
 	description: __( 'Prompt visitors to take action with multiple buttons, side by side.' ),
 	icon,
-	keywords: [ __( 'link' ), __( 'cta' ), 'coblocks' ],
+	keywords: [ _x( 'link', 'block search keyword' ), _x( 'cta', 'block search keyword' ), 'coblocks' ],
 	attributes,
 	transforms,
 	edit,

--- a/src/blocks/buttons/index.js
+++ b/src/blocks/buttons/index.js
@@ -17,7 +17,7 @@ import transforms from './transforms';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -25,7 +25,7 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Buttons' ),
+	title: _x( 'Buttons', 'block name' ),
 	description: __( 'Prompt visitors to take action with multiple buttons, side by side.' ),
 	icon,
 	keywords: [ __( 'link' ), __( 'cta' ), 'coblocks' ],

--- a/src/blocks/buttons/inspector.js
+++ b/src/blocks/buttons/inspector.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { InspectorControls } = wp.blockEditor;
 const { PanelBody, RangeControl, ToggleControl } = wp.components;
@@ -25,7 +25,7 @@ class Inspector extends Component {
 		return (
 			<Fragment>
 				<InspectorControls>
-					<PanelBody title={ __( 'Buttons Settings' ) }>
+					<PanelBody title={ _x( 'Buttons Settings', 'block settings' ) }>
 						<RangeControl
 							label={ __( 'Buttons' ) }
 							value={ items }
@@ -40,7 +40,7 @@ class Inspector extends Component {
 							max={ 4 }
 						/>
 						<ToggleControl
-							label={ __( 'Stack on mobile' ) }
+							label={ _x( 'Stack on mobile', 'visually stack buttons one on top of another' ) }
 							checked={ isStackedOnMobile }
 							onChange={ () => setAttributes( {
 								isStackedOnMobile: ! isStackedOnMobile,

--- a/src/blocks/click-to-tweet/index.js
+++ b/src/blocks/click-to-tweet/index.js
@@ -16,7 +16,7 @@ import transforms from './transforms';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -24,7 +24,7 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Click to Tweet' ),
+	title: _x( 'Click to Tweet', 'block name' ),
 	description: __( 'Add a quote for readers to tweet via Twitter.' ),
 	icon,
 	keywords: [ __( 'share' ), __( 'twitter' ), 'coblocks' ],

--- a/src/blocks/click-to-tweet/index.js
+++ b/src/blocks/click-to-tweet/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Click to Tweet', 'block name' ),
 	description: __( 'Add a quote for readers to tweet via Twitter.' ),
 	icon,
-	keywords: [ __( 'share' ), __( 'twitter' ), 'coblocks' ],
+	keywords: [ _x( 'share', 'block search keyword' ), _x( 'twitter', 'block search keyword' ), 'coblocks' ],
 	example: {
 		attributes: {
 			content: __( 'The easiest way to promote and advertise your blog, website, and business on Twitter.' ),

--- a/src/blocks/click-to-tweet/index.js
+++ b/src/blocks/click-to-tweet/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Click to Tweet', 'block name' ),
 	description: __( 'Add a quote for readers to tweet via Twitter.' ),
 	icon,
-	keywords: [ _x( 'share', 'block search keyword' ), _x( 'twitter', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'share', 'block keyword' ), _x( 'twitter', 'block keyword' ), 'coblocks' ],
 	example: {
 		attributes: {
 			content: __( 'The easiest way to promote and advertise your blog, website, and business on Twitter.' ),

--- a/src/blocks/dynamic-separator/index.js
+++ b/src/blocks/dynamic-separator/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Dynamic HR', 'block name' ),
 	description: __( 'Add a resizable spacer between other blocks.' ),
 	icon,
-	keywords: [ __( 'spacer' ), 'hr', 'coblocks' ],
+	keywords: [ _x( 'spacer', 'block search keyword' ), 'hr', 'coblocks' ],
 	styles: [
 		{ name: 'dots', label: _x( 'Dot', 'block style' ), isDefault: true },
 		{ name: 'line', label: _x( 'Line', 'block style' ) },

--- a/src/blocks/dynamic-separator/index.js
+++ b/src/blocks/dynamic-separator/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Dynamic HR', 'block name' ),
 	description: __( 'Add a resizable spacer between other blocks.' ),
 	icon,
-	keywords: [ _x( 'spacer', 'block search keyword' ), 'hr', 'coblocks' ],
+	keywords: [ _x( 'spacer', 'block keyword' ), 'hr', 'coblocks' ],
 	styles: [
 		{ name: 'dots', label: _x( 'Dot', 'block style' ), isDefault: true },
 		{ name: 'line', label: _x( 'Line', 'block style' ) },

--- a/src/blocks/dynamic-separator/index.js
+++ b/src/blocks/dynamic-separator/index.js
@@ -24,7 +24,7 @@ const { __, _x } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Dynamic HR' ),
+	title: _x( 'Dynamic HR', 'block name' ),
 	description: __( 'Add a resizable spacer between other blocks.' ),
 	icon,
 	keywords: [ __( 'spacer' ), 'hr', 'coblocks' ],

--- a/src/blocks/dynamic-separator/inspector.js
+++ b/src/blocks/dynamic-separator/inspector.js
@@ -6,7 +6,7 @@ import applyWithColors from './colors';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
 const { InspectorControls, PanelColorSettings } = wp.blockEditor;
@@ -40,7 +40,7 @@ class Inspector extends Component {
 		return (
 			<Fragment>
 				<InspectorControls>
-					<PanelBody title={ __( 'Dynamic HR Settings' ) }>
+					<PanelBody title={ _x( 'Dynamic HR Settings', 'hr is html markup - horizonal rule' ) }>
 						<BaseControl label={ __( 'Height in pixels' ) }>
 							<input
 								type="number"

--- a/src/blocks/features/feature/index.js
+++ b/src/blocks/features/feature/index.js
@@ -11,7 +11,7 @@ import save from './save';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -25,7 +25,7 @@ const attributes = {
 };
 
 const settings = {
-	title: __( 'Feature' ),
+	title: _x( 'Feature', 'block name' ),
 	description: __( 'A singular child column within a parent features block.' ),
 	icon,
 	parent: [ 'coblocks/features' ],

--- a/src/blocks/features/index.js
+++ b/src/blocks/features/index.js
@@ -34,7 +34,7 @@ const settings = {
 	title: _x( 'Features', 'block name' ),
 	description: __( 'Add up to three columns of small notes for your product or service.' ),
 	icon,
-	keywords: [ __( 'services' ), 'coblocks' ],
+	keywords: [ _x( 'services', 'block search keyword' ), 'coblocks' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		coBlocksSpacing: true,

--- a/src/blocks/features/index.js
+++ b/src/blocks/features/index.js
@@ -34,7 +34,7 @@ const settings = {
 	title: _x( 'Features', 'block name' ),
 	description: __( 'Add up to three columns of small notes for your product or service.' ),
 	icon,
-	keywords: [ _x( 'services', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'services', 'block keyword' ), 'coblocks' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		coBlocksSpacing: true,

--- a/src/blocks/features/index.js
+++ b/src/blocks/features/index.js
@@ -18,7 +18,7 @@ import { BackgroundAttributes } from '../../components/background';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 /**
  * Block constants
  */
@@ -31,7 +31,7 @@ const attributes = {
 };
 
 const settings = {
-	title: __( 'Features' ),
+	title: _x( 'Features', 'block name' ),
 	description: __( 'Add up to three columns of small notes for your product or service.' ),
 	icon,
 	keywords: [ __( 'services' ), 'coblocks' ],

--- a/src/blocks/food-and-drinks/edit.js
+++ b/src/blocks/food-and-drinks/edit.js
@@ -14,7 +14,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies.
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
 const { withSelect, dispatch, select } = wp.data;
@@ -32,14 +32,14 @@ const TEMPLATE = [
 const layoutOptions = [
 	{
 		name: 'grid',
-		label: __( 'Grid' ),
+		label: _x( 'Grid', 'block style' ),
 		icon: icons.layoutGridIcon,
 		iconWithImages: icons.layoutGridIconWithImages,
 		isDefault: true,
 	},
 	{
 		name: 'list',
-		label: __( 'List' ),
+		label: _x( 'List', 'block style' ),
 		icon: icons.layoutListIcon,
 		iconWithImages: icons.layoutListIconWithImages,
 	},

--- a/src/blocks/food-and-drinks/food-item/index.js
+++ b/src/blocks/food-and-drinks/food-item/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Food Item', 'block name' ),
 	description: __( 'A food and drink item within the Food & Drinks block.' ),
 	icon,
-	keywords: __( 'menu' ),
+	keywords: _x( 'menu', 'block search keyword' ),
 	supports: {
 		inserter: false,
 		customClassName: false,

--- a/src/blocks/food-and-drinks/food-item/index.js
+++ b/src/blocks/food-and-drinks/food-item/index.js
@@ -15,7 +15,7 @@ import save from './save';
 /**
  * WordPress dependencies.
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants.
@@ -23,7 +23,7 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Food Item' ),
+	title: _x( 'Food Item', 'block name' ),
 	description: __( 'A food and drink item within the Food & Drinks block.' ),
 	icon,
 	keywords: __( 'menu' ),

--- a/src/blocks/food-and-drinks/food-item/index.js
+++ b/src/blocks/food-and-drinks/food-item/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Food Item', 'block name' ),
 	description: __( 'A food and drink item within the Food & Drinks block.' ),
 	icon,
-	keywords: _x( 'menu', 'block search keyword' ),
+	keywords: _x( 'menu', 'block keyword' ),
 	supports: {
 		inserter: false,
 		customClassName: false,

--- a/src/blocks/food-and-drinks/index.js
+++ b/src/blocks/food-and-drinks/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Food & Drinks', 'block name' ),
 	description: __( 'Display a menu or price list.' ),
 	icon,
-	keywords: [ _x( 'restaurant', 'block search keyword' ), _x( 'menu', 'block search keyword' ) ],
+	keywords: [ _x( 'restaurant', 'block keyword' ), _x( 'menu', 'block keyword' ) ],
 	supports: {
 		align: [ 'wide' ],
 	},

--- a/src/blocks/food-and-drinks/index.js
+++ b/src/blocks/food-and-drinks/index.js
@@ -15,7 +15,7 @@ import save from './save';
 /**
  * WordPress dependencies.
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants.
@@ -23,7 +23,7 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Food & Drinks' ),
+	title: _x( 'Food & Drinks', 'block name' ),
 	description: __( 'Display a menu or price list.' ),
 	icon,
 	keywords: [ __( 'restaurant' ), __( 'menu' ) ],

--- a/src/blocks/food-and-drinks/index.js
+++ b/src/blocks/food-and-drinks/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Food & Drinks', 'block name' ),
 	description: __( 'Display a menu or price list.' ),
 	icon,
-	keywords: [ __( 'restaurant' ), __( 'menu' ) ],
+	keywords: [ _x( 'restaurant', 'block search keyword' ), _x( 'menu', 'block search keyword' ) ],
 	supports: {
 		align: [ 'wide' ],
 	},

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -19,7 +19,7 @@ import SubmitButton from './submit-button';
 /**
  * WordPress dependencies
  */
-const { __, sprintf } = wp.i18n;
+const { __, _x, sprintf } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { registerBlockType, getBlockType } = wp.blocks;
 const { Button, PanelBody, TextControl, ExternalLink } = wp.components;
@@ -118,7 +118,7 @@ export const childBlocks = [
 		settings: {
 			...FieldDefaults,
 			title: __( 'Message' ),
-			keywords: [ __( 'Textarea' ), 'textarea', __( 'Multiline text' ) ],
+			keywords: [ _x( 'Textarea', 'refers to an HTML element' ), 'textarea', __( 'Multiline text' ) ],
 			description: __( 'A text box for longer responses.' ),
 			icon: icons.textarea,
 			edit: props => (

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -85,7 +85,7 @@ export const childBlocks = [
 		name: 'coblocks/field-name',
 		settings: {
 			...FieldDefaults,
-			title: __( 'Name' ),
+			title: _x( 'Name', 'block name' ),
 			description: __( 'A text field for names.' ),
 			icon: icons.name,
 			edit: props => (
@@ -106,8 +106,8 @@ export const childBlocks = [
 		name: 'coblocks/field-email',
 		settings: {
 			...FieldDefaults,
-			title: __( 'Email' ),
-			keywords: [ __( 'e-mail' ), __( 'mail' ), 'email' ],
+			title: _x( 'Email', 'block name' ),
+			keywords: [ _x( 'e-mail', 'block search keyword' ), _x( 'mail', 'block search keyword' ), 'email' ],
 			description: __( 'An email address field.' ),
 			icon: icons.email,
 			edit: editField( 'email' ),
@@ -117,8 +117,8 @@ export const childBlocks = [
 		name: 'coblocks/field-textarea',
 		settings: {
 			...FieldDefaults,
-			title: __( 'Message' ),
-			keywords: [ _x( 'Textarea', 'refers to an HTML element' ), 'textarea', __( 'Multiline text' ) ],
+			title: _x( 'Message', 'block name' ),
+			keywords: [ _x( 'Textarea', 'block search keyword' ), 'textarea', _x( 'Multiline text', 'block search keyword' ) ],
 			description: __( 'A text box for longer responses.' ),
 			icon: icons.textarea,
 			edit: props => (

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -107,7 +107,7 @@ export const childBlocks = [
 		settings: {
 			...FieldDefaults,
 			title: _x( 'Email', 'block name' ),
-			keywords: [ _x( 'e-mail', 'block search keyword' ), _x( 'mail', 'block search keyword' ), 'email' ],
+			keywords: [ _x( 'e-mail', 'block keyword' ), _x( 'mail', 'block keyword' ), 'email' ],
 			description: __( 'An email address field.' ),
 			icon: icons.email,
 			edit: editField( 'email' ),
@@ -118,7 +118,7 @@ export const childBlocks = [
 		settings: {
 			...FieldDefaults,
 			title: _x( 'Message', 'block name' ),
-			keywords: [ _x( 'Textarea', 'block search keyword' ), 'textarea', _x( 'Multiline text', 'block search keyword' ) ],
+			keywords: [ _x( 'Textarea', 'block keyword' ), 'textarea', _x( 'Multiline text', 'block keyword' ) ],
 			description: __( 'A text box for longer responses.' ),
 			icon: icons.textarea,
 			edit: props => (

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -286,6 +286,7 @@ class FormEdit extends Component {
 			if ( errors.length === 1 ) {
 				if ( errors[ 0 ] && errors[ 0 ].email ) {
 					return sprintf(
+						/* translators: s: Placeholder for email address provided by user.  */
 						__( '%s is not a valid email address.' ),
 						errors[ 0 ].email
 					);
@@ -295,6 +296,7 @@ class FormEdit extends Component {
 
 			if ( errors.length === 2 ) {
 				return sprintf(
+					/* translators: s1: Placeholder for email address provided by user. s2: Placeholder for email address provided by user.  */
 					__( '%s and %s are not a valid email address.' ),
 					errors[ 0 ].email,
 					errors[ 1 ].email
@@ -302,6 +304,7 @@ class FormEdit extends Component {
 			}
 			const inValidEmails = errors.map( error => error.email );
 			return sprintf(
+				/* translators: s1: Placeholder for email address provided by user. */
 				__( '%s are not a valid email address.' ),
 				inValidEmails.join( ', ' )
 			);

--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -286,7 +286,7 @@ class FormEdit extends Component {
 			if ( errors.length === 1 ) {
 				if ( errors[ 0 ] && errors[ 0 ].email ) {
 					return sprintf(
-						/* translators: s: Placeholder for email address provided by user.  */
+						/* translators: %s: Placeholder for email address provided by user.  */
 						__( '%s is not a valid email address.' ),
 						errors[ 0 ].email
 					);
@@ -296,7 +296,7 @@ class FormEdit extends Component {
 
 			if ( errors.length === 2 ) {
 				return sprintf(
-					/* translators: s1: Placeholder for email address provided by user. s2: Placeholder for email address provided by user.  */
+					/* translators: %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.  */
 					__( '%s and %s are not a valid email address.' ),
 					errors[ 0 ].email,
 					errors[ 1 ].email
@@ -304,7 +304,7 @@ class FormEdit extends Component {
 			}
 			const inValidEmails = errors.map( error => error.email );
 			return sprintf(
-				/* translators: s1: Placeholder for email address provided by user. */
+				/* translators: %s1: Placeholder for email address provided by user. */
 				__( '%s are not a valid email address.' ),
 				inValidEmails.join( ', ' )
 			);

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Form', 'block name' ),
 	description: __( 'Add a simple form to your page.' ),
 	icon,
-	keywords: [ __( 'email' ), __( 'about' ), __( 'contact' ) ],
+	keywords: [ _x( 'email', 'block search keyword' ), _x( 'about', 'block search keyword' ), _x( 'contact', 'block search keyword' ) ],
 	supports: {
 		reusable: false,
 		html: false,

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Form', 'block name' ),
 	description: __( 'Add a simple form to your page.' ),
 	icon,
-	keywords: [ _x( 'email', 'block search keyword' ), _x( 'about', 'block search keyword' ), _x( 'contact', 'block search keyword' ) ],
+	keywords: [ _x( 'email', 'block keyword' ), _x( 'about', 'block keyword' ), _x( 'contact', 'block keyword' ) ],
 	supports: {
 		reusable: false,
 		html: false,

--- a/src/blocks/form/index.js
+++ b/src/blocks/form/index.js
@@ -14,7 +14,7 @@ import metadata from './block.json';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { InnerBlocks } = wp.blockEditor;
 
 /**
@@ -23,7 +23,7 @@ const { InnerBlocks } = wp.blockEditor;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Form' ),
+	title: _x( 'Form', 'block name' ),
 	description: __( 'Add a simple form to your page.' ),
 	icon,
 	keywords: [ __( 'email' ), __( 'about' ), __( 'contact' ) ],

--- a/src/blocks/gallery-carousel/index.js
+++ b/src/blocks/gallery-carousel/index.js
@@ -35,7 +35,7 @@ const settings = {
 	title: _x( 'Carousel', 'block name' ),
 	description: __( 'Display multiple images in a beautiful carousel gallery.' ),
 	icon,
-	keywords: [	_x( 'gallery', 'block search keyword' ), _x( 'photos', 'block search keyword' )	],
+	keywords: [	_x( 'gallery', 'block keyword' ), _x( 'photos', 'block keyword' )	],
 	supports: {
 		align: [ 'wide', 'full' ],
 	},

--- a/src/blocks/gallery-carousel/index.js
+++ b/src/blocks/gallery-carousel/index.js
@@ -35,7 +35,7 @@ const settings = {
 	title: _x( 'Carousel', 'block name' ),
 	description: __( 'Display multiple images in a beautiful carousel gallery.' ),
 	icon,
-	keywords: [	__( 'gallery' ), __( 'photos' )	],
+	keywords: [	_x( 'gallery', 'block search keyword' ), _x( 'photos', 'block search keyword' )	],
 	supports: {
 		align: [ 'wide', 'full' ],
 	},

--- a/src/blocks/gallery-carousel/index.js
+++ b/src/blocks/gallery-carousel/index.js
@@ -18,7 +18,7 @@ import { GalleryAttributes } from '../../components/block-gallery/shared';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -32,7 +32,7 @@ const attributes = {
 };
 
 const settings = {
-	title: __( 'Carousel' ),
+	title: _x( 'Carousel', 'block name' ),
 	description: __( 'Display multiple images in a beautiful carousel gallery.' ),
 	icon,
 	keywords: [	__( 'gallery' ), __( 'photos' )	],

--- a/src/blocks/gallery-masonry/index.js
+++ b/src/blocks/gallery-masonry/index.js
@@ -35,7 +35,7 @@ const settings = {
 	title: _x( 'Masonry', 'block name' ),
 	description: __( 'Display multiple images in an organized masonry gallery.' ),
 	icon,
-	keywords: [	__( 'gallery' ), __( 'photos' )	],
+	keywords: [	_x( 'gallery', 'block search keyword' ), _x( 'photos', 'block search keyword' )	],
 	supports: {
 		align: [ 'wide', 'full' ],
 	},

--- a/src/blocks/gallery-masonry/index.js
+++ b/src/blocks/gallery-masonry/index.js
@@ -18,7 +18,7 @@ import { GalleryAttributes } from '../../components/block-gallery/shared';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -32,7 +32,7 @@ const attributes = {
 };
 
 const settings = {
-	title: __( 'Masonry' ),
+	title: _x( 'Masonry', 'block name' ),
 	description: __( 'Display multiple images in an organized masonry gallery.' ),
 	icon,
 	keywords: [	__( 'gallery' ), __( 'photos' )	],

--- a/src/blocks/gallery-masonry/index.js
+++ b/src/blocks/gallery-masonry/index.js
@@ -35,7 +35,7 @@ const settings = {
 	title: _x( 'Masonry', 'block name' ),
 	description: __( 'Display multiple images in an organized masonry gallery.' ),
 	icon,
-	keywords: [	_x( 'gallery', 'block search keyword' ), _x( 'photos', 'block search keyword' )	],
+	keywords: [	_x( 'gallery', 'block keyword' ), _x( 'photos', 'block keyword' )	],
 	supports: {
 		align: [ 'wide', 'full' ],
 	},

--- a/src/blocks/gallery-stacked/index.js
+++ b/src/blocks/gallery-stacked/index.js
@@ -18,7 +18,7 @@ import { GalleryAttributes } from '../../components/block-gallery/shared';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -32,7 +32,7 @@ const attributes = {
 };
 
 const settings = {
-	title: __( 'Stacked' ),
+	title: _x( 'Stacked', 'block name' ),
 	description: __( 'Display multiple images in an single column stacked gallery.' ),
 	icon,
 	keywords: [	__( 'gallery' ), __( 'photos' ) ],

--- a/src/blocks/gallery-stacked/index.js
+++ b/src/blocks/gallery-stacked/index.js
@@ -35,7 +35,7 @@ const settings = {
 	title: _x( 'Stacked', 'block name' ),
 	description: __( 'Display multiple images in an single column stacked gallery.' ),
 	icon,
-	keywords: [	_x( 'gallery', 'block search keyword' ), _x( 'photos', 'block search keyword' ) ],
+	keywords: [	_x( 'gallery', 'block keyword' ), _x( 'photos', 'block keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full', 'left', 'center', 'right' ],
 	},

--- a/src/blocks/gallery-stacked/index.js
+++ b/src/blocks/gallery-stacked/index.js
@@ -35,7 +35,7 @@ const settings = {
 	title: _x( 'Stacked', 'block name' ),
 	description: __( 'Display multiple images in an single column stacked gallery.' ),
 	icon,
-	keywords: [	__( 'gallery' ), __( 'photos' ) ],
+	keywords: [	_x( 'gallery', 'block search keyword' ), _x( 'photos', 'block search keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full', 'left', 'center', 'right' ],
 	},

--- a/src/blocks/gif/index.js
+++ b/src/blocks/gif/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Gif', 'block name' ),
 	description: __( 'Pick a gif, any gif.' ),
 	icon,
-	keywords: [ _x( 'animated', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'animated', 'block keyword' ), 'coblocks' ],
 	supports: {
 		customClassName: false,
 		html: false,

--- a/src/blocks/gif/index.js
+++ b/src/blocks/gif/index.js
@@ -15,7 +15,7 @@ import save from './save';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -23,10 +23,10 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: 'Gif',
+	title: _x( 'Gif', 'block name' ),
 	description: __( 'Pick a gif, any gif.' ),
 	icon,
-	keywords: [ __( 'animated' ), 'coblocks' ],
+	keywords: [ _x( 'animated', 'block search keyword' ), 'coblocks' ],
 	supports: {
 		customClassName: false,
 		html: false,

--- a/src/blocks/gist/index.js
+++ b/src/blocks/gist/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Gist', 'block name' ),
 	description: __( 'Embed GitHub gists by adding a gist link.' ),
 	icon,
-	keywords: [ _x( 'code', 'block search keyword' ), 'github', 'coblocks' ],
+	keywords: [ _x( 'code', 'block keyword' ), 'github', 'coblocks' ],
 	supports: {
 		html: false,
 		align: [ 'wide' ],

--- a/src/blocks/gist/index.js
+++ b/src/blocks/gist/index.js
@@ -17,17 +17,17 @@ import transforms from './transforms';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 /**
  * Block constants
  */
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: 'Gist',
+	title: _x( 'Gist', 'block name' ),
 	description: __( 'Embed GitHub gists by adding a gist link.' ),
 	icon,
-	keywords: [ __( 'code' ), 'github', 'coblocks' ],
+	keywords: [ _x( 'code', 'block search keyword' ), 'github', 'coblocks' ],
 	supports: {
 		html: false,
 		align: [ 'wide' ],

--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -40,7 +40,7 @@ const settings = {
 	title: _x( 'Hero', 'block name' ),
 	description: __( 'An introductory area of a page accompanied by a small amount of text and a call to action.' ),
 	icon,
-	keywords: [ __( 'button' ),	__( 'cta' ), __( 'call to action' ) ],
+	keywords: [ _x( 'button', 'block search keyword' ),	_x( 'cta', 'block search keyword' ), _x( 'call to action', 'block search keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		coBlocksSpacing: true,

--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -40,7 +40,7 @@ const settings = {
 	title: _x( 'Hero', 'block name' ),
 	description: __( 'An introductory area of a page accompanied by a small amount of text and a call to action.' ),
 	icon,
-	keywords: [ _x( 'button', 'block search keyword' ),	_x( 'cta', 'block search keyword' ), _x( 'call to action', 'block search keyword' ) ],
+	keywords: [ _x( 'button', 'block keyword' ),	_x( 'cta', 'block keyword' ), _x( 'call to action', 'block keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		coBlocksSpacing: true,

--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -21,7 +21,7 @@ import { BackgroundAttributes } from '../../components/background';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -37,7 +37,7 @@ const attributes = {
 };
 
 const settings = {
-	title: __( 'Hero' ),
+	title: _x( 'Hero', 'block name' ),
 	description: __( 'An introductory area of a page accompanied by a small amount of text and a call to action.' ),
 	icon,
 	keywords: [ __( 'button' ),	__( 'cta' ), __( 'call to action' ) ],

--- a/src/blocks/highlight/index.js
+++ b/src/blocks/highlight/index.js
@@ -16,7 +16,7 @@ import transforms from './transforms';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -24,10 +24,10 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Highlight' ),
+	title: _x( 'Highlight', 'block name' ),
 	description: __( 'Draw attention and emphasize important narrative.' ),
 	icon,
-	keywords: [ __( 'text' ), __( 'paragraph' ), 'coblocks' ],
+	keywords: [ _x( 'text', 'block search keyword' ), _x( 'paragraph', 'block search keyword' ), 'coblocks' ],
 	example: {
 		attributes: {
 			content: __( 'Add a highlight effect to paragraph text in order to grab attention and emphasize important narrative.' ),

--- a/src/blocks/highlight/index.js
+++ b/src/blocks/highlight/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Highlight', 'block name' ),
 	description: __( 'Draw attention and emphasize important narrative.' ),
 	icon,
-	keywords: [ _x( 'text', 'block search keyword' ), _x( 'paragraph', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'text', 'block keyword' ), _x( 'paragraph', 'block keyword' ), 'coblocks' ],
 	example: {
 		attributes: {
 			content: __( 'Add a highlight effect to paragraph text in order to grab attention and emphasize important narrative.' ),

--- a/src/blocks/icon/index.js
+++ b/src/blocks/icon/index.js
@@ -31,7 +31,7 @@ const settings = {
 	title: _x( 'Icon', 'block name' ),
 	description: __( 'Add a stylized graphic symbol to communicate something more.' ),
 	icon,
-	keywords: [ _x( 'icons', 'block search keyword' ), 'svg', 'coblocks' ],
+	keywords: [ _x( 'icons', 'block keyword' ), 'svg', 'coblocks' ],
 	styles: [
 		{ name: 'outlined', label: _x( 'Outlined', 'block style' ), isDefault: true },
 		{ name: 'filled', label: _x( 'Filled', 'block style' ) },

--- a/src/blocks/icon/index.js
+++ b/src/blocks/icon/index.js
@@ -28,10 +28,10 @@ export const DEFAULT_ICON_SIZE = 60;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Icon' ),
+	title: _x( 'Icon', 'block name' ),
 	description: __( 'Add a stylized graphic symbol to communicate something more.' ),
 	icon,
-	keywords: [ __( 'icons' ), 'svg', 'coblocks' ],
+	keywords: [ _x( 'icons', 'block search keyword' ), 'svg', 'coblocks' ],
 	styles: [
 		{ name: 'outlined', label: _x( 'Outlined', 'block style' ), isDefault: true },
 		{ name: 'filled', label: _x( 'Filled', 'block style' ) },

--- a/src/blocks/logos/index.js
+++ b/src/blocks/logos/index.js
@@ -15,7 +15,7 @@ import save from './save';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants.
@@ -23,10 +23,10 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Logos & Badges' ),
+	title: _x( 'Logos & Badges', 'block name' ),
 	description: __( 'Add logos, badges, or certifications to build credibility.' ),
 	icon,
-	keywords: [ __( 'clients' ), __( 'proof' ), __( 'testimonials' ) ],
+	keywords: [ _x( 'clients', 'block search keyword' ), _x( 'proof', 'block search keyword' ), _x( 'testimonials', 'block search keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full' ],
 	},

--- a/src/blocks/logos/index.js
+++ b/src/blocks/logos/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Logos & Badges', 'block name' ),
 	description: __( 'Add logos, badges, or certifications to build credibility.' ),
 	icon,
-	keywords: [ _x( 'clients', 'block search keyword' ), _x( 'proof', 'block search keyword' ), _x( 'testimonials', 'block search keyword' ) ],
+	keywords: [ _x( 'clients', 'block keyword' ), _x( 'proof', 'block keyword' ), _x( 'testimonials', 'block keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full' ],
 	},

--- a/src/blocks/map/index.js
+++ b/src/blocks/map/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Map', 'block name' ),
 	description: __( 'Add an address and drop a pin on a Google map.' ),
 	icon,
-	keywords: [ _x( 'address', 'block search keyword' ), _x( 'maps', 'block search keyword' ), _x( 'google', 'block search keyword' ) ],
+	keywords: [ _x( 'address', 'block keyword' ), _x( 'maps', 'block keyword' ), _x( 'google', 'block keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		coBlocksSpacing: true,

--- a/src/blocks/map/index.js
+++ b/src/blocks/map/index.js
@@ -16,7 +16,7 @@ import transforms from './transforms';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -24,10 +24,10 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Map' ),
+	title: _x( 'Map', 'block name' ),
 	description: __( 'Add an address and drop a pin on a Google map.' ),
 	icon,
-	keywords: [ __( 'address' ), __( 'maps' ), __( 'google' ) ],
+	keywords: [ _x( 'address', 'block search keyword' ), _x( 'maps', 'block search keyword' ), _x( 'google', 'block search keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		coBlocksSpacing: true,

--- a/src/blocks/map/styles.js
+++ b/src/blocks/map/styles.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { _x } = wp.i18n;
 
 /**
  * Map styles
@@ -9,26 +9,26 @@ const { __ } = wp.i18n;
 export const styleOptions = [
 	{
 		value: 'standard',
-		label: __( 'Standard' ),
+		label: _x( 'Standard', 'block styles' ),
 	},
 	{
 		value: 'silver',
-		label: __( 'Silver' ),
+		label: _x( 'Silver', 'block styles' ),
 	},
 	{
 		value: 'retro',
-		label: __( 'Retro' ),
+		label: _x( 'Retro', 'block styles' ),
 	},
 	{
 		value: 'dark',
-		label: __( 'Dark' ),
+		label: _x( 'Dark', 'block styles' ),
 	},
 	{
 		value: 'night',
-		label: __( 'Night' ),
+		label: _x( 'Night', 'block styles' ),
 	},
 	{
 		value: 'aubergine',
-		label: __( 'Aubergine' ),
+		label: _x( 'Aubergine', 'block styles' ),
 	},
 ];

--- a/src/blocks/media-card/index.js
+++ b/src/blocks/media-card/index.js
@@ -35,7 +35,7 @@ const settings = {
 	title: _x( 'Media Card', 'block name' ),
 	description: __( 'Add an image or video with an offset card side-by-side.' ),
 	icon,
-	keywords: [ _x( 'image', 'block search keyword' ), _x( 'video', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'image', 'block keyword' ), _x( 'video', 'block keyword' ), 'coblocks' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		stackedOnMobile: true,

--- a/src/blocks/media-card/index.js
+++ b/src/blocks/media-card/index.js
@@ -18,7 +18,7 @@ import { BackgroundAttributes } from '../../components/background';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -32,10 +32,10 @@ const attributes = {
 };
 
 const settings = {
-	title: __( 'Media Card' ),
+	title: _x( 'Media Card', 'block name' ),
 	description: __( 'Add an image or video with an offset card side-by-side.' ),
 	icon,
-	keywords: [ __( 'image' ), __( 'video' ), 'coblocks' ],
+	keywords: [ _x( 'image', 'block search keyword' ), _x( 'video', 'block search keyword' ), 'coblocks' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		stackedOnMobile: true,

--- a/src/blocks/media-card/inspector.js
+++ b/src/blocks/media-card/inspector.js
@@ -113,10 +113,18 @@ class Inspector extends Component {
 						/>
 						{ mediaType && (
 							<ToggleControl
-								label={ sprintf( __( ' %s Shadow' ), mediaType.charAt( 0 ).toUpperCase() + mediaType.slice( 1 ) ) }
+								label={
+									/* translators: s1: Placeholder is either 'Card, or 'Image'   */
+									sprintf( __( ' %s Shadow' ), mediaType.charAt( 0 ).toUpperCase() + mediaType.slice( 1 ) )
+								}
 								checked={ !! hasImgShadow }
 								onChange={ () => setAttributes( { hasImgShadow: ! hasImgShadow } ) }
-								help={ !! hasImgShadow ? sprintf( __( 'Showing %s shadow.' ), mediaType ) : sprintf( __( 'Toggle to add an %s shadow' ), mediaType ) }
+								help={ !! hasImgShadow ?
+									/* translators: s1: Placeholder is either 'Card, or 'Image'   */
+									sprintf( __( 'Showing %s shadow.' ), mediaType ) :
+									/* translators: s1: Placeholder is either 'Card, or 'Image'   */
+									sprintf( __( 'Toggle to add an %s shadow' ), mediaType )
+								}
 							/>
 						) }
 					</PanelBody>

--- a/src/blocks/media-card/inspector.js
+++ b/src/blocks/media-card/inspector.js
@@ -114,15 +114,15 @@ class Inspector extends Component {
 						{ mediaType && (
 							<ToggleControl
 								label={
-									/* translators: s1: Placeholder is either 'Card, or 'Image'   */
+									/* translators: %s: Placeholder is either 'Card, or 'Image'   */
 									sprintf( __( ' %s Shadow' ), mediaType.charAt( 0 ).toUpperCase() + mediaType.slice( 1 ) )
 								}
 								checked={ !! hasImgShadow }
 								onChange={ () => setAttributes( { hasImgShadow: ! hasImgShadow } ) }
 								help={ !! hasImgShadow ?
-									/* translators: s1: Placeholder is either 'Card, or 'Image'   */
+									/* translators: %s: Placeholder is either 'Card, or 'Image'   */
 									sprintf( __( 'Showing %s shadow.' ), mediaType ) :
-									/* translators: s1: Placeholder is either 'Card, or 'Image'   */
+									/* translators: %s: Placeholder is either 'Card, or 'Image'   */
 									sprintf( __( 'Toggle to add an %s shadow' ), mediaType )
 								}
 							/>

--- a/src/blocks/pricing-table/controls.js
+++ b/src/blocks/pricing-table/controls.js
@@ -34,8 +34,8 @@ class Controls extends Component {
 						className="components-toolbar-coblocks-numeral-controls"
 						controls={ '123'.split( '' ).map( ( number ) => ( {
 							icon: icons.blank,
-							/* translators: %s: number of tables */
-							title: sprintf( __( '%s Tables' ), number ),
+							/* translators: %d: number of tables */
+							title: sprintf( __( '%d Tables' ), parseInt( number ) ),
 							isActive: count === parseInt( number ),
 							subscript: number,
 							onClick: () => setAttributes( { count: parseInt( number ) } ),

--- a/src/blocks/pricing-table/edit.js
+++ b/src/blocks/pricing-table/edit.js
@@ -36,7 +36,7 @@ const ALLOWED_BLOCKS = [ 'coblocks/pricing-table-item' ];
  * @return {Object[]} Columns layout configuration.
  */
 const getCount = memoize( ( count ) => {
-	/* translators: %d: Represents a digit 1-3 */
+	/* translators: %d: a digit 1-3 */
 	return times( count, ( index ) => [ 'coblocks/pricing-table-item', { placeholder: sprintf( __( 'Plan %d' ), parseInt( index + 1 ) ) } ] );
 } );
 

--- a/src/blocks/pricing-table/edit.js
+++ b/src/blocks/pricing-table/edit.js
@@ -36,7 +36,8 @@ const ALLOWED_BLOCKS = [ 'coblocks/pricing-table-item' ];
  * @return {Object[]} Columns layout configuration.
  */
 const getCount = memoize( ( count ) => {
-	return times( count, ( index ) => [ 'coblocks/pricing-table-item', { placeholder: sprintf( __( 'Plan %s' ), index + 1 ) } ] );
+	/* translators: %d: Represents a digit 1-3 */
+	return times( count, ( index ) => [ 'coblocks/pricing-table-item', { placeholder: sprintf( __( 'Plan %d' ), parseInt( index + 1 ) ) } ] );
 } );
 
 /**

--- a/src/blocks/pricing-table/index.js
+++ b/src/blocks/pricing-table/index.js
@@ -16,7 +16,7 @@ import transforms from './transforms';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -24,10 +24,10 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Pricing Table' ),
+	title: _x( 'Pricing Table', 'block name' ),
 	description: __( 'Add pricing tables to help visitors compare products and plans.' ),
 	icon,
-	keywords: [ __( 'landing' ), __( 'comparison' ), 'coblocks' ],
+	keywords: [ _x( 'landing', 'block search keyword' ), _x( 'comparison', 'block search keyword' ), 'coblocks' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/src/blocks/pricing-table/index.js
+++ b/src/blocks/pricing-table/index.js
@@ -27,7 +27,7 @@ const settings = {
 	title: _x( 'Pricing Table', 'block name' ),
 	description: __( 'Add pricing tables to help visitors compare products and plans.' ),
 	icon,
-	keywords: [ _x( 'landing', 'block search keyword' ), _x( 'comparison', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'landing', 'block keyword' ), _x( 'comparison', 'block keyword' ), 'coblocks' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/src/blocks/pricing-table/pricing-table-item/index.js
+++ b/src/blocks/pricing-table/pricing-table-item/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Pricing Table Item', 'block name' ),
 	description: __( 'A pricing table to help visitors compare products and plans.' ),
 	icon,
-	keywords: [ _x( 'landing', 'block search keyword' ), _x( 'comparison', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'landing', 'block keyword' ), _x( 'comparison', 'block keyword' ), 'coblocks' ],
 	parent: [ 'coblocks/pricing-table' ],
 	supports: {
 		html: false,

--- a/src/blocks/pricing-table/pricing-table-item/index.js
+++ b/src/blocks/pricing-table/pricing-table-item/index.js
@@ -15,7 +15,7 @@ import metadata from './block.json';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -23,10 +23,10 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Pricing Table Item' ),
+	title: _x( 'Pricing Table Item', 'block name' ),
 	description: __( 'A pricing table to help visitors compare products and plans.' ),
 	icon,
-	keywords: [ __( 'landing' ), __( 'comparison' ), 'coblocks' ],
+	keywords: [ _x( 'landing', 'block search keyword' ), _x( 'comparison', 'block search keyword' ), 'coblocks' ],
 	parent: [ 'coblocks/pricing-table' ],
 	supports: {
 		html: false,

--- a/src/blocks/row/column/index.js
+++ b/src/blocks/row/column/index.js
@@ -12,7 +12,7 @@ import { BackgroundAttributes } from '../../../components/background';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -26,7 +26,7 @@ const attributes = {
 };
 
 const settings = {
-	title: __( 'Column' ),
+	title: _x( 'Column', 'block name' ),
 	description: __( 'An immediate child of a row.' ),
 	icon,
 	parent: [ 'coblocks/row' ],

--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -201,7 +201,7 @@ class Edit extends Component {
 						icon={ columns ? rowIcons.layout : rowIcons.row }
 						label={ columns ? __( 'Row Layout' ) : __( 'Row' ) }
 						instructions={ columns ?
-							/* translators: %s: Represents 'one' 'two' 'three' and 'four' */
+							/* translators: %s: 'one' 'two' 'three' and 'four' */
 							sprintf( __( 'Now select a layout for this %s column row.' ), this.numberToText( columns ) ) :
 							__( 'Select the number of columns for this row.' )
 						}

--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -200,7 +200,11 @@ class Edit extends Component {
 						key="placeholder"
 						icon={ columns ? rowIcons.layout : rowIcons.row }
 						label={ columns ? __( 'Row Layout' ) : __( 'Row' ) }
-						instructions={ columns ? sprintf( __( 'Now select a layout for this %s column row.' ), this.numberToText( columns ) ) : __( 'Select the number of columns for this row.' ) }
+						instructions={ columns ?
+							/* translators: %s: Represents 'one' 'two' 'three' and 'four' */
+							sprintf( __( 'Now select a layout for this %s column row.' ), this.numberToText( columns ) ) :
+							__( 'Select the number of columns for this row.' )
+						}
 						className={ 'components-coblocks-visual-dropdown' }
 					>
 						{ ! columns ?

--- a/src/blocks/row/index.js
+++ b/src/blocks/row/index.js
@@ -37,7 +37,7 @@ const settings = {
 	title: _x( 'Row', 'block name' ),
 	description: __( 'Add a structured wrapper for column blocks, then add content blocks you’d like to the columns.' ),
 	icon,
-	keywords: [	_x( 'rows', 'block search keyword' ), _x( 'columns', 'block search keyword' ), _x( 'layouts', 'block search keyword' )	],
+	keywords: [	_x( 'rows', 'block keyword' ), _x( 'columns', 'block keyword' ), _x( 'layouts', 'block keyword' )	],
 	supports: {
 		align: [ 'wide', 'full' ],
 		anchor: true,

--- a/src/blocks/row/index.js
+++ b/src/blocks/row/index.js
@@ -20,7 +20,7 @@ import { BackgroundAttributes } from '../../components/background';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants
@@ -34,10 +34,10 @@ const attributes = {
 };
 
 const settings = {
-	title: __( 'Row' ),
+	title: _x( 'Row', 'block name' ),
 	description: __( 'Add a structured wrapper for column blocks, then add content blocks you’d like to the columns.' ),
 	icon,
-	keywords: [	__( 'rows' ), __( 'columns' ), __( 'layouts' )	],
+	keywords: [	_x( 'rows', 'block search keyword' ), _x( 'columns', 'block search keyword' ), _x( 'layouts', 'block search keyword' )	],
 	supports: {
 		align: [ 'wide', 'full' ],
 		anchor: true,

--- a/src/blocks/row/transforms.js
+++ b/src/blocks/row/transforms.js
@@ -10,7 +10,7 @@ const { createBlock } = wp.blocks;
 
 /**
  * Generates a layout based on the :row prefix.
- * The number of :: represents the number of columns to input.
+ * The number of ::  the number of columns to input.
  * We fallback to the standard divided column layouts.
  *
  * @param {int} columns The number of columns.

--- a/src/blocks/services/index.js
+++ b/src/blocks/services/index.js
@@ -26,7 +26,7 @@ const settings = {
 	title: _x( 'Services', 'block name' ),
 	description: __( 'Add up to four columns of services to display.' ),
 	icon,
-	keywords: [ _x( 'features', 'block search keyword' ) ],
+	keywords: [ _x( 'features', 'block keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		reusable: false,

--- a/src/blocks/services/index.js
+++ b/src/blocks/services/index.js
@@ -15,7 +15,7 @@ import save from './save';
 /**
  * WordPress dependencies.
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants.
@@ -23,10 +23,10 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Services' ),
+	title: _x( 'Services', 'block name' ),
 	description: __( 'Add up to four columns of services to display.' ),
 	icon,
-	keywords: [ __( 'features' ) ],
+	keywords: [ _x( 'features', 'block search keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		reusable: false,

--- a/src/blocks/services/service/index.js
+++ b/src/blocks/services/service/index.js
@@ -15,7 +15,7 @@ import save from './save';
 /**
  * WordPress dependencies.
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 
 /**
  * Block constants.
@@ -23,7 +23,7 @@ const { __ } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Service' ),
+	title: _x( 'Service', 'block name' ),
 	description: __( 'A single service item within a services block.' ),
 	icon,
 	keywords: [],

--- a/src/blocks/shape-divider/index.js
+++ b/src/blocks/shape-divider/index.js
@@ -28,7 +28,7 @@ const settings = {
 	title: _x( 'Shape Divider', 'block name' ),
 	description: __( 'Add a shape divider to visually distinquish page sections.' ),
 	icon,
-	keywords: [ _x( 'separator', 'block search keyword' ), 'hr', 'svg' ],
+	keywords: [ _x( 'separator', 'block keyword' ), 'hr', 'svg' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		coBlocksSpacing: true,

--- a/src/blocks/shape-divider/index.js
+++ b/src/blocks/shape-divider/index.js
@@ -25,10 +25,10 @@ const { __, _x } = wp.i18n;
 const { name, category, attributes } = metadata;
 
 const settings = {
-	title: __( 'Shape Divider' ),
+	title: _x( 'Shape Divider', 'block name' ),
 	description: __( 'Add a shape divider to visually distinquish page sections.' ),
 	icon,
-	keywords: [ __( 'separator' ), 'hr', 'svg' ],
+	keywords: [ _x( 'separator', 'block search keyword' ), 'hr', 'svg' ],
 	supports: {
 		align: [ 'wide', 'full' ],
 		coBlocksSpacing: true,

--- a/src/blocks/share/index.js
+++ b/src/blocks/share/index.js
@@ -25,7 +25,7 @@ const settings = {
 	description: __( 'Add social sharing links to help you get likes and shares.' ),
 	icon,
 	category: 'coblocks',
-	keywords: [ _x( 'social', 'block search keyword' ), 'coblocks' ],
+	keywords: [ _x( 'social', 'block keyword' ), 'coblocks' ],
 	styles: [
 		{ name: 'mask', label: _x( 'Mask', 'block style' ) },
 		{ name: 'icon', label: _x( 'Icon', 'block style' ), isDefault: true },

--- a/src/blocks/share/index.js
+++ b/src/blocks/share/index.js
@@ -21,11 +21,11 @@ const { __, _x } = wp.i18n;
 const name = 'coblocks/social';
 
 const settings = {
-	title: __( 'Share' ),
+	title: _x( 'Share', 'block name' ),
 	description: __( 'Add social sharing links to help you get likes and shares.' ),
 	icon,
 	category: 'coblocks',
-	keywords: [ __( 'social' ), 'coblocks' ],
+	keywords: [ _x( 'social', 'block search keyword' ), 'coblocks' ],
 	styles: [
 		{ name: 'mask', label: _x( 'Mask', 'block style' ) },
 		{ name: 'icon', label: _x( 'Icon', 'block style' ), isDefault: true },

--- a/src/blocks/social-profiles/index.js
+++ b/src/blocks/social-profiles/index.js
@@ -25,7 +25,7 @@ const settings = {
 	description: __( 'Grow your audience with links to social media profiles.' ),
 	icon,
 	category: 'coblocks',
-	keywords: [ _x( 'share', 'block search keyword' ), _x( 'links', 'block search keyword' ), _x( 'icons', 'block search keyword' ) ],
+	keywords: [ _x( 'share', 'block keyword' ), _x( 'links', 'block keyword' ), _x( 'icons', 'block keyword' ) ],
 	styles: [
 		{ name: 'mask', label: _x( 'Mask', 'block style' ) },
 		{ name: 'icon', label: _x( 'Icon', 'block style' ), isDefault: true },

--- a/src/blocks/social-profiles/index.js
+++ b/src/blocks/social-profiles/index.js
@@ -21,11 +21,11 @@ const { __, _x } = wp.i18n;
 const name = 'coblocks/social-profiles';
 
 const settings = {
-	title: __( 'Social Profiles' ),
+	title: _x( 'Social Profiles', 'block name' ),
 	description: __( 'Grow your audience with links to social media profiles.' ),
 	icon,
 	category: 'coblocks',
-	keywords: [ __( 'share' ), __( 'links' ), __( 'icons' ) ],
+	keywords: [ _x( 'share', 'block search keyword' ), _x( 'links', 'block search keyword' ), _x( 'icons', 'block search keyword' ) ],
 	styles: [
 		{ name: 'mask', label: _x( 'Mask', 'block style' ) },
 		{ name: 'icon', label: _x( 'Icon', 'block style' ), isDefault: true },

--- a/src/components/background/panel.js
+++ b/src/components/background/panel.js
@@ -12,7 +12,7 @@ import ResponsiveTabsControl from '../../components/responsive-tabs-control';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { SelectControl, RangeControl, ToggleControl, PanelBody, Button, FocalPointPicker } = wp.components;
 
@@ -80,28 +80,28 @@ class BackgroundPanel extends Component {
 		} = attributes;
 
 		const backgroundPositionOptions = [
-			{ value: 'top left', label: __( 'Top Left' ) },
-			{ value: 'top center', label: __( 'Top Center' ) },
-			{ value: 'top right', label: __( 'Top Right' ) },
-			{ value: 'center left', label: __( 'Center Left' ) },
-			{ value: 'center center', label: __( 'Center Center' ) },
-			{ value: 'center right', label: __( 'Center Right' ) },
-			{ value: 'bottom left', label: __( 'Bottom Left' ) },
-			{ value: 'bottom center', label: __( 'Bottom Center' ) },
-			{ value: 'bottom right', label: __( 'Bottom Right' ) },
+			{ value: 'top left', label: _x( 'Top Left', 'block layout' ) },
+			{ value: 'top center', label: _x( 'Top Center', 'block layout' ) },
+			{ value: 'top right', label: _x( 'Top Right', 'block layout' ) },
+			{ value: 'center left', label: _x( 'Center Left', 'block layout' ) },
+			{ value: 'center center', label: _x( 'Center Center', 'block layout' ) },
+			{ value: 'center right', label: _x( 'Center Right', 'block layout' ) },
+			{ value: 'bottom left', label: _x( 'Bottom Left', 'block layout' ) },
+			{ value: 'bottom center', label: _x( 'Bottom Center', 'block layout' ) },
+			{ value: 'bottom right', label: _x( 'Bottom Right', 'block layout' ) },
 		];
 
 		const backgroundRepeatOptions = [
-			{ value: 'no-repeat', label: __( 'No Repeat' ) },
-			{ value: 'repeat', label: __( 'Repeat' ) },
-			{ value: 'repeat-x', label: __( 'Repeat Horizontally' ) },
-			{ value: 'repeat-y', label: __( 'Repeat Vertically' ) },
+			{ value: 'no-repeat', label: _x( 'No Repeat', 'block layout' ) },
+			{ value: 'repeat', label: _x( 'Repeat', 'block layout' ) },
+			{ value: 'repeat-x', label: _x( 'Repeat Horizontally', 'block layout' ) },
+			{ value: 'repeat-y', label: _x( 'Repeat Vertically', 'block layout' ) },
 		];
 
 		const backgroundSizeOptions = [
-			{ value: 'auto', label: __( 'Auto' ) },
-			{ value: 'cover', label: __( 'Cover' ) },
-			{ value: 'contain', label: __( 'Contain' ) },
+			{ value: 'auto', label: _x( 'Auto', 'block layout' ) },
+			{ value: 'cover', label: _x( 'Cover', 'block layout' ) },
+			{ value: 'contain', label: _x( 'Contain', 'block layout' ) },
 		];
 
 		const backgroundSizeDefault = 'cover';

--- a/src/components/block-gallery/gallery-link-settings.js
+++ b/src/components/block-gallery/gallery-link-settings.js
@@ -6,7 +6,7 @@ import linkOptions from './options/link-options';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { SelectControl, ToggleControl, PanelBody, TextControl } = wp.components;
 
@@ -77,7 +77,7 @@ class GalleryLinkSettings extends Component {
 									checked={ target === '_blank' }
 								/>
 								<TextControl
-									label={ __( 'Link Rel' ) }
+									label={ _x( 'Link Rel', 'a link rel is an HTML attribute' ) }
 									value={ rel }
 									onChange={ ( value ) => setAttributes( { rel: value } ) }
 								/>

--- a/src/components/block-gallery/gallery-link-settings.js
+++ b/src/components/block-gallery/gallery-link-settings.js
@@ -77,7 +77,7 @@ class GalleryLinkSettings extends Component {
 									checked={ target === '_blank' }
 								/>
 								<TextControl
-									label={ _x( 'Link Rel', 'a link rel is an HTML attribute' ) }
+									label={ _x( 'Link Rel', 'HTML attribute that specifies the a relationship between the two pages.' ) }
 									value={ rel }
 									onChange={ ( value ) => setAttributes( { rel: value } ) }
 								/>

--- a/src/components/block-gallery/gallery-placeholder.js
+++ b/src/components/block-gallery/gallery-placeholder.js
@@ -67,7 +67,7 @@ class GalleryPlaceholder extends Component {
 					dropZoneUIOnly={ hasImages && ! isSelected }
 					icon={ ! hasImages && <BlockIcon icon={ this.props.icon } /> }
 					labels={ {
-						/* translators: %s: Represents a textual label. */
+						/* translators: %s: Type of gallery */
 						title: ! hasImages && sprintf( __( '%s Gallery' ), this.props.label ),
 						instructions: ! hasImages && __( 'Drag images, upload new ones or select files from your library.' ),
 					} }

--- a/src/components/block-gallery/gallery-placeholder.js
+++ b/src/components/block-gallery/gallery-placeholder.js
@@ -67,7 +67,7 @@ class GalleryPlaceholder extends Component {
 					dropZoneUIOnly={ hasImages && ! isSelected }
 					icon={ ! hasImages && <BlockIcon icon={ this.props.icon } /> }
 					labels={ {
-						/* translators: %s: Represents a text label. */
+						/* translators: %s: Represents a textual label. */
 						title: ! hasImages && sprintf( __( '%s Gallery' ), this.props.label ),
 						instructions: ! hasImages && __( 'Drag images, upload new ones or select files from your library.' ),
 					} }

--- a/src/components/block-gallery/gallery-placeholder.js
+++ b/src/components/block-gallery/gallery-placeholder.js
@@ -67,6 +67,7 @@ class GalleryPlaceholder extends Component {
 					dropZoneUIOnly={ hasImages && ! isSelected }
 					icon={ ! hasImages && <BlockIcon icon={ this.props.icon } /> }
 					labels={ {
+						/* translators: %s: Represents a text label. */
 						title: ! hasImages && sprintf( __( '%s Gallery' ), this.props.label ),
 						instructions: ! hasImages && __( 'Drag images, upload new ones or select files from your library.' ),
 					} }

--- a/src/components/block-gallery/options/caption-options.js
+++ b/src/components/block-gallery/options/caption-options.js
@@ -7,9 +7,9 @@ const { _x } = wp.i18n;
  * Link options.
  */
 const captionOptions = [
-	{ value: 'dark', label: _x( 'Dark', 'block styles' ) },
-	{ value: 'light', label: _x( 'Light', 'block styles' ) },
-	{ value: 'none', label: _x( 'None', 'block styles' ) },
+	{ value: 'dark', label: _x( 'Dark', 'visual style option' ) },
+	{ value: 'light', label: _x( 'Light', 'visual style option' ) },
+	{ value: 'none', label: _x( 'None', 'visual style option' ) },
 ];
 
 export default captionOptions;

--- a/src/components/block-gallery/options/caption-options.js
+++ b/src/components/block-gallery/options/caption-options.js
@@ -1,15 +1,15 @@
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { _x } = wp.i18n;
 
 /**
  * Link options.
  */
 const captionOptions = [
-	{ value: 'dark', label: __( 'Dark' ) },
-	{ value: 'light', label: __( 'Light' ) },
-	{ value: 'none', label: __( 'None' ) },
+	{ value: 'dark', label: _x( 'Dark', 'block styles' ) },
+	{ value: 'light', label: _x( 'Light', 'block styles' ) },
+	{ value: 'none', label: _x( 'None', 'block styles' ) },
 ];
 
 export default captionOptions;

--- a/src/components/dimensions-control/index.js
+++ b/src/components/dimensions-control/index.js
@@ -14,7 +14,7 @@ import DimensionsSelect from './dimensions-select';
 /**
  * WordPress dependencies
  */
-const { __, sprintf } = wp.i18n;
+const { __, _x, sprintf } = wp.i18n;
 const { withInstanceId } = wp.compose;
 const { dispatch } = wp.data;
 const { Component, Fragment } = wp.element;
@@ -405,15 +405,15 @@ class DimensionsControl extends Component {
 
 		const unitSizes = [
 			{
-				name: __( 'Pixel' ),
+				name: _x( 'Pixel', 'related to CSS Markup' ),
 				unitValue: 'px',
 			},
 			{
-				name: __( 'Em' ),
+				name: _x( 'Em', 'related to CSS Markup' ),
 				unitValue: 'em',
 			},
 			{
-				name: __( 'Percentage' ),
+				name: _x( 'Percentage', 'related to CSS Markup' ),
 				unitValue: '%',
 			},
 		];

--- a/src/components/dimensions-control/index.js
+++ b/src/components/dimensions-control/index.js
@@ -460,6 +460,7 @@ class DimensionsControl extends Component {
 								<div className="components-coblocks-dimensions-control__actions">
 									<ButtonGroup className="components-coblocks-dimensions-control__units" aria-label={ __( 'Select Units' ) }>
 										{ map( unitSizes, ( { unitValue, name } ) => (
+											/* translators: %s: Represents values associated with CSS syntax, 'Pixel', 'Em', 'Percentage' */
 											<Tooltip text={ sprintf( __( '%s Units' ), name ) }>
 												<Button
 													key={ unitValue }
@@ -467,6 +468,7 @@ class DimensionsControl extends Component {
 													isSmall
 													isPrimary={ unit === unitValue }
 													aria-pressed={ unit === unitValue }
+													/* translators: %s: Represents values associated with CSS syntax, 'Pixel', 'Em', 'Percentage' */
 													aria-label={ sprintf( __( '%s Units' ), name ) }
 													onClick={ () => this.onChangeUnits( unitValue ) }
 												>
@@ -481,6 +483,7 @@ class DimensionsControl extends Component {
 										onClick={ () => this.onChangeSize( 'no', -1 ) }
 										isSmall
 										isDefault
+										/* translators: %s: Represents a texual label  */
 										aria-label={ sprintf( __( 'Turn off advanced %s settings' ), label.toLowerCase() ) }
 									>
 										{ __( 'Reset' ) }
@@ -524,6 +527,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeTopValue }
+															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Top' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueTopMobile ? valueTopMobile : '' }
@@ -534,6 +538,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeRightValue }
+															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Right' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueRightMobile ? valueRightMobile : '' }
@@ -544,6 +549,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeBottomValue }
+															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Bottom' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueBottomMobile ? valueBottomMobile : '' }
@@ -554,6 +560,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeLeftValue }
+															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Left' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueLeftMobile ? valueLeftMobile : '' }
@@ -584,6 +591,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeTopValue }
+															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Top' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueTopTablet ? valueTopTablet : '' }
@@ -594,6 +602,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeRightValue }
+															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Right' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueRightTablet ? valueRightTablet : '' }
@@ -604,6 +613,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeBottomValue }
+															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Bottom' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueBottomTablet ? valueBottomTablet : '' }
@@ -614,6 +624,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeLeftValue }
+															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Left' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueLeftTablet ? valueLeftTablet : '' }
@@ -644,6 +655,7 @@ class DimensionsControl extends Component {
 														className="components-coblocks-dimensions-control__number"
 														type="number"
 														onChange={ onChangeTopValue }
+														/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 														aria-label={ sprintf( __( '%s Top' ), label ) }
 														aria-describedby={ !! help ? id + '__help' : undefined }
 														value={ valueTop ? valueTop : '' }
@@ -654,6 +666,7 @@ class DimensionsControl extends Component {
 														className="components-coblocks-dimensions-control__number"
 														type="number"
 														onChange={ onChangeRightValue }
+														/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 														aria-label={ sprintf( __( '%s Right' ), label ) }
 														aria-describedby={ !! help ? id + '__help' : undefined }
 														value={ valueRight ? valueRight : '' }
@@ -664,6 +677,7 @@ class DimensionsControl extends Component {
 														className="components-coblocks-dimensions-control__number"
 														type="number"
 														onChange={ onChangeBottomValue }
+														/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 														aria-label={ sprintf( __( '%s Bottom' ), label ) }
 														aria-describedby={ !! help ? id + '__help' : undefined }
 														value={ valueBottom ? valueBottom : '' }
@@ -674,6 +688,7 @@ class DimensionsControl extends Component {
 														className="components-coblocks-dimensions-control__number"
 														type="number"
 														onChange={ onChangeLeftValue }
+														/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
 														aria-label={ sprintf( __( '%s Left' ), label ) }
 														aria-describedby={ !! help ? id + '__help' : undefined }
 														value={ valueLeft ? valueLeft : '' }
@@ -722,6 +737,7 @@ class DimensionsControl extends Component {
 									onClick={ () => this.onChangeSize( 'advanced', '' ) }
 
 									isDefault
+									/* translators: %s: Represents a texual label */
 									aria-label={ sprintf( __( 'Advanced %s settings' ), label.toLowerCase() ) }
 									isPrimary={ dimensionSize === 'advanced' }
 								>

--- a/src/components/dimensions-control/index.js
+++ b/src/components/dimensions-control/index.js
@@ -527,7 +527,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeTopValue }
-															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+															/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Top' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueTopMobile ? valueTopMobile : '' }
@@ -538,7 +538,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeRightValue }
-															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+															/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Right' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueRightMobile ? valueRightMobile : '' }
@@ -549,7 +549,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeBottomValue }
-															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+															/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Bottom' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueBottomMobile ? valueBottomMobile : '' }
@@ -560,7 +560,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeLeftValue }
-															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+															/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Left' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueLeftMobile ? valueLeftMobile : '' }
@@ -591,7 +591,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeTopValue }
-															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+															/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Top' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueTopTablet ? valueTopTablet : '' }
@@ -602,7 +602,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeRightValue }
-															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+															/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Right' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueRightTablet ? valueRightTablet : '' }
@@ -613,7 +613,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeBottomValue }
-															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+															/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Bottom' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueBottomTablet ? valueBottomTablet : '' }
@@ -624,7 +624,7 @@ class DimensionsControl extends Component {
 															className="components-coblocks-dimensions-control__number"
 															type="number"
 															onChange={ onChangeLeftValue }
-															/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+															/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 															aria-label={ sprintf( __( '%s Left' ), label ) }
 															aria-describedby={ !! help ? id + '__help' : undefined }
 															value={ valueLeftTablet ? valueLeftTablet : '' }
@@ -655,7 +655,7 @@ class DimensionsControl extends Component {
 														className="components-coblocks-dimensions-control__number"
 														type="number"
 														onChange={ onChangeTopValue }
-														/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+														/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 														aria-label={ sprintf( __( '%s Top' ), label ) }
 														aria-describedby={ !! help ? id + '__help' : undefined }
 														value={ valueTop ? valueTop : '' }
@@ -666,7 +666,7 @@ class DimensionsControl extends Component {
 														className="components-coblocks-dimensions-control__number"
 														type="number"
 														onChange={ onChangeRightValue }
-														/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+														/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 														aria-label={ sprintf( __( '%s Right' ), label ) }
 														aria-describedby={ !! help ? id + '__help' : undefined }
 														value={ valueRight ? valueRight : '' }
@@ -677,7 +677,7 @@ class DimensionsControl extends Component {
 														className="components-coblocks-dimensions-control__number"
 														type="number"
 														onChange={ onChangeBottomValue }
-														/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+														/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 														aria-label={ sprintf( __( '%s Bottom' ), label ) }
 														aria-describedby={ !! help ? id + '__help' : undefined }
 														value={ valueBottom ? valueBottom : '' }
@@ -688,7 +688,7 @@ class DimensionsControl extends Component {
 														className="components-coblocks-dimensions-control__number"
 														type="number"
 														onChange={ onChangeLeftValue }
-														/* translators: %s: Represents values associated with CSS syntax, 'Margin', 'Padding' */
+														/* translators: %s:  values associated with CSS syntax, 'Margin', 'Padding' */
 														aria-label={ sprintf( __( '%s Left' ), label ) }
 														aria-describedby={ !! help ? id + '__help' : undefined }
 														value={ valueLeft ? valueLeft : '' }
@@ -737,7 +737,7 @@ class DimensionsControl extends Component {
 									onClick={ () => this.onChangeSize( 'advanced', '' ) }
 
 									isDefault
-									/* translators: %s: Represents a texual label */
+									/* translators: %s:  a texual label */
 									aria-label={ sprintf( __( 'Advanced %s settings' ), label.toLowerCase() ) }
 									isPrimary={ dimensionSize === 'advanced' }
 								>

--- a/src/components/dimensions-control/index.js
+++ b/src/components/dimensions-control/index.js
@@ -405,15 +405,15 @@ class DimensionsControl extends Component {
 
 		const unitSizes = [
 			{
-				name: _x( 'Pixel', 'related to CSS Markup' ),
+				name: _x( 'Pixel', 'A size unit for CSS markup' ),
 				unitValue: 'px',
 			},
 			{
-				name: _x( 'Em', 'related to CSS Markup' ),
+				name: _x( 'Em', 'A size unit for CSS markup' ),
 				unitValue: 'em',
 			},
 			{
-				name: _x( 'Percentage', 'related to CSS Markup' ),
+				name: _x( 'Percentage', 'A size unit for CSS markup' ),
 				unitValue: '%',
 			},
 		];
@@ -460,7 +460,7 @@ class DimensionsControl extends Component {
 								<div className="components-coblocks-dimensions-control__actions">
 									<ButtonGroup className="components-coblocks-dimensions-control__units" aria-label={ __( 'Select Units' ) }>
 										{ map( unitSizes, ( { unitValue, name } ) => (
-											/* translators: %s: Represents values associated with CSS syntax, 'Pixel', 'Em', 'Percentage' */
+											/* translators: %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage' */
 											<Tooltip text={ sprintf( __( '%s Units' ), name ) }>
 												<Button
 													key={ unitValue }
@@ -468,7 +468,7 @@ class DimensionsControl extends Component {
 													isSmall
 													isPrimary={ unit === unitValue }
 													aria-pressed={ unit === unitValue }
-													/* translators: %s: Represents values associated with CSS syntax, 'Pixel', 'Em', 'Percentage' */
+													/* translators: %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage' */
 													aria-label={ sprintf( __( '%s Units' ), name ) }
 													onClick={ () => this.onChangeUnits( unitValue ) }
 												>
@@ -483,7 +483,7 @@ class DimensionsControl extends Component {
 										onClick={ () => this.onChangeSize( 'no', -1 ) }
 										isSmall
 										isDefault
-										/* translators: %s: Represents a texual label  */
+										/* translators: %s: a texual label  */
 										aria-label={ sprintf( __( 'Turn off advanced %s settings' ), label.toLowerCase() ) }
 									>
 										{ __( 'Reset' ) }

--- a/src/components/grid-control/index.js
+++ b/src/components/grid-control/index.js
@@ -7,7 +7,7 @@ import map from 'lodash/map';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { withInstanceId } = wp.compose;
 const { dispatch } = wp.data;
 const { Component, Fragment } = wp.element;
@@ -32,22 +32,22 @@ class CSSGridControl extends Component {
 		 * This will make us of existing block instead of creating new one
 		 */
 		let layoutOptions = [
-			{ value: 'top-left', label: __( 'Top Left' ) },
-			{ value: 'top-center', label: __( 'Top Center' ) },
-			{ value: 'top-right', label: __( 'Top Right' ) },
-			{ value: 'center-left', label: __( 'Center Left' ) },
-			{ value: 'center-center', label: __( 'Center Center' ) },
-			{ value: 'center-right', label: __( 'Center Right' ) },
-			{ value: 'bottom-left', label: __( 'Bottom Left' ) },
-			{ value: 'bottom-center', label: __( 'Bottom Center' ) },
-			{ value: 'bottom-right', label: __( 'Bottom Right' ) },
+			{ value: 'top-left', label: _x( 'Top Left', 'block layout' ) },
+			{ value: 'top-center', label: _x( 'Top Center', 'block layout' ) },
+			{ value: 'top-right', label: _x( 'Top Right', 'block layout' ) },
+			{ value: 'center-left', label: _x( 'Center Left', 'block layout' ) },
+			{ value: 'center-center', label: _x( 'Center Center', 'block layout' ) },
+			{ value: 'center-right', label: _x( 'Center Right', 'block layout' ) },
+			{ value: 'bottom-left', label: _x( 'Bottom Left', 'block layout' ) },
+			{ value: 'bottom-center', label: _x( 'Bottom Center', 'block layout' ) },
+			{ value: 'bottom-right', label: _x( 'Bottom Right', 'block layout' ) },
 		];
 
 		if ( ! fullscreen ) {
 			layoutOptions = [
-				{ value: 'center-left', label: __( 'Center Left' ) },
-				{ value: 'center-center', label: __( 'Center Center' ) },
-				{ value: 'center-right', label: __( 'Center Right' ) },
+				{ value: 'center-left', label: _x( 'Center Left', 'block layout' ) },
+				{ value: 'center-center', label: _x( 'Center Center', 'block layout' ) },
+				{ value: 'center-right', label: _x( 'Center Right', 'block layout' ) },
 			];
 		}
 

--- a/src/components/heading-toolbar/index.js
+++ b/src/components/heading-toolbar/index.js
@@ -14,7 +14,7 @@ class HeadingToolbar extends Component {
 	createLevelControl( targetLevel, selectedLevel, onChange ) {
 		return {
 			icon: 'heading',
-			// translators: %s: heading level e.g: "1", "2", "3"
+			// translators: %d: heading level e.g: "1", "2", "3"
 			title: sprintf( __( 'Heading %d' ), targetLevel ),
 			isActive: targetLevel === selectedLevel,
 			onClick: () => onChange( targetLevel ),

--- a/src/components/media-filter-control/index.js
+++ b/src/components/media-filter-control/index.js
@@ -7,7 +7,7 @@ import './styles/style.scss';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component } = wp.element;
 const {
 	Toolbar,
@@ -28,7 +28,7 @@ class MediaFilterControl extends Component {
 		const filterControls = [
 			{
 				icon: icons.none,
-				title: __( 'Original' ),
+				title: _x( 'Original', 'block styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'none' } );
 				},
@@ -36,7 +36,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.grayscale,
-				title: __( 'Grayscale Filter' ),
+				title: _x( 'Grayscale Filter', 'block styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'grayscale' } );
 				},
@@ -44,7 +44,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.sepia,
-				title: __( 'Sepia Filter' ),
+				title: _x( 'Sepia Filter', 'block styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'sepia' } );
 				},
@@ -52,7 +52,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.saturation,
-				title: __( 'Saturation Filter' ),
+				title: _x( 'Saturation Filter', 'block styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'saturation' } );
 				},
@@ -60,7 +60,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.dark,
-				title: __( 'Dim Filter' ),
+				title: _x( 'Dim Filter', 'block styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'dim' } );
 				},
@@ -68,7 +68,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.vintage,
-				title: __( 'Vintage Filter' ),
+				title: _x( 'Vintage Filter', 'block styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'vintage' } );
 				},

--- a/src/components/media-filter-control/index.js
+++ b/src/components/media-filter-control/index.js
@@ -28,7 +28,7 @@ class MediaFilterControl extends Component {
 		const filterControls = [
 			{
 				icon: icons.none,
-				title: _x( 'Original', 'block styles' ),
+				title: _x( 'Original', 'image styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'none' } );
 				},
@@ -36,7 +36,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.grayscale,
-				title: _x( 'Grayscale Filter', 'block styles' ),
+				title: _x( 'Grayscale Filter', 'image styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'grayscale' } );
 				},
@@ -44,7 +44,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.sepia,
-				title: _x( 'Sepia Filter', 'block styles' ),
+				title: _x( 'Sepia Filter', 'image styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'sepia' } );
 				},
@@ -52,7 +52,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.saturation,
-				title: _x( 'Saturation Filter', 'block styles' ),
+				title: _x( 'Saturation Filter', 'image styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'saturation' } );
 				},
@@ -60,7 +60,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.dark,
-				title: _x( 'Dim Filter', 'block styles' ),
+				title: _x( 'Dim Filter', 'image styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'dim' } );
 				},
@@ -68,7 +68,7 @@ class MediaFilterControl extends Component {
 			},
 			{
 				icon: icons.vintage,
-				title: _x( 'Vintage Filter', 'block styles' ),
+				title: _x( 'Vintage Filter', 'image styles' ),
 				onClick: () => {
 					setAttributes( { filter: 'vintage' } );
 				},

--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -61,7 +61,7 @@ class ResponsiveTabsControl extends Component {
 							if ( 'mobile' === tab.name ) {
 								return (
 									<RangeControl
-										// translators: Control name
+										/* translators: %s: Represents values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width' */
 										label={ sprintf( __( 'Mobile %s' ), label ) }
 										value={ valueMobile }
 										onChange={ ( valueMobile ) => onChangeMobile( valueMobile ) }

--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -61,7 +61,7 @@ class ResponsiveTabsControl extends Component {
 							if ( 'mobile' === tab.name ) {
 								return (
 									<RangeControl
-										/* translators: %s: Represents values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width' */
+										/* translators: %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width' */
 										label={ sprintf( __( 'Mobile %s' ), label ) }
 										value={ valueMobile }
 										onChange={ ( valueMobile ) => onChangeMobile( valueMobile ) }

--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -17,7 +17,7 @@ import icons from './icons';
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { __, _x } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
 const { DOWN } = wp.keycodes;
@@ -73,38 +73,38 @@ class TypographyControls extends Component {
 		const weight = [
 			{
 				value: '',
-				label: __( 'Default' ),
+				label: _x( 'Default', 'block styles' ),
 			},
 			{
 				value: 'normal',
-				label: __( 'Normal' ),
+				label: _x( 'Normal', 'block styles' ),
 			},
 			{
 				value: 'bold',
-				label: __( 'Bold' ),
+				label: _x( 'Bold', 'block styles' ),
 			},
 		];
 
 		const transform = [
 			{
 				value: '',
-				label: __( 'Default' ),
+				label: _x( 'Default', 'block styles' ),
 			},
 			{
 				value: 'uppercase',
-				label: __( 'Uppercase' ),
+				label: _x( 'Uppercase', 'block styles' ),
 			},
 			{
 				value: 'lowercase',
-				label: __( 'Lowercase' ),
+				label: _x( 'Lowercase', 'block styles' ),
 			},
 			{
 				value: 'capitalize',
-				label: __( 'Capitalize' ),
+				label: _x( 'Capitalize', 'block styles' ),
 			},
 			{
 				value: 'initial',
-				label: __( 'Normal' ),
+				label: _x( 'Normal', 'block styles' ),
 			},
 		];
 

--- a/src/components/typography-controls/index.js
+++ b/src/components/typography-controls/index.js
@@ -73,38 +73,38 @@ class TypographyControls extends Component {
 		const weight = [
 			{
 				value: '',
-				label: _x( 'Default', 'block styles' ),
+				label: _x( 'Default', 'typography styles' ),
 			},
 			{
 				value: 'normal',
-				label: _x( 'Normal', 'block styles' ),
+				label: _x( 'Normal', 'typography styles' ),
 			},
 			{
 				value: 'bold',
-				label: _x( 'Bold', 'block styles' ),
+				label: _x( 'Bold', 'typography styles' ),
 			},
 		];
 
 		const transform = [
 			{
 				value: '',
-				label: _x( 'Default', 'block styles' ),
+				label: _x( 'Default', 'typography styles' ),
 			},
 			{
 				value: 'uppercase',
-				label: _x( 'Uppercase', 'block styles' ),
+				label: _x( 'Uppercase', 'typography styles' ),
 			},
 			{
 				value: 'lowercase',
-				label: _x( 'Lowercase', 'block styles' ),
+				label: _x( 'Lowercase', 'typography styles' ),
 			},
 			{
 				value: 'capitalize',
-				label: _x( 'Capitalize', 'block styles' ),
+				label: _x( 'Capitalize', 'typography styles' ),
 			},
 			{
 				value: 'initial',
-				label: _x( 'Normal', 'block styles' ),
+				label: _x( 'Normal', 'typography styles' ),
 			},
 		];
 

--- a/src/extensions/button-styles/index.js
+++ b/src/extensions/button-styles/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { _x } = wp.i18n;
 const { registerBlockStyle } = wp.blocks;
 
 /**
@@ -13,18 +13,18 @@ import './styles/editor.scss';
 // Register custom styles for the core list block.
 registerBlockStyle( 'core/button', {
 	name: 'circular',
-	label: __( 'Circular' ),
+	label: _x( 'Circular', 'block styles' ),
 	isDefault: false,
 } );
 
 registerBlockStyle( 'core/button', {
 	name: '3d',
-	label: __( '3D' ),
+	label: _x( '3D', 'block styles' ),
 	isDefault: false,
 } );
 
 registerBlockStyle( 'core/button', {
 	name: 'shadow',
-	label: __( 'Shadow' ),
+	label: _x( 'Shadow', 'block styles' ),
 	isDefault: false,
 } );

--- a/src/extensions/list-styles/index.js
+++ b/src/extensions/list-styles/index.js
@@ -12,19 +12,19 @@ import './styles/style.scss';
 // Default list style for reset.
 registerBlockStyle( 'core/list', {
 	name: 'default',
-	label: __( 'Default' ),
+	label: _x( 'Default', 'block styles' ),
 	isDefault: true,
 } );
 
 registerBlockStyle( 'core/list', {
 	name: 'none',
-	label: __( 'None' ),
+	label: _x( 'None', 'block styles' ),
 	isDefault: false,
 } );
 
 registerBlockStyle( 'core/list', {
 	name: 'checkbox',
-	label: __( 'Checkbox' ),
+	label: _x( 'Checkbox', 'block styles' ),
 	isDefault: false,
 } );
 

--- a/src/extensions/list-styles/index.js
+++ b/src/extensions/list-styles/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
+const { _x } = wp.i18n;
 const { registerBlockStyle } = wp.blocks;
 
 /**

--- a/src/sidebars/block-manager/components/options/disable-blocks.js
+++ b/src/sidebars/block-manager/components/options/disable-blocks.js
@@ -229,7 +229,7 @@ class DisableBlocks extends Component {
 					} ) :
 					<section className="coblocks-block-manager__section coblocks-block-manager__section--noresults ">
 						<p className="editor-inserter__no-results">{
-							/* translators: %s: Represents text input from user  */
+							/* translators: %s: search text  */
 							sprintf( __( 'No "%s" blocks found.' ), this.props.keyword )
 						}</p>
 					</section>

--- a/src/sidebars/block-manager/components/options/disable-blocks.js
+++ b/src/sidebars/block-manager/components/options/disable-blocks.js
@@ -228,7 +228,10 @@ class DisableBlocks extends Component {
 						}
 					} ) :
 					<section className="coblocks-block-manager__section coblocks-block-manager__section--noresults ">
-						<p className="editor-inserter__no-results">{ sprintf( __( 'No "%s" blocks found.' ), this.props.keyword ) }</p>
+						<p className="editor-inserter__no-results">{
+							/* translators: %s: Represents text input from user  */
+							sprintf( __( 'No "%s" blocks found.' ), this.props.keyword )
+						}</p>
 					</section>
 				}
 			</Fragment>

--- a/src/utils/block-category.js
+++ b/src/utils/block-category.js
@@ -17,7 +17,7 @@ setCategories( [
 	},
 	{
 		slug: 'coblocks-galleries',
-		/* translators: %s: Represents 'CoBlocks' */
+		/* translators: %s: Plugin title, i.e. CoBlocks */
 		title: sprintf( __( '%s Galleries' ), 'CoBlocks' ),
 		icon: brandAssets.categoryIcon,
 	},

--- a/src/utils/block-category.js
+++ b/src/utils/block-category.js
@@ -17,6 +17,7 @@ setCategories( [
 	},
 	{
 		slug: 'coblocks-galleries',
+		/* translators: %s: Represents 'CoBlocks' */
 		title: sprintf( __( '%s Galleries' ), 'CoBlocks' ),
 		icon: brandAssets.categoryIcon,
 	},


### PR DESCRIPTION
- Added comments where needed for translators.
  * `/* translators: %s: This is a description of what the variable is */`
  * Applies to all use of `%s` and `%d` within strings.
- Reviewed use of `__()` in php and JS and added context with `_x()` where needed.
- Closes #841.