### PR TITLE
convert Alert block to use alignment classnames

### DIFF
--- a/src/blocks/alert/deprecated.js
+++ b/src/blocks/alert/deprecated.js
@@ -114,9 +114,7 @@ const deprecated = [
 		},
 	},
 	{
-		attributes: {
-			...attributes,
-		},
+		attributes,
 		save( { attributes } ) {
 			const {
 				backgroundColor,

--- a/src/blocks/alert/deprecated.js
+++ b/src/blocks/alert/deprecated.js
@@ -11,7 +11,7 @@ const { RichText, getColorClassName } = wp.blockEditor;
 /**
  * Internal dependencies
  */
-import { attributes } from './';
+import { attributes } from './block.json';
 
 const deprecated = [
 	{
@@ -107,6 +107,57 @@ const deprecated = [
 						className={ textClasses }
 						value={ value }
 						style={ textStyles }
+					/>
+					}
+				</div>
+			);
+		},
+	},
+	{
+		save( { attributes } ) {
+			const {
+				backgroundColor,
+				customBackgroundColor,
+				customTextColor,
+				textAlign,
+				textColor,
+				title,
+				value,
+			} = attributes;
+
+			const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+			const textClass = getColorClassName( 'color', textColor );
+
+			const classes = classnames( {
+				'has-text-color': textColor || customTextColor,
+				[ textClass ]: textClass,
+				'has-background': backgroundColor || customBackgroundColor,
+				[ backgroundClass ]: backgroundClass,
+			} );
+
+			const styles = {
+				backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+				color: textClass ? undefined : customTextColor,
+				textAlign: textAlign ? textAlign : null,
+			};
+
+			return (
+				<div
+					className={ classes }
+					style={ styles }
+				>
+					{ ! RichText.isEmpty( title ) &&
+					<RichText.Content
+						tagName="p"
+						className="wp-block-coblocks-alert__title"
+						value={ title }
+					/>
+					}
+					{ ! RichText.isEmpty( value ) &&
+					<RichText.Content
+						tagName="p"
+						className="wp-block-coblocks-alert__text"
+						value={ value }
 					/>
 					}
 				</div>

--- a/src/blocks/alert/deprecated.js
+++ b/src/blocks/alert/deprecated.js
@@ -114,6 +114,9 @@ const deprecated = [
 		},
 	},
 	{
+		attributes: {
+			...attributes,
+		},
 		save( { attributes } ) {
 			const {
 				backgroundColor,

--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -87,7 +87,6 @@ class Edit extends Component {
 					style={ {
 						backgroundColor: backgroundColor.color,
 						color: textColor.color,
-						textAlign: textAlign,
 					} }
 				>
 					{ ( ! RichText.isEmpty( title ) || isSelected ) && (

--- a/src/blocks/alert/save.js
+++ b/src/blocks/alert/save.js
@@ -25,6 +25,7 @@ const save = ( { attributes } ) => {
 	const classes = classnames( {
 		'has-text-color': textColor || customTextColor,
 		[ textClass ]: textClass,
+		[ `has-text-align-${ textAlign }` ]: textAlign,
 		'has-background': backgroundColor || customBackgroundColor,
 		[ backgroundClass ]: backgroundClass,
 	} );
@@ -32,7 +33,6 @@ const save = ( { attributes } ) => {
 	const styles = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
 		color: textClass ? undefined : customTextColor,
-		textAlign: textAlign ? textAlign : null,
 	};
 
 	return (


### PR DESCRIPTION
- Related to #850.
- Found that attributes were not being properly imported in deprecated.js.
- Added new deprecated save function to handle blocks with inline style. 
- Tested with and without Gutenberg plugin.
- Tested in FireFox, Chrome, and IE11.