### PR TITLE
convert Click-to-Tweet block to use alignment classnames

### DIFF
--- a/src/blocks/click-to-tweet/deprecated.js
+++ b/src/blocks/click-to-tweet/deprecated.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+const { RichText, getColorClassName, getFontSizeClass } = wp.blockEditor;
+
+/**
+ * Internal dependencies
+ */
+import { attributes } from './block.json';
+
+const deprecated = [
+	{
+		attributes,
+		save( { attributes } ) {
+			const {
+				buttonColor,
+				buttonText,
+				customButtonColor,
+				customTextColor,
+				content,
+				customFontSize,
+				fontSize,
+				textColor,
+				textAlign,
+				url,
+				via,
+			} = attributes;
+
+			const viaUrl = via ? `&via=${ via }` : '';
+
+			const tweetUrl = `http://twitter.com/share?&text=${ encodeURIComponent( content ) }&url=${ url }${ viaUrl }`;
+
+			const textColorClass = getColorClassName( 'color', textColor );
+
+			const fontSizeClass = getFontSizeClass( fontSize );
+
+			const textClasses = classnames( 'wp-block-coblocks-click-to-tweet__text', {
+				'has-text-color': textColor || customTextColor,
+				[ fontSizeClass ]: fontSizeClass,
+				[ textColorClass ]: textColorClass,
+			} );
+
+			const textStyles = {
+				fontSize: fontSizeClass ? undefined : customFontSize,
+				color: textColorClass ? undefined : customTextColor,
+			};
+
+			const buttonColorClass = getColorClassName( 'background-color', buttonColor );
+
+			const buttonClasses = classnames( 'wp-block-coblocks-click-to-tweet__twitter-btn', {
+				'has-button-color': buttonColor || customButtonColor,
+				[ buttonColorClass ]: buttonColorClass,
+			} );
+
+			const buttonStyles = {
+				backgroundColor: buttonColorClass ? undefined : customButtonColor,
+			};
+
+			return (
+				! RichText.isEmpty( content ) && (
+					<blockquote style={ { textAlign: textAlign } }>
+						<RichText.Content
+							tagName="p"
+							className={ textClasses }
+							style={ textStyles }
+							value={ content }
+						/>
+						<RichText.Content
+							tagName="a"
+							className={ buttonClasses }
+							style={ buttonStyles }
+							value={ buttonText }
+							href={ tweetUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					</blockquote>
+				)
+			);
+		} },
+];
+
+export default deprecated;

--- a/src/blocks/click-to-tweet/edit.js
+++ b/src/blocks/click-to-tweet/edit.js
@@ -60,6 +60,8 @@ class Edit extends Component {
 			textAlign,
 		} = attributes;
 
+		const blockquoteClasses = classnames( className, { [ `has-text-align-${ textAlign }` ]: textAlign } );
+
 		return (
 			<Fragment>
 				{ isSelected && (
@@ -72,7 +74,7 @@ class Edit extends Component {
 						{ ...this.props }
 					/>
 				) }
-				<blockquote className={ className } style={ { textAlign: textAlign } }>
+				<blockquote className={ blockquoteClasses }>
 					<RichText
 						tagName="p"
 						multiline="false"

--- a/src/blocks/click-to-tweet/index.js
+++ b/src/blocks/click-to-tweet/index.js
@@ -12,6 +12,7 @@ import icon from './icon';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import deprecated from './deprecated';
 
 /**
  * WordPress dependencies
@@ -35,6 +36,7 @@ const settings = {
 	},
 	attributes,
 	transforms,
+	deprecated,
 	edit,
 	save,
 };

--- a/src/blocks/click-to-tweet/save.js
+++ b/src/blocks/click-to-tweet/save.js
@@ -37,6 +37,8 @@ const save = ( { attributes } ) => {
 		[ textColorClass ]: textColorClass,
 	} );
 
+	const blockquoteClasses = classnames( { [ `has-text-align-${ textAlign }` ]: textAlign } );
+
 	const textStyles = {
 		fontSize: fontSizeClass ? undefined : customFontSize,
 		color: textColorClass ? undefined : customTextColor,
@@ -55,7 +57,7 @@ const save = ( { attributes } ) => {
 
 	return (
 		! RichText.isEmpty( content ) && (
-			<blockquote style={ { textAlign: textAlign } }>
+			<blockquote className={ blockquoteClasses }>
 				<RichText.Content
 					tagName="p"
 					className={ textClasses }


### PR DESCRIPTION
- Related to #850.
- Added new deprecated save function to handle blocks with inline style.
- Tested with and without Gutenberg plugin.
- Tested in FireFox and Chrome.