### PR TITLE
convert Row block to use alignment classnames

### DIFF
--- a/src/blocks/row/column/deprecated.js
+++ b/src/blocks/row/column/deprecated.js
@@ -6,8 +6,9 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
-import { BackgroundClasses, BackgroundVideo } from '../../../components/background';
+import { BackgroundStyles, BackgroundClasses, BackgroundVideo, BackgroundAttributes } from '../../../components/background';
+import { attributes } from './block.json';
+import DimensionsAttributes from '../../../components/dimensions-control/attributes';
 
 /**
  * WordPress dependencies
@@ -15,7 +16,7 @@ import { BackgroundClasses, BackgroundVideo } from '../../../components/backgrou
 const { InnerBlocks, getColorClassName } = wp.blockEditor;
 
 const deprecated = [ {
-	attributes: metadata.attributes,
+	attributes,
 	save( { attributes } ) {
 		const {
 			id,
@@ -75,6 +76,61 @@ const deprecated = [ {
 		);
 	},
 },
+{
+	attributes: {
+		...BackgroundAttributes,
+		...DimensionsAttributes,
+		...attributes,
+	},
+	save( { attributes } ) {
+		const {
+			coblocks,
+			textColor,
+			customTextColor,
+			marginSize,
+			paddingSize,
+			contentAlign,
+		} = attributes;
+		const textClass = getColorClassName( 'color', textColor );
+
+		let classes = '';
+
+		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+			classes = classnames( classes, `coblocks-column-${ coblocks.id }` );
+		}
+
+		const innerClasses = classnames(
+			'wp-block-coblocks-column__inner',
+			...BackgroundClasses( attributes ),
+			{
+				'has-padding': paddingSize && paddingSize !== 'no',
+				'has-margin': marginSize && marginSize !== 'no',
+				[ `has-${ paddingSize }-padding` ]:
+					paddingSize && paddingSize !== 'advanced',
+				[ `has-${ marginSize }-margin` ]: marginSize && marginSize !== 'advanced',
+			}
+		);
+
+		const styles = {
+			textAlign: contentAlign ? contentAlign : null,
+		};
+
+		const innerStyles = {
+			...BackgroundStyles( attributes ),
+			color: textClass ? undefined : customTextColor,
+		};
+
+		return (
+			<div className={ classes } style={ styles } >
+				<div className={ innerClasses } style={ innerStyles }>
+					{ BackgroundVideo( attributes ) }
+					<InnerBlocks.Content />
+				</div>
+			</div>
+		);
+	},
+},
 ];
 
 export default deprecated;
+//compose( [ applyWithColors ] )( deprecated );

--- a/src/blocks/row/column/edit.js
+++ b/src/blocks/row/column/edit.js
@@ -96,7 +96,7 @@ class Edit extends Component {
 				columnBlocks &&
 				columnBlocks.innerBlocks &&
 				Object.keys( columnBlocks.innerBlocks ).length < 1,
-		} );
+		}, { [ `has-text-align-${ contentAlign }` ]: contentAlign } );
 
 		if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
 			classes = classnames( classes, `coblocks-column-${ coblocks.id }` );
@@ -167,7 +167,6 @@ class Edit extends Component {
 								`url(${ backgroundImg })` :
 								undefined,
 							color: textColor.color,
-							textAlign: contentAlign,
 						} }
 					>
 						<div className="wp-block-coblocks-column">
@@ -278,7 +277,7 @@ class Edit extends Component {
 				>
 					<div
 						className={ classes }
-						style={ { color: textColor.color, textAlign: contentAlign } }
+						style={ { color: textColor.color } }
 					>
 						{ isBlobURL( backgroundImg ) && <Spinner /> }
 						{ BackgroundVideo( attributes ) }

--- a/src/blocks/row/column/save.js
+++ b/src/blocks/row/column/save.js
@@ -24,7 +24,7 @@ const save = ( { attributes } ) => {
 	} = attributes;
 	const textClass = getColorClassName( 'color', textColor );
 
-	let classes = '';
+	let classes = classnames( { [ `has-text-align-${ contentAlign }` ]: contentAlign } );
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
 		classes = classnames( classes, `coblocks-column-${ coblocks.id }` );
@@ -41,17 +41,13 @@ const save = ( { attributes } ) => {
 			[ `has-${ marginSize }-margin` ]: marginSize && ( marginSize !== 'advanced' ),
 		} );
 
-	const styles = {
-		textAlign: contentAlign ? contentAlign : null,
-	};
-
 	const innerStyles = {
 		...BackgroundStyles( attributes ),
 		color: textClass ? undefined : customTextColor,
 	};
 
 	return (
-		<div className={ classes } style={ styles } >
+		<div className={ classes } >
 			<div className={ innerClasses } style={ innerStyles }>
 				{ BackgroundVideo( attributes ) }
 				<InnerBlocks.Content />


### PR DESCRIPTION
- Related to #850.
- Added new deprecated save function to handle blocks with inline style.
- Tested with and without Gutenberg plugin.
- Tested in FireFox, Chrome, and IE11.