### PR TITLE
Update Row block CSS to hide default appender

### DIFF
--- a/src/blocks/row/styles/editor.scss
+++ b/src/blocks/row/styles/editor.scss
@@ -526,6 +526,15 @@ body {
 						}
 					}
 				}
+
+				> .block-list-appender {
+					> div:not(.wp-block) {
+						> .editor-default-block-appender {
+							display: none !important;
+							position: relative;
+						}
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Closes #891.
- Change seems to be related to structure changes with the default editor inserter with Gutenberg 6.5.
- This proposed change handles the display in FireFox, Chrome, IE11 and Edge.