### PR TITLE
Save custom padding and margin into post content Row block

### DIFF
--- a/src/blocks/row/deprecated.js
+++ b/src/blocks/row/deprecated.js
@@ -2,7 +2,8 @@
  * Internal dependencies
  */
 import { BackgroundClasses, BackgroundVideo } from '../../components/background';
-import metadata from './block.json';
+import { attributes } from './block.json';
+import DimensionsAttributes from '../../components/dimensions-control/attributes';
 
 /**
  * External dependencies
@@ -32,7 +33,10 @@ function Deprecation( { attributes } ) {
 	} = attributes;
 
 	const textClass = getColorClassName( 'color', textColor );
-	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+	const backgroundClass = getColorClassName(
+		'background-color',
+		backgroundColor
+	);
 
 	let classlist = {
 		[ `coblocks-row--${ id }` ]: id,
@@ -40,7 +44,7 @@ function Deprecation( { attributes } ) {
 		[ textClass ]: textClass,
 	};
 
-	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+	if ( coblocks && typeof coblocks.id !== 'undefined' ) {
 		classlist = Object.assign( classlist, [ `coblocks-row-${ coblocks.id }` ] );
 	}
 
@@ -52,14 +56,16 @@ function Deprecation( { attributes } ) {
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-row__inner',
-		...BackgroundClasses( attributes ), {
+		...BackgroundClasses( attributes ),
+		{
 			[ `has-${ gutter }-gutter` ]: gutter,
 			'has-padding': paddingSize && paddingSize !== 'no',
-			[ `has-${ paddingSize }-padding` ]: paddingSize && ( paddingSize !== 'advanced' ),
+			[ `has-${ paddingSize }-padding` ]: paddingSize && paddingSize !== 'advanced',
 			'has-margin': marginSize && marginSize !== 'no',
-			[ `has-${ marginSize }-margin` ]: marginSize && ( marginSize !== 'advanced' ),
+			[ `has-${ marginSize }-margin` ]: marginSize && marginSize !== 'advanced',
 			'is-stacked-on-mobile': isStackedOnMobile,
-		} );
+		}
+	);
 
 	const innerStyles = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
@@ -67,7 +73,13 @@ function Deprecation( { attributes } ) {
 	};
 
 	return (
-		<div className={ classes } data-id={ id } data-columns={ columns } data-layout={ layout } style={ styles } >
+		<div
+			className={ classes }
+			data-id={ id }
+			data-columns={ columns }
+			data-layout={ layout }
+			style={ styles }
+		>
 			<div className={ innerClasses } style={ innerStyles }>
 				<InnerBlocks.Content />
 			</div>
@@ -96,35 +108,52 @@ function DeprecationVideo( { attributes } ) {
 	} = attributes;
 
 	const textClass = getColorClassName( 'color', textColor );
-	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+	const backgroundClass = getColorClassName(
+		'background-color',
+		backgroundColor
+	);
 
 	const classes = classnames( {
 		[ `coblocks-row--${ id }` ]: id,
-		[ `coblocks-row-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
+		[ `coblocks-row-${ coblocks.id }` ]:
+			coblocks && typeof coblocks.id !== 'undefined',
 	} );
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-row__inner',
-		...BackgroundClasses( attributes ), {
+		...BackgroundClasses( attributes ),
+		{
 			'has-text-color': textColor || customTextColor,
 			[ textClass ]: textClass,
 			[ `has-${ gutter }-gutter` ]: gutter,
 			'has-padding': paddingSize && paddingSize !== 'no',
-			[ `has-${ paddingSize }-padding` ]: paddingSize && ( paddingSize !== 'advanced' ),
+			[ `has-${ paddingSize }-padding` ]: paddingSize && paddingSize !== 'advanced',
 			'has-margin': marginSize && marginSize !== 'no',
-			[ `has-${ marginSize }-margin` ]: marginSize && ( marginSize !== 'advanced' ),
+			[ `has-${ marginSize }-margin` ]: marginSize && marginSize !== 'advanced',
 			'is-stacked-on-mobile': isStackedOnMobile,
-		} );
+		}
+	);
 
 	const innerStyles = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
-		backgroundImage: backgroundImg && backgroundType === 'image' ? `url(${ backgroundImg })` : undefined,
-		backgroundPosition: focalPoint && ! hasParallax ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : undefined,
+		backgroundImage:
+			backgroundImg && backgroundType === 'image' ?
+				`url(${ backgroundImg })` :
+				undefined,
+		backgroundPosition:
+			focalPoint && ! hasParallax ?
+				`${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` :
+				undefined,
 		color: textClass ? undefined : customTextColor,
 	};
 
 	return (
-		<div className={ classes } data-id={ id } data-columns={ columns } data-layout={ layout } >
+		<div
+			className={ classes }
+			data-id={ id }
+			data-columns={ columns }
+			data-layout={ layout }
+		>
 			{ BackgroundVideo( attributes ) }
 			<div className={ innerClasses } style={ innerStyles }>
 				<InnerBlocks.Content />
@@ -133,7 +162,82 @@ function DeprecationVideo( { attributes } ) {
 	);
 }
 
-const { attributes } = metadata;
+function DeprecatedInlinePaddingMarginsSave( { attributes } ) {
+	const {
+		coblocks,
+		backgroundColor,
+		backgroundImg,
+		columns,
+		customBackgroundColor,
+		customTextColor,
+		gutter,
+		id,
+		layout,
+		isStackedOnMobile,
+		marginSize,
+		paddingSize,
+		textColor,
+		focalPoint,
+		hasParallax,
+		backgroundType,
+	} = attributes;
+
+	const textClass = getColorClassName( 'color', textColor );
+	const backgroundClass = getColorClassName(
+		'background-color',
+		backgroundColor
+	);
+
+	let classes = classnames( {
+		[ `coblocks-row--${ id }` ]: id,
+	} );
+
+	if ( coblocks && typeof coblocks.id !== 'undefined' ) {
+		classes = classnames( classes, `coblocks-row-${ coblocks.id }` );
+	}
+
+	const innerClasses = classnames(
+		'wp-block-coblocks-row__inner',
+		...BackgroundClasses( attributes ),
+		{
+			'has-text-color': textColor || customTextColor,
+			[ textClass ]: textClass,
+			[ `has-${ gutter }-gutter` ]: gutter,
+			'has-padding': paddingSize && paddingSize !== 'no',
+			[ `has-${ paddingSize }-padding` ]:
+				paddingSize && paddingSize !== 'advanced',
+			'has-margin': marginSize && marginSize !== 'no',
+			[ `has-${ marginSize }-margin` ]: marginSize && marginSize !== 'advanced',
+			'is-stacked-on-mobile': isStackedOnMobile,
+		}
+	);
+
+	const innerStyles = {
+		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+		backgroundImage:
+			backgroundImg && backgroundType === 'image' ?
+				`url(${ backgroundImg })` :
+				undefined,
+		backgroundPosition:
+			focalPoint && ! hasParallax ?
+				`${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` :
+				undefined,
+		color: textClass ? undefined : customTextColor,
+	};
+	return (
+		<div
+			className={ classes }
+			data-id={ id }
+			data-columns={ columns }
+			data-layout={ layout }
+		>
+			<div className={ innerClasses } style={ innerStyles }>
+				{ BackgroundVideo( attributes ) }
+				<InnerBlocks.Content />
+			</div>
+		</div>
+	);
+}
 
 const deprecated = [
 	{
@@ -149,6 +253,17 @@ const deprecated = [
 			...attributes,
 		},
 		save: Deprecation,
+	},
+	{
+		attributes: {
+			...DimensionsAttributes,
+			...attributes,
+			isStackedOnMobile: {
+				type: 'boolean',
+				default: true,
+			},
+		},
+		save: DeprecatedInlinePaddingMarginsSave,
 	},
 ];
 

--- a/src/blocks/row/deprecated.js
+++ b/src/blocks/row/deprecated.js
@@ -48,7 +48,7 @@ function InlineTextColor( { attributes } ) {
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
 		classlist[ `coblocks-row-${ coblocks.id }` ] = 'true';
 	}
-	console.log( classlist );
+
 	const classes = classnames( classlist );
 
 	const styles = {

--- a/src/blocks/row/deprecated.js
+++ b/src/blocks/row/deprecated.js
@@ -40,15 +40,15 @@ function InlineTextColor( { attributes } ) {
 	const textClass = getColorClassName( 'color', textColor );
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-	let classlist = {
+	const classlist = {
 		'has-text-color': textColor || customTextColor,
 		[ textClass ]: textClass,
 	};
 
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
-		classlist = Object.assign( classlist, [ `coblocks-row-${ coblocks.id }` ] );
+		classlist[ `coblocks-row-${ coblocks.id }` ] = 'true';
 	}
-
+	console.log( classlist );
 	const classes = classnames( classlist );
 
 	const styles = {

--- a/src/blocks/row/deprecated.js
+++ b/src/blocks/row/deprecated.js
@@ -56,8 +56,10 @@ function InlineTextColor( { attributes } ) {
 		...BackgroundClasses( attributes ), {
 			[ `has-${ gutter }-gutter` ]: gutter,
 			'has-padding': paddingSize && paddingSize !== 'no',
-			[ `has-${ paddingSize }-padding` ]: paddingSize && ( paddingSize !== 'advanced' ),			'has-margin': marginSize && marginSize !== 'no',
-			[ `has-${ marginSize }-margin` ]: marginSize && ( marginSize !== 'advanced' ),			'is-stacked-on-mobile': isStackedOnMobile,
+			[ `has-${ paddingSize }-padding` ]: paddingSize && ( paddingSize !== 'advanced' ),
+			'has-margin': marginSize && marginSize !== 'no',
+			[ `has-${ marginSize }-margin` ]: marginSize && ( marginSize !== 'advanced' ),
+			'is-stacked-on-mobile': isStackedOnMobile,
 		}
 	);
 

--- a/src/blocks/row/deprecated.js
+++ b/src/blocks/row/deprecated.js
@@ -1,14 +1,20 @@
 /**
- * Internal dependencies
- */
-import { attributes } from './block.json';
-import { BackgroundClasses, BackgroundVideo } from '../../components/background';
-import DimensionsAttributes from '../../components/dimensions-control/attributes';
-
-/**
  * External dependencies
  */
 import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import { BackgroundAttributes, BackgroundClasses, BackgroundVideo } from '../../components/background';
+import DimensionsAttributes from '../../components/dimensions-control/attributes';
+
+const attributes = {
+	...DimensionsAttributes,
+	...BackgroundAttributes,
+	...metadata.attributes,
+};
 
 /**
  * WordPress dependencies
@@ -24,7 +30,6 @@ function InlineTextColor( { attributes } ) {
 		customBackgroundColor,
 		customTextColor,
 		gutter,
-		id,
 		layout,
 		isStackedOnMobile,
 		marginSize,
@@ -36,7 +41,6 @@ function InlineTextColor( { attributes } ) {
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
 	let classlist = {
-		[ `coblocks-row--${ id }` ]: id,
 		'has-text-color': textColor || customTextColor,
 		[ textClass ]: textClass,
 	};
@@ -69,7 +73,7 @@ function InlineTextColor( { attributes } ) {
 	};
 
 	return (
-		<div className={ classes } data-id={ id } data-columns={ columns } data-layout={ layout } style={ styles } >
+		<div className={ classes } data-columns={ columns } data-layout={ layout } style={ styles } >
 			<div className={ innerClasses } style={ innerStyles }>
 				<InnerBlocks.Content />
 			</div>
@@ -86,7 +90,6 @@ function DeprecationVideo( { attributes } ) {
 		customBackgroundColor,
 		customTextColor,
 		gutter,
-		id,
 		layout,
 		isStackedOnMobile,
 		marginSize,
@@ -100,10 +103,10 @@ function DeprecationVideo( { attributes } ) {
 	const textClass = getColorClassName( 'color', textColor );
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-	const classes = classnames( {
-		[ `coblocks-row--${ id }` ]: id,
-		[ `coblocks-row-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
-	} );
+	let classes;
+	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+		classes = classnames( classes, `coblocks-row-${ coblocks.id }` );
+	}
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-row__inner',
@@ -127,7 +130,7 @@ function DeprecationVideo( { attributes } ) {
 	};
 
 	return (
-		<div className={ classes } data-id={ id } data-columns={ columns } data-layout={ layout } >
+		<div className={ classes } data-columns={ columns } data-layout={ layout } >
 			{ BackgroundVideo( attributes ) }
 			<div className={ innerClasses } style={ innerStyles }>
 				<InnerBlocks.Content />
@@ -145,7 +148,6 @@ function InlinePaddingMargins( { attributes } ) {
 		customBackgroundColor,
 		customTextColor,
 		gutter,
-		id,
 		layout,
 		isStackedOnMobile,
 		marginSize,
@@ -162,10 +164,7 @@ function InlinePaddingMargins( { attributes } ) {
 		backgroundColor
 	);
 
-	let classes = classnames( {
-		[ `coblocks-row--${ id }` ]: id,
-	} );
-
+	let classes;
 	if ( coblocks && typeof coblocks.id !== 'undefined' ) {
 		classes = classnames( classes, `coblocks-row-${ coblocks.id }` );
 	}
@@ -199,7 +198,7 @@ function InlinePaddingMargins( { attributes } ) {
 		color: textClass ? undefined : customTextColor,
 	};
 	return (
-		<div className={ classes } data-id={ id } data-columns={ columns } data-layout={ layout }>
+		<div className={ classes } data-columns={ columns } data-layout={ layout }>
 			<div className={ innerClasses } style={ innerStyles }>
 				{ BackgroundVideo( attributes ) }
 				<InnerBlocks.Content />
@@ -227,10 +226,6 @@ const deprecated = [
 		attributes: {
 			...DimensionsAttributes,
 			...attributes,
-			isStackedOnMobile: {
-				type: 'boolean',
-				default: true,
-			},
 		},
 		save: InlinePaddingMargins,
 	},

--- a/src/blocks/row/deprecated.js
+++ b/src/blocks/row/deprecated.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { BackgroundClasses, BackgroundVideo } from '../../components/background';
 import { attributes } from './block.json';
+import { BackgroundClasses, BackgroundVideo } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 
 /**
@@ -15,7 +15,7 @@ import classnames from 'classnames';
  */
 const { getColorClassName, InnerBlocks } = wp.blockEditor;
 
-function Deprecation( { attributes } ) {
+function InlineTextColor( { attributes } ) {
 	const {
 		coblocks,
 		backgroundColor,
@@ -33,10 +33,7 @@ function Deprecation( { attributes } ) {
 	} = attributes;
 
 	const textClass = getColorClassName( 'color', textColor );
-	const backgroundClass = getColorClassName(
-		'background-color',
-		backgroundColor
-	);
+	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
 	let classlist = {
 		[ `coblocks-row--${ id }` ]: id,
@@ -44,7 +41,7 @@ function Deprecation( { attributes } ) {
 		[ textClass ]: textClass,
 	};
 
-	if ( coblocks && typeof coblocks.id !== 'undefined' ) {
+	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
 		classlist = Object.assign( classlist, [ `coblocks-row-${ coblocks.id }` ] );
 	}
 
@@ -56,14 +53,11 @@ function Deprecation( { attributes } ) {
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-row__inner',
-		...BackgroundClasses( attributes ),
-		{
+		...BackgroundClasses( attributes ), {
 			[ `has-${ gutter }-gutter` ]: gutter,
 			'has-padding': paddingSize && paddingSize !== 'no',
-			[ `has-${ paddingSize }-padding` ]: paddingSize && paddingSize !== 'advanced',
-			'has-margin': marginSize && marginSize !== 'no',
-			[ `has-${ marginSize }-margin` ]: marginSize && marginSize !== 'advanced',
-			'is-stacked-on-mobile': isStackedOnMobile,
+			[ `has-${ paddingSize }-padding` ]: paddingSize && ( paddingSize !== 'advanced' ),			'has-margin': marginSize && marginSize !== 'no',
+			[ `has-${ marginSize }-margin` ]: marginSize && ( marginSize !== 'advanced' ),			'is-stacked-on-mobile': isStackedOnMobile,
 		}
 	);
 
@@ -73,13 +67,7 @@ function Deprecation( { attributes } ) {
 	};
 
 	return (
-		<div
-			className={ classes }
-			data-id={ id }
-			data-columns={ columns }
-			data-layout={ layout }
-			style={ styles }
-		>
+		<div className={ classes } data-id={ id } data-columns={ columns } data-layout={ layout } style={ styles } >
 			<div className={ innerClasses } style={ innerStyles }>
 				<InnerBlocks.Content />
 			</div>
@@ -108,52 +96,36 @@ function DeprecationVideo( { attributes } ) {
 	} = attributes;
 
 	const textClass = getColorClassName( 'color', textColor );
-	const backgroundClass = getColorClassName(
-		'background-color',
-		backgroundColor
-	);
+	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
 	const classes = classnames( {
 		[ `coblocks-row--${ id }` ]: id,
-		[ `coblocks-row-${ coblocks.id }` ]:
-			coblocks && typeof coblocks.id !== 'undefined',
+		[ `coblocks-row-${ coblocks.id }` ]: coblocks && ( typeof coblocks.id !== 'undefined' ),
 	} );
 
 	const innerClasses = classnames(
 		'wp-block-coblocks-row__inner',
-		...BackgroundClasses( attributes ),
-		{
+		...BackgroundClasses( attributes ), {
 			'has-text-color': textColor || customTextColor,
 			[ textClass ]: textClass,
 			[ `has-${ gutter }-gutter` ]: gutter,
 			'has-padding': paddingSize && paddingSize !== 'no',
-			[ `has-${ paddingSize }-padding` ]: paddingSize && paddingSize !== 'advanced',
+			[ `has-${ paddingSize }-padding` ]: paddingSize && ( paddingSize !== 'advanced' ),
 			'has-margin': marginSize && marginSize !== 'no',
-			[ `has-${ marginSize }-margin` ]: marginSize && marginSize !== 'advanced',
+			[ `has-${ marginSize }-margin` ]: marginSize && ( marginSize !== 'advanced' ),
 			'is-stacked-on-mobile': isStackedOnMobile,
 		}
 	);
 
 	const innerStyles = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
-		backgroundImage:
-			backgroundImg && backgroundType === 'image' ?
-				`url(${ backgroundImg })` :
-				undefined,
-		backgroundPosition:
-			focalPoint && ! hasParallax ?
-				`${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` :
-				undefined,
+		backgroundImage: backgroundImg && backgroundType === 'image' ? `url(${ backgroundImg })` : undefined,
+		backgroundPosition: focalPoint && ! hasParallax ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : undefined,
 		color: textClass ? undefined : customTextColor,
 	};
 
 	return (
-		<div
-			className={ classes }
-			data-id={ id }
-			data-columns={ columns }
-			data-layout={ layout }
-		>
+		<div className={ classes } data-id={ id } data-columns={ columns } data-layout={ layout } >
 			{ BackgroundVideo( attributes ) }
 			<div className={ innerClasses } style={ innerStyles }>
 				<InnerBlocks.Content />
@@ -162,7 +134,7 @@ function DeprecationVideo( { attributes } ) {
 	);
 }
 
-function DeprecatedInlinePaddingMarginsSave( { attributes } ) {
+function InlinePaddingMargins( { attributes } ) {
 	const {
 		coblocks,
 		backgroundColor,
@@ -225,12 +197,7 @@ function DeprecatedInlinePaddingMarginsSave( { attributes } ) {
 		color: textClass ? undefined : customTextColor,
 	};
 	return (
-		<div
-			className={ classes }
-			data-id={ id }
-			data-columns={ columns }
-			data-layout={ layout }
-		>
+		<div className={ classes } data-id={ id } data-columns={ columns } data-layout={ layout }>
 			<div className={ innerClasses } style={ innerStyles }>
 				{ BackgroundVideo( attributes ) }
 				<InnerBlocks.Content />
@@ -252,7 +219,7 @@ const deprecated = [
 			},
 			...attributes,
 		},
-		save: Deprecation,
+		save: InlineTextColor,
 	},
 	{
 		attributes: {
@@ -263,7 +230,7 @@ const deprecated = [
 				default: true,
 			},
 		},
-		save: DeprecatedInlinePaddingMarginsSave,
+		save: InlinePaddingMargins,
 	},
 ];
 

--- a/src/blocks/row/save.js
+++ b/src/blocks/row/save.js
@@ -31,6 +31,16 @@ function Save( { attributes } ) {
 		focalPoint,
 		hasParallax,
 		backgroundType,
+		paddingTop,
+		paddingRight,
+		paddingBottom,
+		paddingLeft,
+		marginTop,
+		marginRight,
+		marginBottom,
+		marginLeft,
+		paddingUnit,
+		marginUnit,
 	} = attributes;
 
 	const textClass = getColorClassName( 'color', textColor );
@@ -62,6 +72,14 @@ function Save( { attributes } ) {
 		backgroundImage: backgroundImg && backgroundType === 'image' ? `url(${ backgroundImg })` : undefined,
 		backgroundPosition: focalPoint && ! hasParallax ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : undefined,
 		color: textClass ? undefined : customTextColor,
+		paddingTop: paddingSize === 'advanced' && paddingTop ? paddingTop + paddingUnit : undefined,
+		paddingRight: paddingSize === 'advanced' && paddingRight ? paddingRight + paddingUnit : undefined,
+		paddingBottom: paddingSize === 'advanced' && paddingBottom ? paddingBottom + paddingUnit : undefined,
+		paddingLeft: paddingSize === 'advanced' && paddingLeft ? paddingLeft + paddingUnit : undefined,
+		marginTop: marginSize === 'advanced' && marginTop ? marginTop + marginUnit : undefined,
+		marginRight: marginSize === 'advanced' && marginRight ? marginRight + marginUnit : undefined,
+		marginBottom: marginSize === 'advanced' && marginBottom ? marginBottom + marginUnit : undefined,
+		marginLeft: marginSize === 'advanced' && marginLeft ? marginLeft + marginUnit : undefined,
 	};
 
 	return (

--- a/src/blocks/row/save.js
+++ b/src/blocks/row/save.js
@@ -22,7 +22,6 @@ function Save( { attributes } ) {
 		customBackgroundColor,
 		customTextColor,
 		gutter,
-		id,
 		layout,
 		isStackedOnMobile,
 		marginSize,
@@ -46,10 +45,7 @@ function Save( { attributes } ) {
 	const textClass = getColorClassName( 'color', textColor );
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-	let classes = classnames( {
-		[ `coblocks-row--${ id }` ]: id,
-	} );
-
+	let classes;
 	if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
 		classes = classnames( classes, `coblocks-row-${ coblocks.id }` );
 	}
@@ -83,7 +79,7 @@ function Save( { attributes } ) {
 	};
 
 	return (
-		<div className={ classes } data-id={ id } data-columns={ columns } data-layout={ layout } >
+		<div className={ classes } data-columns={ columns } data-layout={ layout } >
 			<div className={ innerClasses } style={ innerStyles }>
 				{ BackgroundVideo( attributes ) }
 				<InnerBlocks.Content />


### PR DESCRIPTION
- Closes #893 
- Adjust save function to apply inline styles when advanced margins or padding are used.
- Create deprecated save function to handle old block markup.