### PR TITLE
Updating the readme for 1.14.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,31 @@
 == Changelog ==
 
+= 1.14.0 =
+
+### Features
+* New image block style can be applied which [masks images with a wave shape](https://github.com/godaddy/coblocks/pull/877)
+* [Image cropping](https://github.com/godaddy/coblocks/pull/749) within the Image and Cover blocks
+
+### Enhancements
+* Improved the [context of strings](https://github.com/godaddy/coblocks/pull/852) for translators
+* [New filter in the Form block](https://github.com/godaddy/coblocks/pull/834) to prevent wp_mail from sending mail
+* CoBlocks [admin page has been moved](https://github.com/godaddy/coblocks/pull/746) under Tools
+* [Shortened the button placeholder](https://github.com/godaddy/coblocks/pull/878) text within the Hero block
+* [Exposed additional controls](https://github.com/godaddy/coblocks/pull/765) from [Flickity](https://flickity.metafizzy.co/) in the Carousel block
+* Font size, background and text color [controls added to the Author block](https://github.com/godaddy/coblocks/pull/808)
+* [Pricing table toolbar control](https://github.com/godaddy/coblocks/pull/811) updated to follow new Gutenberg pattern
+* [Row block toolbar control](https://github.com/godaddy/coblocks/pull/827) updated to follow new Gutenberg pattern
+* Groundwork added for [improved automated testing of blocks](https://github.com/godaddy/coblocks/pull/835) with Jest
+
+### Bug Fixes
+* Styles [preview scaling has been fixed](https://github.com/godaddy/coblocks/pull/879) in the Icon block with the Gutenberg plugin
+* Pricing Table will now [use all available width](https://github.com/godaddy/coblocks/pull/844) with any number of tables
+* [Bottom margin removed](https://github.com/godaddy/coblocks/pull/845) from last item within the Feature block
+* Improve the [spacing between figure and content](https://github.com/godaddy/coblocks/pull/846) on the Services block
+* Hero block [toolbar is now accessible](https://github.com/godaddy/coblocks/pull/838) when a Group block preceeds it
+* [Aligned responsive control SVG icons](https://github.com/godaddy/coblocks/pull/820) in Firefox and Edge
+
+
 = 1.13.0 =
 * New: Support for Gutenberg 6.4 🎊
 * New: Example block content added for the new block inserter help panel

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,7 +22,7 @@
 * Pricing Table will now [use all available width](https://github.com/godaddy/coblocks/pull/844) with any number of tables
 * [Bottom margin removed](https://github.com/godaddy/coblocks/pull/845) from last item within the Feature block
 * Improve the [spacing between figure and content](https://github.com/godaddy/coblocks/pull/846) on the Services block
-* Hero block [toolbar is now accessible](https://github.com/godaddy/coblocks/pull/838) when a Group block preceeds it
+* Hero block [toolbar is now accessible](https://github.com/godaddy/coblocks/pull/838) when a Group block precedes it
 * [Aligned responsive control SVG icons](https://github.com/godaddy/coblocks/pull/820) in Firefox and Edge
 
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -199,6 +199,16 @@ module.exports = function( grunt ) {
 					},
 				],
 			},
+			languages: {
+				src: 'languages/coblocks.pot',
+				overwrite: true,
+				replacements: [
+					{
+						from: /(Project-Id-Version: CoBlocks )[0-9\.]+/,
+						to: '$1' + pkg.version,
+					},
+				],
+			},
 		},
 
 		shell: {

--- a/languages/coblocks.pot
+++ b/languages/coblocks.pot
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 GoDaddy Operating Company, LLC. All Rights Reserved.
 msgid ""
 msgstr ""
-"Project-Id-Version: CoBlocks 1.12.1\n"
+"Project-Id-Version: CoBlocks 1.13.0\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/readme.txt
+++ b/readme.txt
@@ -37,21 +37,21 @@ https://www.youtube.com/watch?v=SfWoVX_uJ0M
 * Dynamic Separator Block
 * Features Block
 * Food & Drinks Block
-* Form Block (New!)
+* Form Block
 * Gif Block
 * GitHub Gist Block
 * Hero Block
 * Highlight Block
 * Icon Block
-* Logos & Badges Block (New!)
+* Logos & Badges Block
 * Map Block
 * Masonry Gallery Block
 * Media Card Block
 * Pricing Table Block
 * Resizable Row/Columns Blocks
-* Services Block (New!)
+* Services Block
 * Shape Divider Block
-* Social Profiles Block (New!)
+* Social Profiles Block
 * Social Sharing Block
 * Stacked Gallery Block
 

--- a/readme.txt
+++ b/readme.txt
@@ -117,24 +117,24 @@ Developers can also apply minor style touch-ups to their themes if necessary. If
 == Changelog ==
 
 ### Features
-* New image block style can be applied which [masks images with a wave shape](https://github.com/godaddy/coblocks/pull/877)
-* [Image cropping](https://github.com/godaddy/coblocks/pull/749) within the Image and Cover blocks
+* Add new [Crop Settings panel](https://github.com/godaddy/coblocks/pull/749) to the Image and Cover blocks to allow image cropping
+* Add [font size, background and text color controls](https://github.com/godaddy/coblocks/pull/808) to the Author block
+* Add new Image block styles to [mask images with a wave shape](https://github.com/godaddy/coblocks/pull/877)
 
 ### Enhancements
-* Improved the [context of strings](https://github.com/godaddy/coblocks/pull/852) for translators
-* [New filter in the Form block](https://github.com/godaddy/coblocks/pull/834) to prevent wp_mail from sending mail
-* CoBlocks [admin page has been moved](https://github.com/godaddy/coblocks/pull/746) under Tools
-* [Shortened the button placeholder](https://github.com/godaddy/coblocks/pull/878) text within the Hero block
-* [Exposed additional controls](https://github.com/godaddy/coblocks/pull/765) from [Flickity](https://flickity.metafizzy.co/) in the Carousel block
-* Font size, background and text color [controls added to the Author block](https://github.com/godaddy/coblocks/pull/808)
-* [Pricing table toolbar control](https://github.com/godaddy/coblocks/pull/811) updated to follow new Gutenberg pattern
-* [Row block toolbar control](https://github.com/godaddy/coblocks/pull/827) updated to follow new Gutenberg pattern
-* Groundwork added for [improved automated testing of blocks](https://github.com/godaddy/coblocks/pull/835) with Jest
+* Improve the [context of strings](https://github.com/godaddy/coblocks/pull/852) for translators
+* Add a [new filter](https://github.com/godaddy/coblocks/pull/834) in the Form block to prevent wp_mail from sending mail
+* Move the CoBlocks [top-level admin page](https://github.com/godaddy/coblocks/pull/746) under Tools
+* Shorten [the Button block placeholder text](https://github.com/godaddy/coblocks/pull/878) within the Hero block
+* Add [additional carousel controls](https://github.com/godaddy/coblocks/pull/765) to the Carousel block
+* Update the [Pricing Table block toolbar control](https://github.com/godaddy/coblocks/pull/811) to follow new Gutenberg patterns
+* Update the [Row block toolbar control](https://github.com/godaddy/coblocks/pull/827) to follow new Gutenberg patterns
+* Lay the groundwork for [improved automated tests for blocks](https://github.com/godaddy/coblocks/pull/835) using Jest
 
 ### Bug Fixes
-* Styles [preview scaling has been fixed](https://github.com/godaddy/coblocks/pull/879) in the Icon block with the Gutenberg plugin
-* Pricing Table will now [use all available width](https://github.com/godaddy/coblocks/pull/844) with any number of tables
-* [Bottom margin removed](https://github.com/godaddy/coblocks/pull/845) from last item within the Feature block
-* Improve the [spacing between figure and content](https://github.com/godaddy/coblocks/pull/846) on the Services block
-* Hero block [toolbar is now accessible](https://github.com/godaddy/coblocks/pull/838) when a Group block precedes it
-* [Aligned responsive control SVG icons](https://github.com/godaddy/coblocks/pull/820) in Firefox and Edge
+* Fix the [styles preview](https://github.com/godaddy/coblocks/pull/879) in the Icon block in Gutenberg 6.3+
+* Fix one column Pricing Table block display to use the [full available width](https://github.com/godaddy/coblocks/pull/844)
+* Remove [margin bottom](https://github.com/godaddy/coblocks/pull/845) from the last item within the Feature block
+* Improve the [spacing between the figure and content elements](https://github.com/godaddy/coblocks/pull/846) in the Services block
+* Avoid z-index issues with the [Hero block toolbar](https://github.com/godaddy/coblocks/pull/838)
+* Fix [misaligned responsive control SVG icons](https://github.com/godaddy/coblocks/pull/820) in Firefox and Edge

--- a/readme.txt
+++ b/readme.txt
@@ -136,5 +136,5 @@ Developers can also apply minor style touch-ups to their themes if necessary. If
 * Pricing Table will now [use all available width](https://github.com/godaddy/coblocks/pull/844) with any number of tables
 * [Bottom margin removed](https://github.com/godaddy/coblocks/pull/845) from last item within the Feature block
 * Improve the [spacing between figure and content](https://github.com/godaddy/coblocks/pull/846) on the Services block
-* Hero block [toolbar is now accessible](https://github.com/godaddy/coblocks/pull/838) when a Group block preceeds it
+* Hero block [toolbar is now accessible](https://github.com/godaddy/coblocks/pull/838) when a Group block precedes it
 * [Aligned responsive control SVG icons](https://github.com/godaddy/coblocks/pull/820) in Firefox and Edge

--- a/readme.txt
+++ b/readme.txt
@@ -116,54 +116,25 @@ Developers can also apply minor style touch-ups to their themes if necessary. If
 
 == Changelog ==
 
-= 1.13.0 =
-* New: Support for Gutenberg 6.4 🎊
-* New: Example block content added for the new block inserter help panel
-* New: Block level background color can be applied to the Share block
-* New: Block level background color can be applied to the Social Profiles block
-* New: Stacked Gallery block can now be aligned left, right, and center
-* New: Internationalization improvements for utilizing GlotPress
-* New: Improvements in code organization to prepare for the Block Directory
-* Tweak: Center align Share icons by default for wide and full block alignment
-* Tweak: Center align Social Profile icons by default for wide and full block alignment
-* Tweak: Simplify top and bottom block margin setting labels
-* Tweak: Version history moved to a changelog.txt file
-* Tweak: Adjust spacing for nested blocks when selecting the parent block
-* Tweak: Improve the Pricing block description
-* Tweak: Improve the Social Profiles block description
-* Tweak: Improve the Highlight block description
-* Tweak: Improve the Author block icon and description
-* Tweak: Improve the placeholder behavior in the Food and Drinks block
-* Tweak: Unify the size control in the Icon block to match core settings
-* Tweak: Added a cancel button to the Map block preventing unwanted updates
-* Tweak: Simplify specificity of CSS styles on the Alert block
-* Tweak: Simplify specificity of CSS styles on the Accordion block
-* Tweak: Moved the Accordion block into the CoBlocks block category
-* Tweak: Change the Icon block size selector to a proper Select control
-* Tweak: Focus style added to Food and Drink block's item attributes
-* Tweak: Prevent enqueuing frontend scripts on AMP responses
-* Tweak: Improved Alert block style selection with core component
-* Fix: Grid layout control no longer visually broken on the Hero block
-* Fix: Removed the "Layout" sidebar panel from the Row block
-* Fix: Resolve grid control tooltips missing a unique key
-* Fix: Child blocks no longer missing when adding the Hero block to a post
-* Fix: Gallery block's media filter control no longer missing dropdown indicator
-* Fix: Resolve the edit screen failing to load with a Hero block present
-* Fix: Icon block no longer missing height attribute when a size is applied
-* Fix: Styles panel no longer visually broken on the Services block
-* Fix: Styles panel no longer visually broken on the Food and Drinks block
-* Fix: Styles panel no longer visually broken on the Share block
-* Fix: Styles panel no longer visually broken on the Social Profiles block
-* Fix: Author image placeholder no longer misaligned
-* Fix: Orientation control no longer visually broken on the Shape Divider block
-* Fix: Shape Divider block no longer loses focus when using the resize control
-* Fix: Hero block no longer loses focus when using the resize control
-* Fix: Gif block no longer loses focus when using the resize control
-* Fix: Icon block no longer loses focus when using the resize control
-* Fix: Carousel Gallery block no longer loses focus when using the resize control
-* Fix: Row block no longer loses focus when using the resize control
-* Fix: When empty, the Pricing Table block no longer saves to the post content
-* Fix: Features block is now utilizing the available block width
-* Fix: Alert block no longer escapes HTML when transforming another block to it
-* Fix: Click to Tweet block no longer removes inline HTML elements from pasted text
-* Fix: Social Profiles popover component no longer visually broken
+### Features
+* New image block style can be applied which [masks images with a wave shape](https://github.com/godaddy/coblocks/pull/877)
+* [Image cropping](https://github.com/godaddy/coblocks/pull/749) within the Image and Cover blocks
+
+### Enhancements
+* Improved the [context of strings](https://github.com/godaddy/coblocks/pull/852) for translators
+* [New filter in the Form block](https://github.com/godaddy/coblocks/pull/834) to prevent wp_mail from sending mail
+* CoBlocks [admin page has been moved](https://github.com/godaddy/coblocks/pull/746) under Tools
+* [Shortened the button placeholder](https://github.com/godaddy/coblocks/pull/878) text within the Hero block
+* [Exposed additional controls](https://github.com/godaddy/coblocks/pull/765) from [Flickity](https://flickity.metafizzy.co/) in the Carousel block
+* Font size, background and text color [controls added to the Author block](https://github.com/godaddy/coblocks/pull/808)
+* [Pricing table toolbar control](https://github.com/godaddy/coblocks/pull/811) updated to follow new Gutenberg pattern
+* [Row block toolbar control](https://github.com/godaddy/coblocks/pull/827) updated to follow new Gutenberg pattern
+* Groundwork added for [improved automated testing of blocks](https://github.com/godaddy/coblocks/pull/835) with Jest
+
+### Bug Fixes
+* Styles [preview scaling has been fixed](https://github.com/godaddy/coblocks/pull/879) in the Icon block with the Gutenberg plugin
+* Pricing Table will now [use all available width](https://github.com/godaddy/coblocks/pull/844) with any number of tables
+* [Bottom margin removed](https://github.com/godaddy/coblocks/pull/845) from last item within the Feature block
+* Improve the [spacing between figure and content](https://github.com/godaddy/coblocks/pull/846) on the Services block
+* Hero block [toolbar is now accessible](https://github.com/godaddy/coblocks/pull/838) when a Group block preceeds it
+* [Aligned responsive control SVG icons](https://github.com/godaddy/coblocks/pull/820) in Firefox and Edge


### PR DESCRIPTION
Updating the Readme and Changelog for the 1.14.0 release.

Also using a slightly different format by utilizing Markdown [like the Gutenberg plugin](https://plugins.trac.wordpress.org/browser/gutenberg/trunk/readme.txt#L80). I liked the format a lot and it looks nice in the admin when clicking "View Details". It also exposes our GitHub a bit more with links to the PR of each change.

Contains everything added in the [latest milestone](https://github.com/godaddy/coblocks/milestone/13)

This PR also added our POT file into the version bump script on deploy.