### PR TITLE
convert Share block to use alignment classnames

### DIFF
--- a/src/blocks/share/edit.js
+++ b/src/blocks/share/edit.js
@@ -73,6 +73,7 @@ class edit extends Component {
 			[ `has-button-size-${ size }` ]: size !== 'med',
 			'has-colors': hasColors,
 			'has-background': blockBackgroundColor.color || customBlockBackgroundColor,
+			[ `has-text-align-${ textAlign }` ]: textAlign,
 		}
 		);
 
@@ -103,7 +104,7 @@ class edit extends Component {
 			<Fragment>
 				{ isSelected && <Controls { ...this.props } /> }
 				{ isSelected && <Inspector { ...this.props } /> }
-				<div className={ classes } style={ { textAlign, backgroundColor: blockBackgroundColor.color || '' } }>
+				<div className={ classes } style={ { backgroundColor: blockBackgroundColor.color || '' } }>
 					<ul>
 						{ facebook &&
 						<li>

--- a/src/blocks/share/index.php
+++ b/src/blocks/share/index.php
@@ -92,7 +92,6 @@ function coblocks_render_share_block( $attributes ) {
 	$google_url    = apply_filters( 'coblocks_google_share_url', $google_url );
 
 	// Attributes.
-	$text_align       = is_array( $attributes ) && isset( $attributes['textAlign'] ) ? "text-align:{$attributes['textAlign']};" : '';
 	$background_color = is_array( $attributes ) && isset( $attributes['customBlockBackgroundColor'] ) ? "background-color:{$attributes['customBlockBackgroundColor']};" : '';
 	$border_radius    = is_array( $attributes ) && isset( $attributes['borderRadius'] ) ? "border-radius: {$attributes['borderRadius']}px;" : '';
 	$has_padding      = is_array( $attributes ) && isset( $attributes['padding'] ) ? 'has-padding' : '';
@@ -197,6 +196,10 @@ function coblocks_render_share_block( $attributes ) {
 	// Build classes.
 	$class = 'wp-block-coblocks-social';
 
+	if ( isset( $attributes['textAlign'] ) ) {
+		$class .= " has-text-align-{$attributes['textAlign']}";
+	}
+
 	if ( isset( $attributes['className'] ) ) {
 		$class .= ' ' . $attributes['className'];
 	}
@@ -223,9 +226,8 @@ function coblocks_render_share_block( $attributes ) {
 
 	// Render block content.
 	$block_content = sprintf(
-		'<div class="%1$s" style="%2$s %3$s"><ul>%4$s</ul></div>',
+		'<div class="%1$s" style="%2$s"><ul>%3$s</ul></div>',
 		esc_attr( $class ),
-		esc_attr( $text_align ),
 		esc_attr( $background_color ),
 		$markup
 	);

--- a/src/blocks/share/index.php
+++ b/src/blocks/share/index.php
@@ -226,7 +226,7 @@ function coblocks_render_share_block( $attributes ) {
 
 	// Render block content.
 	$block_content = sprintf(
-		'<div class="%1$s" style="%2$s"><ul>%3$s</ul></div>',
+		'<div class="%1$s" style="%2$s "><ul>%3$s</ul></div>',
 		esc_attr( $class ),
 		esc_attr( $background_color ),
 		$markup


### PR DESCRIPTION
- Related to #850.
- No deprecation needed on server-side rendered blocks
- Tested with and without Gutenberg plugin.
- Tested in FireFox, Chrome, and IE11.