### PR TITLE
Add new attributes for future thumbnails and responsiveHeight options

### DIFF
--- a/src/blocks/gallery-carousel/block.json
+++ b/src/blocks/gallery-carousel/block.json
@@ -44,9 +44,17 @@
 		},
 		"pauseHover": {
 			"type": "boolean",
-				"default": false
+			"default": false
 		},
 		"freeScroll": {
+			"type": "boolean",
+			"default": false
+		},
+		"thumbnails": {
+			"type": "boolean",
+			"default": false
+		},
+		"responsiveHeight": {
 			"type": "boolean",
 			"default": false
 		}

--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -164,6 +164,8 @@ class GalleryCarouselEdit extends Component {
 			primaryCaption,
 			backgroundImg,
 			alignCells,
+			thumbnails,
+			responsiveHeight,
 		} = attributes;
 
 		const hasImages = !! images.length;
@@ -211,6 +213,8 @@ class GalleryCarouselEdit extends Component {
 			wrapAround: true,
 			autoPlay: false,
 			cellAlign: alignCells ? 'left' : 'center',
+			responsiveHeight: responsiveHeight,
+			thumbnails: thumbnails,
 			arrowShape: {
 				x0: 10,
 				x1: 60, y1: 50,

--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -213,14 +213,14 @@ class GalleryCarouselEdit extends Component {
 			wrapAround: true,
 			autoPlay: false,
 			cellAlign: alignCells ? 'left' : 'center',
-			responsiveHeight: responsiveHeight,
-			thumbnails: thumbnails,
 			arrowShape: {
 				x0: 10,
 				x1: 60, y1: 50,
 				x2: 65, y2: 45,
 				x3: 20,
 			},
+			responsiveHeight: responsiveHeight,
+			thumbnails: thumbnails,
 		};
 
 		if ( ! hasImages ) {

--- a/src/blocks/gallery-carousel/save.js
+++ b/src/blocks/gallery-carousel/save.js
@@ -80,14 +80,14 @@ const save = ( { attributes, className } ) => {
 		cellAlign: alignCells ? 'left' : 'center',
 		pauseAutoPlayOnHover: pauseHover,
 		freeScroll: freeScroll,
-		thumbnails: thumbnails,
-		responsiveHeight: responsiveHeight,
 		arrowShape: {
 			x0: 10,
 			x1: 60, y1: 50,
 			x2: 65, y2: 45,
 			x3: 20,
 		},
+		thumbnails: thumbnails,
+		responsiveHeight: responsiveHeight,
 	};
 
 	const captionColorClass = getColorClassName( 'color', captionColor );

--- a/src/blocks/gallery-carousel/save.js
+++ b/src/blocks/gallery-carousel/save.js
@@ -34,6 +34,8 @@ const save = ( { attributes, className } ) => {
 		prevNextButtons,
 		primaryCaption,
 		alignCells,
+		thumbnails,
+		responsiveHeight,
 	} = attributes;
 
 	const innerClasses = classnames(
@@ -78,6 +80,8 @@ const save = ( { attributes, className } ) => {
 		cellAlign: alignCells ? 'left' : 'center',
 		pauseAutoPlayOnHover: pauseHover,
 		freeScroll: freeScroll,
+		thumbnails: thumbnails,
+		responsiveHeight: responsiveHeight,
 		arrowShape: {
 			x0: 10,
 			x1: 60, y1: 50,


### PR DESCRIPTION
Tested to ensure the deprecation from 1.13 to 1.14 (today's release) is unaffected, and that we won't need another deprecation for 1.14 to the next release, which will include thumbnail and responsive height support for the Carousel block via #839.