### PR TITLE
Make the Styles panel on Food & Drinks block not open on default

### DIFF
--- a/src/blocks/food-and-drinks/inspector.js
+++ b/src/blocks/food-and-drinks/inspector.js
@@ -23,7 +23,7 @@ const Inspector = props => {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Styles' ) } initialOpen={ true }>
+			<PanelBody title={ __( 'Styles' ) } initialOpen={ false }>
 				<div className="editor-block-styles block-editor-block-styles coblocks-editor-block-styles">
 					{ layoutOptions.map( style => (
 						<div


### PR DESCRIPTION
This PR tweaks the UX of the Styles panel within the Food & Drinks block, to follow Gutenberg core's updated patterns. Instead of the Styles panel opening by default, it's closed.

<img width="1292" alt="Screen Shot 2019-09-29 at 5 03 10 PM" src="https://user-images.githubusercontent.com/1813435/65839404-1801d800-e2db-11e9-83e0-199ff6d2f134.png">
