### PR TITLE
Tweak Map block description

### DIFF
--- a/src/blocks/map/index.js
+++ b/src/blocks/map/index.js
@@ -25,7 +25,7 @@ const { name, category, attributes } = metadata;
 
 const settings = {
 	title: _x( 'Map', 'block name' ),
-	description: __( 'Add an address and drop a pin on a Google map.' ),
+	description: __( 'Add an address or location to drop a pin on a Google map.' ),
 	icon,
 	keywords: [ _x( 'address', 'block keyword' ), _x( 'maps', 'block keyword' ), _x( 'google', 'block keyword' ) ],
 	supports: {


### PR DESCRIPTION
The PR updates the Map block description from `Add an address and drop a pin on a Google map.` to `Add an address or location to drop a pin on a Google map.` to reflect the ability to simply search for a location - instead of needing an address. 🗺