### PR TITLE
Add coBlocksSpacing to galleries

### DIFF
--- a/src/blocks/gallery-carousel/index.js
+++ b/src/blocks/gallery-carousel/index.js
@@ -42,6 +42,7 @@ const settings = {
 
 	supports: {
 		align: [ 'wide', 'full' ],
+		coBlocksSpacing: true,
 	},
 	example: {
 		attributes: {

--- a/src/blocks/gallery-masonry/index.js
+++ b/src/blocks/gallery-masonry/index.js
@@ -39,6 +39,7 @@ const settings = {
 	keywords: [ _x( 'gallery', 'block keyword' ), _x( 'photos', 'block keyword' ), _x( 'lightbox', 'block keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full' ],
+		coBlocksSpacing: true,
 	},
 	example: {
 		attributes: {

--- a/src/blocks/gallery-stacked/index.js
+++ b/src/blocks/gallery-stacked/index.js
@@ -39,6 +39,7 @@ const settings = {
 	keywords: [ _x( 'gallery', 'block keyword' ), _x( 'photos', 'block keyword' ), _x( 'lightbox', 'block keyword' ) ],
 	supports: {
 		align: [ 'wide', 'full', 'left', 'center', 'right' ],
+		coBlocksSpacing: true,
 	},
 	example: {
 		attributes: {

--- a/src/components/block-gallery/shared/transforms.js
+++ b/src/components/block-gallery/shared/transforms.js
@@ -35,6 +35,8 @@ function GalleryTransforms( props ) {
 		shadow: props.shadow,
 		target: props.target,
 		lightbox: props.lightbox,
+		noBottomMargin: props.noBottomMargin,
+		noTopMargin: props.noTopMargin,
 	};
 
 	return transforms;


### PR DESCRIPTION
This PR adds the functionality to remove margin top and bottom from the gallery blocks. Opting into `coBlocksSpacing ` adds the toggles to the Advanced panel within the Settings Sidebar.