### PR TITLE
Remove extra spacing on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The vision for CoBlocks is to create a suite of WordPress blocks and tools to he
 -   Click to Tweet Block
 -   Dynamic Separator Block
 -   Features Block
--       Food & Drinks Block (New!)
+-   Food & Drinks Block (New!)
 -   Form Block (New!)
 -   Gif Block
 -   GitHub Gist Block


### PR DESCRIPTION
Extra spacing left within the bullet list resulted in unexpected styles. 

![image](https://user-images.githubusercontent.com/30462574/65975232-2a872900-e423-11e9-83c5-1d2e39537eda.png)

Pull request to resolve this issue. 