### PR TITLE
Remove redirect action when activating CoBlocks

### DIFF
--- a/.dev/tests/phpunit/includes/admin/test-coblocks-getting-started-page.php
+++ b/.dev/tests/phpunit/includes/admin/test-coblocks-getting-started-page.php
@@ -17,7 +17,7 @@ class CoBlocks_Getting_Started_Page_Tests extends WP_UnitTestCase {
 		$this->coblocks_getting_started_page = new CoBlocks_Getting_Started_Page();
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-		
+
 		set_current_screen( 'tools_page_coblocks-getting-started' );
 
 	}
@@ -120,17 +120,4 @@ class CoBlocks_Getting_Started_Page_Tests extends WP_UnitTestCase {
 		$this->assertTrue( true );
 
 	}
-
-	/**
-	 * Test that the page content is rendered correctly
-	 */
-	public function test_content() {
-
-		$this->expectOutputRegex(
-			'/You&#039;ve just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: <strong> tens of blocks<\/strong>, a <strong> page-builder experience <\/strong> and <strong> custom typography controls<\/strong>./',
-			$this->coblocks_getting_started_page->content()
-		);
-
-	}
-
 }

--- a/.dev/tests/phpunit/includes/admin/test-coblocks-getting-started-page.php
+++ b/.dev/tests/phpunit/includes/admin/test-coblocks-getting-started-page.php
@@ -37,7 +37,6 @@ class CoBlocks_Getting_Started_Page_Tests extends WP_UnitTestCase {
 
 		$actions = [
 			[ 'admin_menu', 'screen_page' ],
-			[ 'activated_plugin', 'redirect' ],
 			[ 'admin_enqueue_scripts', 'load_style', 100 ],
 		];
 
@@ -134,12 +133,4 @@ class CoBlocks_Getting_Started_Page_Tests extends WP_UnitTestCase {
 
 	}
 
-	/**
-	 * Test the plugin redirects properly
-	 */
-	public function test_redirect() {
-
-		$this->markTestSkipped( 'Todo: Figure out how to properly test the redirection.' );
-
-	}
 }

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -20,7 +20,6 @@ class CoBlocks_Getting_Started_Page {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'screen_page' ) );
-		add_action( 'activated_plugin', array( $this, 'redirect' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_style' ), 100 );
 	}
 

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -176,52 +176,6 @@ class CoBlocks_Getting_Started_Page {
 		</div>
 		<?php
 	}
-
-	/**
-	 * Redirect to the Getting Started page upon plugin activation.
-	 *
-	 * @param string $plugin The activate plugin name.
-	 */
-	public function redirect( $plugin ) {
-
-		if ( 'coblocks/class-coblocks.php' !== $plugin ) {
-
-			return;
-
-		}
-
-		$nonce          = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
-		$activate_multi = filter_input( INPUT_GET, 'activate-multi', FILTER_VALIDATE_BOOLEAN );
-
-		if ( ! $nonce ) {
-
-			return;
-
-		}
-
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-
-			WP_CLI::log(
-				WP_CLI::colorize(
-					'%b' . sprintf( '🎉 %s %s', __( 'Get started with CoBlocks here:', 'coblocks' ), admin_url( 'admin.php?page=coblocks-getting-started' ) ) . '%n'
-				)
-			);
-
-			return;
-
-		}
-
-		if ( $activate_multi ) {
-
-			return;
-
-		}
-
-		wp_safe_redirect( admin_url( 'admin.php?page=coblocks-getting-started' ) );
-
-		die();
-
-	}
 }
 
 return new CoBlocks_Getting_Started_Page();


### PR DESCRIPTION
Pull request to remove redirect action which occurs during plugin activation. We have had a number of support requests arise related to this getting started page. Removing the redirect should be a first step until we can add more value to the getting started page. 

**Related support request**
https://wordpress.org/support/topic/fails-with-wordpress-5-3-beta1-46334/