### PR TITLE
Add icon to Logos & Badges block placeholder

### DIFF
--- a/src/blocks/logos/index.js
+++ b/src/blocks/logos/index.js
@@ -44,4 +44,4 @@ const settings = {
 	save,
 };
 
-export { name, category, metadata, settings };
+export { name, category, metadata, settings, icon };


### PR DESCRIPTION
- Closes #919 
- Add icon for Logos & Badges block to index exports. 

![image](https://user-images.githubusercontent.com/30462574/65993190-97abb600-e445-11e9-9108-ce3718c3365a.png)
