### PR TITLE
Remove category setup from Carousel settings

### DIFF
--- a/src/blocks/gallery-carousel/index.js
+++ b/src/blocks/gallery-carousel/index.js
@@ -33,7 +33,6 @@ const attributes = {
 const settings = {
 	title: _x( 'Carousel', 'block name' ),
 	description: __( 'Display multiple images in a beautiful carousel gallery.' ),
-	category: 'coblocks-galleries',
 	attributes,
 	icon,
 	keywords: [ _x( 'gallery', 'block keyword' ), _x( 'photos', 'block keyword' ) ],


### PR DESCRIPTION
This was left over from block.json refactors. Pull request for code cleanup. 