### PR TITLE
Convert Icon block to use alignment classes

### DIFF
--- a/src/blocks/icon/deprecated.js
+++ b/src/blocks/icon/deprecated.js
@@ -6,12 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-const { RichText, getColorClassName } = wp.blockEditor;
+const { getColorClassName } = wp.blockEditor;
 
 /**
  * Internal dependencies
  */
 import metadata from './block.json';
+import svgs from './svgs';
 
 const deprecated = [
 	{

--- a/src/blocks/icon/deprecated.js
+++ b/src/blocks/icon/deprecated.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+const { RichText, getColorClassName } = wp.blockEditor;
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const deprecated = [
+	{
+		attributes: {
+			...metadata.attributes,
+		},
+		save( { attributes, className } ) {
+			const {
+				icon,
+				backgroundColor,
+				customBackgroundColor,
+				customIconColor,
+				contentAlign,
+				iconColor,
+				height,
+				width,
+				borderRadius,
+				padding,
+				href,
+				linkTarget,
+				rel,
+			} = attributes;
+
+			let iconStyle = 'outlined';
+
+			if ( attributes.className ) {
+				if ( attributes.className.includes( 'is-style-filled' ) ) {
+					iconStyle = 'filled';
+				}
+			}
+
+			const textClass = getColorClassName( 'color', iconColor );
+			const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+
+			const classes = classnames( 'wp-block-coblocks-icon__inner', {
+				'has-text-color': iconColor || customIconColor,
+				[ textClass ]: textClass,
+				'has-background': backgroundColor || customBackgroundColor,
+				[ backgroundClass ]: backgroundClass,
+			} );
+
+			const styles = {
+				backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+				color: textClass ? undefined : customIconColor,
+				fill: textClass ? undefined : customIconColor,
+				height: height,
+				width: width,
+				borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+				padding: padding ? padding + 'px' : undefined,
+			};
+
+			return (
+				<div className={ className } style={ { textAlign: contentAlign ? contentAlign : undefined } }>
+					<div className={ classes } style={ styles }>
+						{ href ?
+							( <a href={ href } target={ linkTarget } rel={ rel }>
+								{ svgs[ iconStyle ][ icon ].icon }
+							</a> ) :
+							svgs[ iconStyle ][ icon ].icon
+						}
+					</div>
+				</div>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -62,7 +62,11 @@ class Edit extends Component {
 			hasContentAlign,
 		} = attributes;
 
-		const classes = classnames( 'wp-block-coblocks-icon__inner', {
+		const classes = classnames( className, {
+			[ `has-text-align-${ contentAlign }` ]: contentAlign,
+		} );
+
+		const innerClasses = classnames( 'wp-block-coblocks-icon__inner', {
 			'has-background': backgroundColor.color,
 			[ backgroundColor.class ]: backgroundColor.class,
 			'has-text-color': iconColor.color,
@@ -70,7 +74,7 @@ class Edit extends Component {
 			'is-selected': isSelected,
 		} );
 
-		const styles = {
+		const innerStyles = {
 			backgroundColor: backgroundColor.color,
 			color: iconColor.color,
 			fill: iconColor.color,
@@ -132,11 +136,10 @@ class Edit extends Component {
 						{ ...this.props }
 					/>
 				) }
-
-				<div className={ className } style={ { textAlign: contentAlign } } >
+				<div className={ classes }>
 					<ResizableBox
-						className={ classes }
-						style={ styles }
+						className={ innerClasses }
+						style={ innerStyles }
 						size={ { width } }
 						minWidth={ padding ? MIN_ICON_SIZE + 28 : MIN_ICON_SIZE }
 						maxWidth={ MAX_ICON_SIZE }

--- a/src/blocks/icon/index.js
+++ b/src/blocks/icon/index.js
@@ -8,6 +8,7 @@ import './styles/style.scss';
  * Internal dependencies
  */
 import edit from './edit';
+import deprecated from './deprecated';
 import icon from './icon';
 import metadata from './block.json';
 import save from './save';
@@ -44,6 +45,7 @@ const settings = {
 	attributes,
 	edit,
 	save,
+	deprecated,
 };
 
 export { name, category, metadata, settings };

--- a/src/blocks/icon/save.js
+++ b/src/blocks/icon/save.js
@@ -41,14 +41,18 @@ const save = ( { attributes, className } ) => {
 	const textClass = getColorClassName( 'color', iconColor );
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 
-	const classes = classnames( 'wp-block-coblocks-icon__inner', {
+	const classes = classnames( className, {
+		[ `has-text-align-${ contentAlign }` ]: contentAlign,
+	} );
+
+	const innerClasses = classnames( 'wp-block-coblocks-icon__inner', {
 		'has-text-color': iconColor || customIconColor,
 		[ textClass ]: textClass,
 		'has-background': backgroundColor || customBackgroundColor,
 		[ backgroundClass ]: backgroundClass,
 	} );
 
-	const styles = {
+	const innerStyles = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
 		color: textClass ? undefined : customIconColor,
 		fill: textClass ? undefined : customIconColor,
@@ -59,8 +63,8 @@ const save = ( { attributes, className } ) => {
 	};
 
 	return (
-		<div className={ className } style={ { textAlign: contentAlign ? contentAlign : undefined } }>
-			<div className={ classes } style={ styles }>
+		<div className={ classes }>
+			<div className={ innerClasses } style={ innerStyles }>
 				{ href ?
 					( <a href={ href } target={ linkTarget } rel={ rel }>
 						{ svgs[ iconStyle ][ icon ].icon }


### PR DESCRIPTION
This PR finishes up the work for #850, which replaces the inline style alignments with `.has-text-align-{value}`. Deprecation has been added to the Icon block.