### PR TITLE
Move deprecations below save function

### DIFF
--- a/src/blocks/click-to-tweet/index.js
+++ b/src/blocks/click-to-tweet/index.js
@@ -36,9 +36,9 @@ const settings = {
 	},
 	attributes,
 	transforms,
-	deprecated,
 	edit,
 	save,
+	deprecated,
 };
 
 export { name, category, metadata, settings };

--- a/src/blocks/gallery-carousel/index.js
+++ b/src/blocks/gallery-carousel/index.js
@@ -54,8 +54,8 @@ const settings = {
 	},
 	transforms,
 	edit,
-	deprecated,
 	save,
+	deprecated,
 };
 
 export { name, category, icon, metadata, settings };

--- a/src/blocks/gallery-masonry/index.js
+++ b/src/blocks/gallery-masonry/index.js
@@ -57,9 +57,9 @@ const settings = {
 	},
 	attributes,
 	transforms,
-	deprecated,
 	edit,
 	save,
+	deprecated,
 };
 
 export { name, category, icon, metadata, settings };

--- a/src/blocks/gallery-stacked/index.js
+++ b/src/blocks/gallery-stacked/index.js
@@ -53,8 +53,8 @@ const settings = {
 	attributes,
 	transforms,
 	edit,
-	deprecated,
 	save,
+	deprecated,
 };
 
 export { name, category, icon, metadata, settings };

--- a/src/blocks/pricing-table/index.js
+++ b/src/blocks/pricing-table/index.js
@@ -40,9 +40,9 @@ const settings = {
 	},
 	attributes,
 	transforms,
-	deprecated,
 	edit,
 	save,
+	deprecated,
 };
 
 export { name, category, metadata, settings };


### PR DESCRIPTION
This PR organizes the block settings by moving the deprecations below the save functions for blocks that don't already do this. 