### PR TITLE
Remove allowedBlocks limitation from the Accordion Item

### DIFF
--- a/src/blocks/accordion/accordion-item/edit.js
+++ b/src/blocks/accordion/accordion-item/edit.js
@@ -21,8 +21,6 @@ const { InnerBlocks, RichText } = wp.blockEditor;
 /**
  * Constants
  */
-const ALLOWED_BLOCKS = [ 'core/button', 'core/paragraph', 'core/heading', 'core/list', 'core/image', 'core/columns', 'core/column', 'coblocks/row', 'coblocks/column', 'coblocks/highlight', 'coblocks/alert', 'coblocks/social' ];
-
 const TEMPLATE = [ [ 'core/paragraph', { placeholder: 'Add content...' } ] ];
 
 /**
@@ -91,7 +89,6 @@ class Edit extends Component {
 						style={ { borderColor: backgroundColor.color } }
 					>
 						<InnerBlocks
-							allowedBlocks={ ALLOWED_BLOCKS }
 							template={ TEMPLATE }
 							templateInsertUpdatesSelection={ false }
 						/>

--- a/src/blocks/accordion/accordion-item/styles/style.scss
+++ b/src/blocks/accordion/accordion-item/styles/style.scss
@@ -46,5 +46,13 @@
 		border-radius: 0 0 $accordion-border-radius $accordion-border-radius;
 		margin-top: -1px;
 		padding: 15px 20px;
+
+		> div {
+			max-width: 100%;
+		}
+	}
+
+	.alignfull img {
+		max-width: 100% !important;
 	}
 }


### PR DESCRIPTION
This PR fixes #888, which was caused by limited the kind of blocks that could be placed within an Accordion Item block. The limitation has been lifted and I added a slight style tweak to ensure that fullwidth images don't flow out of the bounds of the Accordion Item.