### PR TITLE
Remove inherit colors fallback

### DIFF
--- a/src/blocks/author/styles/editor.scss
+++ b/src/blocks/author/styles/editor.scss
@@ -53,17 +53,13 @@
 			}
 
 			svg {
-				fill: #444;
+				fill: $dark-gray-500;
 				margin: auto auto;
 				pointer-events: none;
 				transform: translate3d(0, 0, 0);
 				transition: transform 100ms cubic-bezier(0.645, 0.045, 0.355, 1);
 			}
 		}
-	}
-
-	&.has-text-color p.wp-block-coblocks-author__biography {
-		color: inherit;
 	}
 }
 

--- a/src/blocks/author/styles/style.scss
+++ b/src/blocks/author/styles/style.scss
@@ -24,7 +24,6 @@
 		}
 	}
 
-	.block-editor__container &__avatar-img,
 	&__avatar-img {
 		border-radius: 100%;
 		display: inline-block;

--- a/src/blocks/features/styles/style.scss
+++ b/src/blocks/features/styles/style.scss
@@ -81,19 +81,6 @@
 		}
 	}
 
-	.has-text-color {
-		p,
-		a,
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
-			color: inherit !important;
-		}
-	}
-
 	.wp-block-coblocks-feature__inner {
 		// Add padding so the feature does not run into the viewport edge on mobile.
 		&.has-no-padding {

--- a/src/blocks/media-card/styles/style.scss
+++ b/src/blocks/media-card/styles/style.scss
@@ -139,19 +139,6 @@
 .is-twentynineteen {
 	.entry .entry-content {
 		.wp-block-coblocks-media-card {
-			&__content {
-				p,
-				a,
-				h1,
-				h2,
-				h3,
-				h4,
-				h5,
-				h6 {
-					color: inherit;
-				}
-			}
-
 			@media (min-width: #{ ($break-small-twentynineteen--min) }) and (max-width: #{ ($break-small-twentynineteen) }) {
 				&.is-stacked-on-mobile {
 					flex-direction: column;

--- a/src/blocks/row/styles/editor.scss
+++ b/src/blocks/row/styles/editor.scss
@@ -495,24 +495,6 @@ div[data-type="coblocks/row"].is-resizing .has-huge-gutter .components-resizable
 	}
 }
 
-//Fix background color contrast issue
-body {
-	.editor-styles-wrapper {
-		.wp-block-coblocks-column {
-			p,
-			a,
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				color: inherit;
-			}
-		}
-	}
-}
-
 // Our custom inserter.
 .wp-block-coblocks-column {
 	> .wp-block-coblocks-column__inner {

--- a/src/blocks/row/styles/style.scss
+++ b/src/blocks/row/styles/style.scss
@@ -69,17 +69,6 @@
 		}
 	}
 
-	p,
-	a,
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
-		color: inherit;
-	}
-
 	&__inner {
 		&.has-background-overlay {
 			> * {


### PR DESCRIPTION
This PR resolves #398 which originally was added before color settings used color classes, which add enough specificity to not need inherit fallback - which in itself caused a bunch of style issues. 