### PR TITLE
Tag each release of CoBlocks on the WordPress.org SVN during deployment

### DIFF
--- a/.dev/bin/deploy-plugin.sh
+++ b/.dev/bin/deploy-plugin.sh
@@ -7,6 +7,10 @@ svn co "http://svn.wp-plugins.org/coblocks" $HOME/coblocks
 rm -rf $HOME/coblocks/trunk/*
 cp -a build/coblocks/* $HOME/coblocks/trunk/
 
+# Create the tag on the SVN repo and copy over plugin files
+mkdir $HOME/coblocks/tags/${CIRCLE_TAG}
+cp -a build/coblocks/* $HOME/coblocks/tags/${CIRCLE_TAG}/
+
 # Copy the WordPress.org assets over
 rm -rf $HOME/coblocks/assets/*
 cp -a .wordpress-org/* $HOME/coblocks/assets/

--- a/.dev/bin/deploy-plugin.sh
+++ b/.dev/bin/deploy-plugin.sh
@@ -8,8 +8,8 @@ rm -rf $HOME/coblocks/trunk/*
 cp -a build/coblocks/* $HOME/coblocks/trunk/
 
 # Create the tag on the SVN repo and copy over plugin files
-mkdir $HOME/coblocks/tags/${CIRCLE_TAG}
-cp -a build/coblocks/* $HOME/coblocks/tags/${CIRCLE_TAG}/
+svn cp trunk tags/${CIRCLE_TAG}
+svn commit -m "Tagging version ${CIRCLE_TAG}"
 
 # Copy the WordPress.org assets over
 rm -rf $HOME/coblocks/assets/*


### PR DESCRIPTION
Resolves #905 

Create a tag directory on WordPress.org SVN during plugin deployments.