### PR TITLE
Improve Alert block stability through block validation testing

### DIFF
--- a/src/blocks/alert/deprecated.js
+++ b/src/blocks/alert/deprecated.js
@@ -23,6 +23,10 @@ const deprecated = [
 			customBorderColor: {
 				type: 'string',
 			},
+			type: {
+				type: 'string',
+				default: 'default',
+			},
 		},
 
 		save( { attributes, className } ) {

--- a/src/blocks/alert/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/alert/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/alert should render 1`] = `
+"<!-- wp:coblocks/alert -->
+<div class=\\"wp-block-coblocks-alert\\"></div>
+<!-- /wp:coblocks/alert -->"
+`;

--- a/src/blocks/alert/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/alert/test/__snapshots__/save.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`coblocks/alert should render 1`] = `
-"<!-- wp:coblocks/alert -->
-<div class=\\"wp-block-coblocks-alert\\"></div>
+exports[`coblocks/alert should render with content 1`] = `
+"<!-- wp:coblocks/alert {\\"title\\":\\"Alert title\\"} -->
+<div class=\\"wp-block-coblocks-alert\\"><p class=\\"wp-block-coblocks-alert__title\\">Alert title</p><p class=\\"wp-block-coblocks-alert__text\\">Alert description</p></div>
 <!-- /wp:coblocks/alert -->"
 `;

--- a/src/blocks/alert/test/deprecated.spec.js
+++ b/src/blocks/alert/test/deprecated.spec.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	title: [ undefined, '' ],
+	value: [ undefined, '', [] ],
+	backgroundColor: [ undefined, 'primary' ],
+	customBackgroundColor: [ undefined, '#123456' ],
+	textColor: [ undefined, 'primary' ],
+	customTextColor: [ undefined, '#123456' ],
+	titleColor: [ undefined, 'primary' ],
+	customTitleColor: [ undefined, '#123456' ],
+	borderColor: [ undefined, 'primary' ],
+	customBorderColor: [ undefined, '#123456' ],
+	textAlign: [ undefined, 'left', 'center', 'right' ],
+	type: [ undefined, 'default', 'info', 'success', 'warning', 'error' ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/alert/test/save.spec.js
+++ b/src/blocks/alert/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );

--- a/src/blocks/alert/test/save.spec.js
+++ b/src/blocks/alert/test/save.spec.js
@@ -27,10 +27,14 @@ describe( name, () => {
 		serializedBlock = '';
 	} );
 
-	it( 'should render', () => {
+	it( 'should render with content', () => {
+		block.attributes.title = 'Alert title';
+		block.attributes.value = 'Alert description';
 		serializedBlock = serialize( block );
 
 		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'Alert title' );
+		expect( serializedBlock ).toContain( 'Alert description' );
 		expect( serializedBlock ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
Provides deprecation tests for the Alert block as part of #854. 

```
Test Suites: 2 passed, 2 total
Tests:       59 passed, 59 total
Snapshots:   1 passed, 1 total
Time:        2.504s
```