### PR TITLE
Improve Author block stability through block validation testing

### DIFF
--- a/src/blocks/author/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/author/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/author should render with content 1`] = `
+"<!-- wp:coblocks/author {\\"name\\":\\"Author Name\\"} -->
+<div class=\\"wp-block-coblocks-author\\"><div class=\\"wp-block-coblocks-author__content\\"><span class=\\"wp-block-coblocks-author__name\\">Author Name</span><p class=\\"wp-block-coblocks-author__biography\\">Author biography</p></div></div>
+<!-- /wp:coblocks/author -->"
+`;

--- a/src/blocks/author/test/deprecated.spec.js
+++ b/src/blocks/author/test/deprecated.spec.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	heading: [ undefined, '', 'testing' ],
+	biography: [ undefined, '', 'testing' ],
+	name: [ undefined, '', 'testing' ],
+	imgId: [ undefined, 0, 10 ],
+	imgUrl: [ undefined, '', 'https://website.com/wp-content/uploads/1234/56/image.jpg' ],
+	backgroundColor: [ undefined, 'primary' ],
+	customBackgroundColor: [ undefined, '#123456' ],
+	textColor: [ undefined, 'primary' ],
+	customTextColor: [ undefined, '#123456' ],
+	fontSize: [ undefined, 'small', 'large' ],
+	customFontSize: [ undefined, 0, 16, '0', '16' ],
+	textAlign: [ undefined, 'left', 'center', 'right' ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/author/test/save.spec.js
+++ b/src/blocks/author/test/save.spec.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render with content', () => {
+		block.attributes.name = 'Author Name';
+		block.attributes.biography = 'Author biography';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'Author Name' );
+		expect( serializedBlock ).toContain( 'Author biography' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should not render without content', () => {
+		serializedBlock = serialize( createBlock( name ) );
+		expect( serializedBlock ).toEqual( `<!-- wp:${ name } /-->` );
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Author block as part of #855.

```
Test Suites: 2 passed, 2 total
Tests:       38 passed, 38 total
Snapshots:   1 written, 1 total
Time:        3.293s
```