### PR TITLE
i18n: Remove unnecessary `declare` statement.

### DIFF
--- a/.dev/bin/update-po.sh
+++ b/.dev/bin/update-po.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-declare -A myarray
-
 # Merge coblocks.pot changes into the appropriate .po for each locale in package.json
 LOCALES=$(cat package.json | jq -r '.locales')
 POTPATH='languages';


### PR DESCRIPTION
From what I can tell, the `declare` statement doesn't serve any purpose in the `update-po.sh` script. This PR removes it, which also conveniently avoids a build warning on macOS, where `-A` is not a supported argument.

<img width="682" alt="Screen Shot 2019-10-07 at 1 11 40 PM" src="https://user-images.githubusercontent.com/349751/66345049-0f755700-e904-11e9-8b44-ea9ca865fac8.png">


