### PR TITLE
Improve Button block stability through block validation testing

### DIFF
--- a/src/blocks/buttons/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/buttons/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/buttons should render with content 1`] = `
+"<!-- wp:coblocks/buttons -->
+<div class=\\"wp-block-coblocks-buttons\\"><div class=\\"wp-block-coblocks-buttons__inner flex-align-left\\"></div></div>
+<!-- /wp:coblocks/buttons -->"
+`;

--- a/src/blocks/buttons/test/deprecated.spec.js
+++ b/src/blocks/buttons/test/deprecated.spec.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	items: [ undefined, 0, 1, 3 ],
+	contentAlign: [ 'left', 'center', 'right' ],
+	isStackedOnMobile: [ undefined, true, false ],
+	gutter: [ undefined, 'none', 'small', 'medium', 'large', 'xlarge' ],
+	stacked: [ undefined, true, false ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/buttons/test/save.spec.js
+++ b/src/blocks/buttons/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render with content', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Button block as part of #856. 

```
Test Suites: 2 passed, 2 total
Tests:       21 passed, 21 total
Snapshots:   1 passed, 1 total
Time:        2.751s, estimated 3s
```