### PR TITLE
Improve Click to Tweet block stability through block validation testing

### DIFF
--- a/src/blocks/click-to-tweet/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/click-to-tweet/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/click-to-tweet should render with content 1`] = `
+"<!-- wp:coblocks/click-to-tweet {\\"url\\":\\"https://wordpress.org\\"} -->
+<blockquote class=\\"wp-block-coblocks-click-to-tweet\\"><p class=\\"wp-block-coblocks-click-to-tweet__text\\">Quote to tweet</p><a class=\\"wp-block-coblocks-click-to-tweet__twitter-btn\\" href=\\"http://twitter.com/share?&amp;text=Quote%20to%20tweet&amp;url=https://wordpress.org\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Tweet</a></blockquote>
+<!-- /wp:coblocks/click-to-tweet -->"
+`;

--- a/src/blocks/click-to-tweet/test/deprecated.spec.js
+++ b/src/blocks/click-to-tweet/test/deprecated.spec.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	content: [ undefined, '', 'Text to tweet' ],
+	url: [ undefined ],
+	textAlign: [ undefined, 'left', 'center', 'right' ],
+	via: [ undefined ],
+	buttonText: [ undefined, '', 'Button text' ],
+	buttonColor: [ undefined, 'primary' ],
+	customButtonColor: [ undefined, '#123456' ],
+	textColor: [ undefined, 'primary' ],
+	customTextColor: [ undefined, '#123456' ],
+	fontSize: [ undefined, 'small', 'large' ],
+	customFontSize: [ undefined, 0, 16, '0', '16' ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/click-to-tweet/test/save.spec.js
+++ b/src/blocks/click-to-tweet/test/save.spec.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render with content', () => {
+		block.attributes.content = 'Quote to tweet';
+		block.attributes.buttonText = 'Tweet';
+		block.attributes.url = 'https://wordpress.org';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'Quote to tweet' );
+		expect( serializedBlock ).toContain( 'Tweet' );
+		expect( serializedBlock ).toContain( 'https://wordpress.org' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should not render without content', () => {
+		serializedBlock = serialize( createBlock( name ) );
+		expect( serializedBlock ).toEqual( `<!-- wp:${ name } /-->` );
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Click to Tweet block as part of #857. 

```
Test Suites: 2 passed, 2 total
Tests:       31 passed, 31 total
Snapshots:   1 passed, 1 total
Time:        2.409s
```