### PR TITLE
Improve Accordion block stability through block validation testing

### DIFF
--- a/src/blocks/accordion/accordion-item/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/accordion/accordion-item/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/accordion-item should render with content 1`] = `
+"<!-- wp:coblocks/accordion-item {\\"title\\":\\"Accordion title\\"} -->
+<div class=\\"wp-block-coblocks-accordion-item\\"><details><summary class=\\"wp-block-coblocks-accordion-item__title\\">Accordion title</summary><div class=\\"wp-block-coblocks-accordion-item__content\\"></div></details></div>
+<!-- /wp:coblocks/accordion-item -->"
+`;

--- a/src/blocks/accordion/accordion-item/test/save.spec.js
+++ b/src/blocks/accordion/accordion-item/test/save.spec.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render with content', () => {
+		block.attributes.title = 'Accordion title';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'Accordion title' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );

--- a/src/blocks/accordion/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/accordion/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/accordion should render with content 1`] = `
+"<!-- wp:coblocks/accordion -->
+<div class=\\"wp-block-coblocks-accordion\\"></div>
+<!-- /wp:coblocks/accordion -->"
+`;

--- a/src/blocks/accordion/test/save.spec.js
+++ b/src/blocks/accordion/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render with content', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This block did not have deprecations. Instead I added a basic test on the save function to detect when we need to write a deprecation. Related to #853.

```
Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   2 passed, 2 total
Time:        2.402s
```