### PR TITLE
Improve Features block stability through block validation testing

### DIFF
--- a/src/blocks/features/feature/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/features/feature/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/feature should render 1`] = `
+"<!-- wp:coblocks/feature -->
+<div class=\\"wp-block-coblocks-feature\\"><div class=\\"wp-block-coblocks-feature__inner has-no-padding\\"></div></div>
+<!-- /wp:coblocks/feature -->"
+`;

--- a/src/blocks/features/feature/test/save.spec.js
+++ b/src/blocks/features/feature/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );

--- a/src/blocks/features/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/features/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/features should render 1`] = `
+"<!-- wp:coblocks/features -->
+<div class=\\"wp-block-coblocks-features\\" data-columns=\\"2\\"><div class=\\"wp-block-coblocks-features__inner has-no-padding has-no-margin has-large-gutter has-center-content\\"></div></div>
+<!-- /wp:coblocks/features -->"
+`;

--- a/src/blocks/features/test/save.spec.js
+++ b/src/blocks/features/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This block did not have deprecations. Instead I added a basic test on the save function to detect when we need to write a deprecation. Related to #859.

```
Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   1 written, 1 passed, 2 total
Time:        3.839s
```