### PR TITLE
Food and Drinks block basic save tests

### DIFF
--- a/src/blocks/food-and-drinks/food-item/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/food-and-drinks/food-item/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/food-item should render with content 1`] = `
+"<!-- wp:coblocks/food-item -->
+<div class=\\"wp-block-coblocks-food-item\\" itemscope itemtype=\\"http://schema.org/MenuItem\\"><div class=\\"wp-block-coblocks-food-item__content\\"><div class=\\"wp-block-coblocks-food-item__heading-wrapper\\"><h4 class=\\"wp-block-coblocks-food-item__heading\\" itemprop=\\"name\\">Food item title</h4></div><p class=\\"wp-block-coblocks-food-item__description\\" itemprop=\\"description\\">Food item description</p><p class=\\"wp-block-coblocks-food-item__price\\" itemprop=\\"offers\\" itemscope itemtype=\\"http://schema.org/Offer\\"><span itemprop=\\"price\\">$1.00</span></p></div></div>
+<!-- /wp:coblocks/food-item -->"
+`;

--- a/src/blocks/food-and-drinks/food-item/test/save.spec.js
+++ b/src/blocks/food-and-drinks/food-item/test/save.spec.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render with content', () => {
+		block.attributes.title = 'Food item title';
+		block.attributes.description = 'Food item description';
+		block.attributes.price = '$1.00';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'Food item title' );
+		expect( serializedBlock ).toContain( 'Food item description' );
+		expect( serializedBlock ).toContain( '$1.00' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should not render without content', () => {
+		serializedBlock = serialize( createBlock( name ) );
+		expect( serializedBlock ).toEqual( `<!-- wp:${ name } /-->` );
+	} );
+} );

--- a/src/blocks/food-and-drinks/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/food-and-drinks/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/food-and-drinks should render 1`] = `
+"<!-- wp:coblocks/food-and-drinks -->
+<div class=\\"wp-block-coblocks-food-and-drinks\\" data-columns=\\"2\\" itemscope itemtype=\\"http://schema.org/Menu\\"></div>
+<!-- /wp:coblocks/food-and-drinks -->"
+`;

--- a/src/blocks/food-and-drinks/test/save.spec.js
+++ b/src/blocks/food-and-drinks/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This block did not have deprecations. Instead I added a basic test on the save function to detect when we need to write a deprecation. Related to #860.

```
Test Suites: 2 passed, 2 total
Tests:       3 passed, 3 total
Snapshots:   2 passed, 2 total
Time:        3.274s
```