### PR TITLE
Stacked Gallery block deprecation tests

### DIFF
--- a/src/blocks/gallery-stacked/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/gallery-stacked/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/gallery-stacked should render with images 1`] = `
+"<!-- wp:coblocks/gallery-stacked -->
+<div class=\\"wp-block-coblocks-gallery-stacked alignfull\\"><ul class=\\"coblocks-gallery has-fullwidth-images\\"><li class=\\"coblocks-gallery--item\\"><figure class=\\"coblocks-gallery--figure\\"><img src=\\"https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg\\" data-id=\\"1\\" class=\\"wp-image-1 has-shadow-none\\"/></figure></li></ul></div>
+<!-- /wp:coblocks/gallery-stacked -->"
+`;

--- a/src/blocks/gallery-stacked/test/deprecated.spec.js
+++ b/src/blocks/gallery-stacked/test/deprecated.spec.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	images: [
+		[],
+		[ { url: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', id: 1, href: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', caption: 'image-1 caption' } ],
+	],
+	linkTo: [ undefined, 'none', 'media', 'attachment', 'custom' ],
+	target: [],
+	rel: [],
+	align: [ '', 'wide', 'full', 'left', 'center', 'right' ],
+	gutter: [ undefined, 'none', 'small', 'medium', 'large', 'xlarge' ],
+	gutterMobile: [ undefined, 'none', 'small', 'medium', 'large', 'xlarge' ],
+	radius: [ undefined, 0, 20 ],
+	shadow: [ undefined, 'none', 'sml', 'med', 'lrg', 'xlrg' ],
+	filter: [],
+	captions: [],
+	captionStyle: [ undefined, 'none', 'dark', 'light' ],
+	captionColor: [ undefined, 'primary' ],
+	customCaptionColor: [ undefined, '#123456' ],
+	fontSize: [ undefined, 'small', 'large' ],
+	customFontSize: [ undefined, 0, 16, '0', '16' ],
+	primaryCaption: [],
+	backgroundRadius: [ undefined, 0, 20 ],
+	backgroundPadding: [ undefined, 'none', 'small', 'medium', 'large', 'xlarge' ],
+	backgroundPaddingMobile: [ undefined, 'none', 'small', 'medium', 'large', 'xlarge' ],
+	lightbox: [ undefined, true, false ],
+	fullWidth: [ undefined, true, false ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/gallery-stacked/test/save.spec.js
+++ b/src/blocks/gallery-stacked/test/save.spec.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render with images', () => {
+		block.attributes.images = [
+			{ url: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', id: 1 },
+		];
+
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg' );
+		expect( serializedBlock ).toContain( 'data-id="1"' );
+		expect( serializedBlock ).toContain( 'wp-image-1' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Stacked Gallery block as part of #864.

```
Test Suites: 1 passed, 1 total
Tests:       138 passed, 138 total
Snapshots:   0 total
Time:        4.062s
```