### PR TITLE
Improve Masonry Gallery block stability through block validation testing

### DIFF
--- a/src/blocks/gallery-masonry/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/gallery-masonry/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/gallery-masonry should render 1`] = `
+"<!-- wp:coblocks/gallery-masonry -->
+<div class=\\"wp-block-coblocks-gallery-masonry\\"><div class=\\"coblocks-gallery has-no-alignment has-caption-style-dark has-gutter\\"><ul class=\\"has-grid-xlrg has-gutter-15 has-gutter-mobile-15\\"><li class=\\"coblocks-gallery--item\\"><figure class=\\"coblocks-gallery--figure\\"><img src=\\"https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg\\" data-id=\\"1\\" class=\\"wp-image-1\\"/></figure></li></ul></div></div>
+<!-- /wp:coblocks/gallery-masonry -->"
+`;

--- a/src/blocks/gallery-masonry/test/deprecated.spec.js
+++ b/src/blocks/gallery-masonry/test/deprecated.spec.js
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	images: [
+		[],
+		[ { url: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', id: 1, href: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', caption: 'image-1 caption' } ],
+	],
+	linkTo: [ undefined, 'none', 'media', 'attachment', 'custom' ],
+	target: [ '', '_blank', '_self', '_parent' ],
+	rel: [ '', 'alternate', 'author', 'preload' ],
+	align: [ '', 'wide', 'full', 'left', 'center', 'right' ],
+	gutter: [ 0, 10, 100 ],
+	gutterMobile: [ 0, 10, 100 ],
+	radius: [ undefined, 0, 20 ],
+	shadow: [ undefined, 'none', 'sml', 'med', 'lrg', 'xlrg' ],
+	filter: [ 'none', 'grayscale', 'sepia', 'saturation', 'dim', 'vintage' ],
+	captions: [ undefined, true, false ],
+	captionStyle: [ 'none', 'dark', 'light' ],
+	captionColor: [ undefined, 'primary' ],
+	customCaptionColor: [ undefined, '#123456' ],
+	fontSize: [ undefined, 'small', 'large' ],
+	customFontSize: [ undefined, 0, 16, '0', '16' ],
+	primaryCaption: [ undefined, '', 'caption text' ],
+	backgroundRadius: [ undefined, 0, 20 ],
+	backgroundPadding: [ undefined, 'none', 'small', 'medium', 'large', 'xlarge' ],
+	backgroundPaddingMobile: [ undefined, 'none', 'small', 'medium', 'large', 'xlarge' ],
+	lightbox: [ undefined, true, false ],
+	backgroundType: [ undefined, '', 'image', 'video' ],
+	backgroundImg: [ undefined, '', 'https://website.com/wp-content/uploads/1234/56/image.jpg', 'https://website.com/wp-content/uploads/1234/56/video.mp4' ],
+	backgroundPosition: [ undefined, '' ],
+	backgroundRepeat: [ 'no-repeat', 'repeat', 'repeat-x', 'repeat-y' ],
+	backgroundSize: [ 'cover', 'contain' ],
+	backgroundOverlay: [ 0, 100 ],
+	backgroundColor: [ undefined, 'primary' ],
+	customBackgroundColor: [ '#123456' ],
+	hasParallax: [ undefined, true, false ],
+	focalPoint: [ undefined, { x: 0, y: 0 }, { x: 0.33663366336633666, y: 0.8335193452380952 } ],
+	videoMuted: [ undefined, true, false ],
+	videoLoop: [ undefined, true, false ],
+	openPopover: [ undefined, true, false ],
+	gridSize: [ 'none', 'sml', 'med', 'lrg', 'xlrg' ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/gallery-masonry/test/save.spec.js
+++ b/src/blocks/gallery-masonry/test/save.spec.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		block.attributes.images = [
+			{ url: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', id: 1 },
+		];
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg' );
+		expect( serializedBlock ).toContain( 'data-id="1"' );
+		expect( serializedBlock ).toContain( 'wp-image-1' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Masonry Gallery block as part of #863.

```
Test Suites: 2 passed, 2 total
Tests:       317 passed, 317 total
Snapshots:   1 passed, 1 total
Time:        4.653s
```