### PR TITLE
Improve Carousel Gallery block stability through block validation testing

### DIFF
--- a/src/blocks/gallery-carousel/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/gallery-carousel/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/gallery-carousel should render 1`] = `
+"<!-- wp:coblocks/gallery-carousel -->
+<div class=\\"wp-block-coblocks-gallery-carousel\\"><div class=\\"is-cropped coblocks-gallery has-no-alignment has-caption-style-dark has-horizontal-gutter\\"><div class=\\"has-carousel has-carousel-lrg\\" style=\\"height:400px\\" data-flickity=\\"{&quot;autoPlay&quot;:false,&quot;draggable&quot;:true,&quot;pageDots&quot;:false,&quot;prevNextButtons&quot;:true,&quot;wrapAround&quot;:true,&quot;cellAlign&quot;:&quot;center&quot;,&quot;pauseAutoPlayOnHover&quot;:false,&quot;freeScroll&quot;:false,&quot;arrowShape&quot;:{&quot;x0&quot;:10,&quot;x1&quot;:60,&quot;y1&quot;:50,&quot;x2&quot;:65,&quot;y2&quot;:45,&quot;x3&quot;:20},&quot;thumbnails&quot;:false,&quot;responsiveHeight&quot;:false}\\"><div class=\\"coblocks-gallery--item\\"><figure class=\\"coblocks-gallery--figure has-margin-left-5 has-margin-left-mobile-5 has-margin-right-5 has-margin-right-mobile-5\\"><img src=\\"https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg\\" data-id=\\"1\\" class=\\"wp-image-1\\"/></figure></div></div></div></div>
+<!-- /wp:coblocks/gallery-carousel -->"
+`;

--- a/src/blocks/gallery-carousel/test/deprecated.spec.js
+++ b/src/blocks/gallery-carousel/test/deprecated.spec.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	images: [
+		[],
+		[ { url: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', id: 1, href: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', caption: 'image-1 caption' } ],
+	],
+	linkTo: [ undefined, 'none', 'media', 'attachment', 'custom' ],
+	target: [ '', '_blank', '_self', '_parent' ],
+	rel: [ '', 'alternate', 'author', 'preload' ],
+	align: [ '', 'wide', 'full', 'left', 'center', 'right' ],
+	gutter: [ 0, 10, 100 ],
+	gutterMobile: [ 0, 10, 100 ],
+	radius: [ undefined, 0, 20 ],
+	shadow: [ undefined, 'none', 'sml', 'med', 'lrg', 'xlrg' ],
+	filter: [ 'none', 'grayscale', 'sepia', 'saturation', 'dim', 'vintage' ],
+	captions: [ undefined, true, false ],
+	captionStyle: [ 'none', 'dark', 'light' ],
+	captionColor: [ undefined, 'primary' ],
+	customCaptionColor: [ undefined, '#123456' ],
+	fontSize: [ undefined, 'small', 'large' ],
+	customFontSize: [ undefined, 0, 16, '0', '16' ],
+	primaryCaption: [ undefined, '', 'caption text' ],
+	backgroundRadius: [ undefined, 0, 20 ],
+	backgroundPadding: [ undefined, 'none', 'small', 'medium', 'large', 'xlarge' ],
+	backgroundPaddingMobile: [ undefined, 'none', 'small', 'medium', 'large', 'xlarge' ],
+	lightbox: [ undefined, true, false ],
+	backgroundType: [ undefined, '', 'image', 'video' ],
+	backgroundImg: [ undefined, '', 'https://website.com/wp-content/uploads/1234/56/image.jpg', 'https://website.com/wp-content/uploads/1234/56/video.mp4' ],
+	backgroundPosition: [ undefined, '' ],
+	backgroundRepeat: [ 'no-repeat', 'repeat', 'repeat-x', 'repeat-y' ],
+	backgroundSize: [ 'cover', 'contain' ],
+	backgroundOverlay: [ 0, 100 ],
+	backgroundColor: [ undefined, 'primary' ],
+	customBackgroundColor: [ '#123456' ],
+	hasParallax: [ undefined, true, false ],
+	focalPoint: [ undefined, { x: 0, y: 0 }, { x: 0.33663366336633666, y: 0.8335193452380952 } ],
+	videoMuted: [ undefined, true, false ],
+	videoLoop: [ undefined, true, false ],
+	openPopover: [ undefined, true, false ],
+	gridSize: [ 'none', 'sml', 'med', 'lrg', 'xlrg' ],
+	height: [ undefined, 0, 400 ],
+	pageDots: [ undefined, true, false ],
+	prevNextButtons: [ undefined, true, false ],
+	autoPlay: [ undefined, true, false ],
+	autoPlaySpeed: [ undefined, 0, 1000, 3000 ],
+	draggable: [ undefined, true, false ],
+	alignCells: [ undefined, true, false ],
+	pauseHover: [ undefined, true, false ],
+	freeScroll: [ undefined, true, false ],
+	thumbnails: [ undefined, true, false ],
+	responsiveHeight: [ undefined, true, false ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/gallery-carousel/test/save.spec.js
+++ b/src/blocks/gallery-carousel/test/save.spec.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		block.attributes.images = [
+			{ url: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', id: 1 },
+		];
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg' );
+		expect( serializedBlock ).toContain( 'data-id="1"' );
+		expect( serializedBlock ).toContain( 'wp-image-1' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Carousel Gallery block as part of #862.

```
Test Suites: 2 passed, 2 total
Tests:       610 passed, 610 total
Snapshots:   1 passed, 1 total
Time:        4.867s
```