### PR TITLE
Add a CODEOWNERS file for GitHub to provide better reviewer suggestions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+@richtabor
+@jrtashjian
+@EvanHerman
+@paranoia1906


### PR DESCRIPTION
This file basically recommends each of us as a reviewer when a PR is submitted. Right now when we've been submitting PRs, we've had to search for each person to request a review from. With this change we will display right in the suggested reviewers section with "Request" links.