### PR TITLE
Prevent the Block Manager from loading in WordPress 5.2+

### DIFF
--- a/src/sidebars/block-manager/deprecated.js
+++ b/src/sidebars/block-manager/deprecated.js
@@ -58,6 +58,6 @@ function deprecateBlockManager() {
 	} );
 }
 
-if ( typeof dispatcher !== 'undefined' || ! dispatcher.hasOwnProperty( 'hideBlockTypes' ) ) {
+if ( typeof dispatcher !== 'undefined' && ! Object.keys( dispatcher ).includes( 'hideBlockTypes' ) ) {
 	deprecateBlockManager();
 }

--- a/src/sidebars/block-manager/index.js
+++ b/src/sidebars/block-manager/index.js
@@ -14,7 +14,7 @@ const dispatcher = dispatch( 'core/edit-post' );
 /**
  * Register Plugin
  */
-if ( typeof dispatcher !== 'undefined' || ! dispatcher.hasOwnProperty( 'hideBlockTypes' ) ) {
+if ( typeof dispatcher !== 'undefined' && ! Object.keys( dispatcher ).includes( 'hideBlockTypes' ) ) {
 	registerPlugin( 'coblocks-block-manager', {
 		icon: false,
 		render: ModalSettings,


### PR DESCRIPTION
We had a minor regression after merging #948 that is causing our custom Block Manager to load even if we detect the Block Manager exists in Core. The issue surrounds the conditional around checking for this existence before loading our plugin.

This PR fixes that conditional and improves its detection slightly.

**NOTE** This regression was not deployed to users but needs to be resolved before the next release.