### PR TITLE
Improve the Map block Google Maps API key UX

### DIFF
--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -204,7 +204,7 @@ class Inspector extends Component {
 						initialOpen={ false }
 						className="components-coblocks-block-settings-sidebar"
 					>
-						<p>{ __( 'Add your Google Maps API key. Updating this API key will set all your maps to use the new key.' ) }</p>
+						<p>{ __( 'Add a Google Maps API key. Updating this API key will set all your maps to use the new key.' ) }</p>
 						{ apiKey === '' &&
 							<p>
 								<ExternalLink href={ RETRIEVE_KEY_URL }>{ __( 'Retrieve your key' ) }</ExternalLink>|&nbsp;

--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -17,7 +17,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl, RangeControl, TextControl, Button, ButtonGroup, ExternalLink } from '@wordpress/components';
 import { ENTER } from '@wordpress/keycodes';
 
-const RETRIEVE_KEY_URL = 'https://cloud.google.com/maps-platform';
+const GET_KEY_URL = 'https://cloud.google.com/maps-platform';
 const HELP_URL = 'https://developers.google.com/maps/documentation/javascript/get-api-key';
 
 class Inspector extends Component {
@@ -207,7 +207,7 @@ class Inspector extends Component {
 						<p>{ __( 'Add a Google Maps API key. Updating this API key will set all your maps to use the new key.' ) }</p>
 						{ apiKey === '' &&
 							<p>
-								<ExternalLink href={ RETRIEVE_KEY_URL }>{ __( 'Retrieve your key' ) }</ExternalLink>|&nbsp;
+								<ExternalLink href={ GET_KEY_URL }>{ __( 'Get ar key' ) }</ExternalLink>|&nbsp;
 								<ExternalLink href={ HELP_URL }>{ __( 'Need help?' ) }</ExternalLink>
 							</p>
 						}

--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -39,6 +39,10 @@ class Inspector extends Component {
 		this.handleKeyDown = this.handleKeyDown.bind( this );
 	}
 
+	componentDidMount() {
+		this.setState( { apiKey: this.props.apiKey } );
+	}
+
 	setControls() {
 		const {
 			setAttributes,
@@ -207,7 +211,7 @@ class Inspector extends Component {
 						<p>{ __( 'Add a Google Maps API key. Updating this API key will set all your maps to use the new key.' ) }</p>
 						{ apiKey === '' &&
 							<p>
-								<ExternalLink href={ GET_KEY_URL }>{ __( 'Get ar key' ) }</ExternalLink>|&nbsp;
+								<ExternalLink href={ GET_KEY_URL }>{ __( 'Get a key.' ) }</ExternalLink>|&nbsp;
 								<ExternalLink href={ HELP_URL }>{ __( 'Need help?' ) }</ExternalLink>
 							</p>
 						}
@@ -223,7 +227,7 @@ class Inspector extends Component {
 							onClick={ this.updateApiKey }
 							disabled={ ( this.state.apiKey === '' ) || ( this.state.apiKey === this.props.apiKey ) }
 						>
-							{ this.props.attributes.hasApiKey ? __( 'Saved' ) : __( 'Save' ) }
+							{ ( this.state.apiKey === this.props.apiKey && this.props.apiKey !== '' ) ? __( 'Saved' ) : __( 'Save' ) }
 						</Button>
 						{ apiKey &&
 						<Button

--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -212,7 +212,7 @@ class Inspector extends Component {
 						<p>{ __( 'Add a Google Maps API key. Updating this API key will set all your maps to use the new key.' ) }</p>
 						{ apiKey === '' &&
 							<p>
-								<ExternalLink href={ GET_KEY_URL }>{ __( 'Get a key.' ) }</ExternalLink>|&nbsp;
+								<ExternalLink href={ GET_KEY_URL }>{ __( 'Get a key' ) }</ExternalLink>|&nbsp;
 								<ExternalLink href={ HELP_URL }>{ __( 'Need help?' ) }</ExternalLink>
 							</p>
 						}

--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -225,6 +225,7 @@ class Inspector extends Component {
 						>
 							{ this.props.attributes.hasApiKey ? __( 'Saved' ) : __( 'Save' ) }
 						</Button>
+						{ apiKey &&
 						<Button
 							className="components-block-coblocks-map-api-key-remove__button"
 							isDefault
@@ -233,6 +234,7 @@ class Inspector extends Component {
 						>
 							{ __( 'Remove' ) }
 						</Button>
+						}
 					</PanelBody>
 				</InspectorControls>
 			</Fragment>


### PR DESCRIPTION
Closes #918

Added `componentDidMount` function to reassign the state for the `apiKey`. This makes it so that the input field is autofilled with the 'saved' `apiKey` whenever the inspector is opened.

![mapSaveApiButton](https://user-images.githubusercontent.com/30462574/66611465-82d0d000-eb73-11e9-8984-924c486b5359.gif)


