### PR TITLE
Convert map height slider control to number input

### DIFF
--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -133,7 +133,6 @@ class Inspector extends Component {
 										onChange={ ( event ) => setAttributes( { height: parseInt( event.target.value, 10 ) } ) }
 										value={ height }
 										min={ 200 }
-										max={ 1000 }
 										step={ 10 }
 									/>
 								</BaseControl>

--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -125,15 +125,6 @@ class Inspector extends Component {
 					{ address &&
 						<PanelBody title={ __( 'Map Settings' ) }>
 							<Fragment>
-								<RangeControl
-									label={ __( 'Zoom Level' ) }
-									value={ zoom }
-									onChange={ ( nextZoom ) => setAttributes( { zoom: nextZoom } ) }
-									className="components-block-coblocks-map-zoom__custom-input"
-									min={ 5 }
-									max={ 20 }
-									step={ 1 }
-								/>
 								<BaseControl label={ __( 'Height in pixels' ) }>
 									<input
 										type="number"
@@ -146,6 +137,15 @@ class Inspector extends Component {
 										step={ 10 }
 									/>
 								</BaseControl>
+								<RangeControl
+									label={ __( 'Zoom Level' ) }
+									value={ zoom }
+									onChange={ ( nextZoom ) => setAttributes( { zoom: nextZoom } ) }
+									className="components-block-coblocks-map-zoom__custom-input"
+									min={ 5 }
+									max={ 20 }
+									step={ 1 }
+								/>
 								{
 									!! apiKey &&
 									<RangeControl

--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -14,7 +14,7 @@ import { styleOptions } from './styles';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, RangeControl, TextControl, Button, ButtonGroup, ExternalLink } from '@wordpress/components';
+import { BaseControl, PanelBody, ToggleControl, RangeControl, TextControl, Button, ButtonGroup, ExternalLink } from '@wordpress/components';
 import { ENTER } from '@wordpress/keycodes';
 
 const RETRIEVE_KEY_URL = 'https://cloud.google.com/maps-platform';
@@ -134,16 +134,18 @@ class Inspector extends Component {
 									max={ 20 }
 									step={ 1 }
 								/>
-								<RangeControl
-									label={ __( 'Height in pixels' ) }
-									aria-label={ __( 'Height for the map in pixels' ) }
-									value={ height }
-									onChange={ ( event ) => setAttributes( { height: parseInt( event.target.value, 10 ) } ) }
-									className="components-block-coblocks-height__custom-input"
-									min={ 200 }
-									max={ 1000 }
-									step={ 10 }
-								/>
+								<BaseControl label={ __( 'Height in pixels' ) }>
+									<input
+										type="number"
+										aria-label={ __( 'Height for the map in pixels' ) }
+										className="components-block-coblocks-height__custom-input"
+										onChange={ ( event ) => setAttributes( { height: parseInt( event.target.value, 10 ) } ) }
+										value={ height }
+										min={ 200 }
+										max={ 1000 }
+										step={ 10 }
+									/>
+								</BaseControl>
 								{
 									!! apiKey &&
 									<RangeControl


### PR DESCRIPTION
Resolves #950 

- Updated the 'Height in pixels' slider to a number input, to follow Gutenberg's UX pattern.
- Also, Shifted the 'Height in pixels' control above the 'Zoom Level' settings, as this looked better than having the number input in between the two slider controls.
- Removed `max` attribute from height input, so the input field width better adheres to Gutenberg's UX pattern.
________________
### New UI
<img src="https://user-images.githubusercontent.com/5321364/66661074-6042c380-ec14-11e9-8c45-7d4e1664f67f.png" width="250" />
