### PR TITLE
Fix .pot/.po translations, add i18n generation to build process

### DIFF
--- a/.dev/bin/update-po.sh
+++ b/.dev/bin/update-po.sh
@@ -6,5 +6,5 @@ POTPATH='languages';
 
 while IFS="=" read -r KEY value
 do
-	msgmerge --update "${POTPATH}/coblocks-${KEY}.po" "${POTPATH}/coblocks.pot"
+	msgmerge -vU "${POTPATH}/coblocks-${KEY}.po" "${POTPATH}/coblocks.pot"
 done < <(echo $LOCALES | jq -r "to_entries|map(\"\(.key)=\(.value)\")|.[]")

--- a/languages/coblocks-da_DK.po
+++ b/languages/coblocks-da_DK.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Vis åben"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Tilføj harmonikatitel ..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Harmonikaemne"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Tilføj harmonikagenstande som kan skjules til harmonikaer."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "faneblade"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "ofte stillede spørgsmål"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,39 @@ msgstr "Harmonikaemner åbent som standard."
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Skift for at indstille dette harmonikaemne til at være åbent som standard."
+msgstr ""
+"Skift for at indstille dette harmonikaemne til at være åbent som standard."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Indstillinger for harmonikaemne"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Vis åben"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Farveindstillinger"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Baggrundsfarve"
@@ -103,14 +64,6 @@ msgstr "Baggrundsfarve"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Farve for titeltekst"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Tilføj harmonikaemne"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Harmonika"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +79,83 @@ msgstr "Understøttelse af Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Tilføj understøttelse af Internet Explorer ved at indlæse JavaScript-polyfill."
+msgstr ""
+"Tilføj understøttelse af Internet Explorer ved at indlæse JavaScript-"
+"polyfill."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Understøtter Internet Explorer ved at indlæse JavaScript-polyfill på denne side."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Understøtter Internet Explorer ved at indlæse JavaScript-polyfill på denne "
+"side."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Advarsel"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Fejl"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Meddelelsestype"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Standardindstilling"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Info"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Handlingen lykkedes"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Skriv titel ..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Skriv tekst ..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Advarsel"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Giv kontekstbaserede tilbagemeldinger."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "bemærkning"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "besked"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Tekstfarver"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Rediger billede"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Rediger galleri"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Fjern billede"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Skriv billedtekst ..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Giv slip for at tilføje som avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Overskrift ..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Forfatterens navn"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Skriv biografi"
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Formularindstillinger"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Forfatter"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Tilføj en forfatterbiografi."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografi"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profil"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "Knapper"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "Få besøgende til at udføre en handling med flere knapper side om side."
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "link"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Indstillinger for knap"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Stablet på mobil"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "Knapper"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +173,25 @@ msgstr "Twitter-brugernavn"
 msgid "Username"
 msgstr "Brugernavn"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Tilføj knap ..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Tilføj et citat i tweet ..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Klik for at tweete"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Tilføj et citat som dine læsere kan tweete via Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "del"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +199,18 @@ msgid "Text Settings"
 msgstr "Tekstindstillinger"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Knapfarve"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynamisk HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Tilføj definerbar afstand mellem andre blokke."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "afstand"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Dynamiske HR-indstillinger"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Højde i pixels"
 
@@ -347,17 +222,12 @@ msgstr "Højde for det dynamiske separatorelement i pixels."
 msgid "Color"
 msgstr "Farve"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Indstil som baggrund"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Funktion"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "En enkelt underordnet kolonne i en overordnet funktionsblok."
 
@@ -366,73 +236,56 @@ msgid "Feature Settings"
 msgstr "Funktionsindstillinger"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Polstring"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Funktioner"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Tilføj op til tre kolonner med små bemærkninger til dit produkt eller din tjeneste."
+msgstr ""
+"Tilføj op til tre kolonner med små bemærkninger til dit produkt eller din "
+"tjeneste."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "serviceydelser"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Margin"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Indbindingsmargin"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Afstand mellem hver kolonne."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Lille"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Medium"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +295,8 @@ msgstr "Stor"
 msgid "Features Settings"
 msgstr "Funktionsindstillinger"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Kolonner"
 
@@ -455,76 +308,72 @@ msgstr "Tilføj menuafsnit"
 msgid "Menu title..."
 msgstr "Menutitel ..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Net"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Liste"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Giv slip på billede for at erstatte"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Fjern billede"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Tilføj titel ..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Krydret"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Hot"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetarisk"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Glutenfri"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescetarisk"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Veganer"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Tilføj beskrivelse ..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0.00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Fødevare"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "En mad & drikke-genstand i blokken Mad & Drikke."
 
@@ -560,62 +409,46 @@ msgstr "Skift for at vise prisen for dette emne."
 msgid "Item Attributes"
 msgstr "Emneattributter"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Mere krydret"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Billedindstillinger"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Alternativ tekst"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Beskriv formålet med billedet"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Lad stå tomt hvis billedet blot er dekorativt."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Fokuspunkt"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Mad & drikke"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Vis en menu eller prisliste"
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restaurant"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menu"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Stil"
@@ -648,134 +481,86 @@ msgstr "Viser prisen for hvert emne"
 msgid "Toggle to show the price of each item."
 msgstr "Slå til for at vise prisen for hvert emne."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "E-mail"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "e-mail"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "mail"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Et felt til mailadresse."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Besked"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Tekstområde"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Flerlinjet tekst"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "En tekstboks til længere besvarelser."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s er ikke en gyldig mailadresse."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s og %s er ikke en gyldig mailadresse."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s er ikke en gyldig mailadresse."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "E-mailadresse"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "navn@eksempel.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Emne"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Formularindstillinger"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Tilføj dit reCAPTCHA-site og hemmelige nøgler for at beskytte din formular mod spam."
+msgstr ""
+"Tilføj dit reCAPTCHA-site og hemmelige nøgler for at beskytte din formular "
+"mod spam."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Generér nøgler"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Mine nøgler"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Få hjælp"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Sitenøgle"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Hemmelig nøgle"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Gemmer"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Gem"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Fjern"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Første"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Sidste"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Navn"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Et tekstfelt til navne."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Et felt til mailadresse."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Tilføj mærkat ..."
 
@@ -783,41 +568,38 @@ msgstr "Tilføj mærkat ..."
 msgid "Required"
 msgstr "Obligatorisk"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Indstillinger for navnefelt"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Efternavn"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Viser felter til både fornavn og efternavn."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Slå til for at tilføje et felt til efternavn."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Formular"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Et tekstfelt til navne."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "En tekstboks til længere besvarelser."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Tilføj en enkel fomular på din side."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "e-mail"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "om"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "kontakt"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Emne"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +609,219 @@ msgstr "Tilføj tekst ..."
 msgid "Button Text Color"
 msgstr "Farve for knaptekst"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Rediger galleri"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Karrusel"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "billede %1$d a %2$d i galleri"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Skriv billedtekst ..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Karrusel"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Viser flere billeder i et smukt karruselgalleri."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galleri"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "fotos"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s indstillinger"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Linjehøjde"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Viser pile til priknavigation."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Slå til for at vise medietekster."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Farveindstillinger"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Størrelse"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Runde hjørner"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Tekstfarve"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Anvend"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Mursten"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Skriv beskrivelse ..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Viser flere billeder i et velorganiseret murstensgalleri."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Viser flere billeder i et smukt karruselgalleri."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Søjlestørrelse"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Billedindstillinger"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Tilføj runde hjørner til galleriemner."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Skygge"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Billedtekster"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Tekststil"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Viser tekst til hvert medieemne."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Slå til for at vise medietekster."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Mursten"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Viser flere billeder i et velorganiseret murstensgalleri."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Slå til for at aktivere indstillinger for kortstyring."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Kortindstillinger"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Søjlestørrelse"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Tilføj runde hjørner til galleriemner."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Lys"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Stablet"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Viser et galleri med flere billeder stablet i en enkel kolonne."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Billeder i fuld bredde"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Billede i fuld bredde"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Boksskygge"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Billeder i fuld bredde er aktiveret."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Slå til for at fylde den tilgængelige plads i galleriet med billeder i fuld bredde."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Slå til for at fylde den tilgængelige plads i galleriet med billeder i fuld "
+"bredde."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Emneindstillinger"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Billeder i fuld bredde"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Billede i fuld bredde"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Fjern gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Denne gif har en tom alt-attribut"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Søg efter den perfekte gif på Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Søg efter gifs"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Vælg en vilkårlig gif"
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animeret"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +847,11 @@ msgstr "GitHub-fil"
 msgid "File"
 msgstr "Fil"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Vis denne gist på GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist-webadresse"
 
@@ -1024,12 +864,9 @@ msgid "Loading Gist"
 msgstr "Indlæser Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Indlejr gists fra GitHub ved at tilføje gist-linket."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "kode"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +889,159 @@ msgid "Gist Meta"
 msgstr "Gist-meta"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Skift layout"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Tilføj baggrund til %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Et introduktionsområde på en side ledsaget af en lille mængde tekst og en "
+"opfordring til handling."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Et introduktionsområde på en side ledsaget af en lille mængde tekst og en opfordring til handling."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "knap"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "opfordring til handling"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Bredde af materiale i pixels"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Hero-indstillinger"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Plads i objektbeholderen"
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Øverst til venstre"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Øverst i midten"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Øverst til højre"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "I midten til venstre"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Centrum"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "I midten til højre"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Nederst til venstre"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Nederst i midten"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Nederst til højre"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Tilføj fremhævet tekst ..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Fremhævning"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Fremhæv tekst."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "tekst"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "afsnit"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Ikon"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Tilføj et stiliseret grafisk symbol som signalerer noget mere."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "ikoner"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Stor"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Tilføj et stiliseret grafisk symbol som signalerer noget mere."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Ikonindstillinger"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Slå aktiverede indstillinger for %s fra"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Nulstil"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Tilpas %s størrelse"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Avancerede indstillinger for %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Brugerdefineret"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Avanceret"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Radius"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Ikonsøgning"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Der er ikke fundet resultater."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Link-indstillinger‌‌"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "Link URL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Link Rel"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Åbner i et nyt faneblad"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Åbn i et nyt faneblad"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Ikonfarver"
 
@@ -1261,30 +1050,18 @@ msgid "Edit logos"
 msgstr "Rediger logoer"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logoer og badges"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr "Træk billeder, upload nye, eller vælg filer fra dit bibliotek."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Tilføj logoer, badges eller certifikater for at få større troværdighed."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "kunder"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "beviser"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "anbefalinger"
+msgstr ""
+"Tilføj logoer, badges eller certifikater for at få større troværdighed."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1083,142 @@ msgstr "Rediger beliggenhed"
 msgid "Map style"
 msgstr "Kortstil"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Ugyldig API-nøgle eller for mange anmodninger"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google kort"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Angiv en placering eller adresse for at sætte en markør på et Google-kort."
+msgstr ""
+"Angiv en placering eller adresse for at sætte en markør på et Google-kort."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Søg efter et sted eller en adresse ..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Anvend"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Kort"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Tilføj en adresse, og sæt en markør på et Google-kort."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "adresse"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "kort"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Vælg kortstil"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Kortindstillinger"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Zoomniveau"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Højde på kortet i pixels"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Zoomniveau"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Markørstørrelse"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Finjustering er aktiveret."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Slå til for at aktivere indstillinger for kortstyring."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Kortindstillinger"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Korttype"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "Mulighed for at skifte mellem standard- og satellitvisning er aktiveret."
+msgstr ""
+"Mulighed for at skifte mellem standard- og satellitvisning er aktiveret."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Slå til for at aktivere mulighed for at skifte mellem standard- og satellitkort."
+msgstr ""
+"Slå til for at aktivere mulighed for at skifte mellem standard- og "
+"satellitkort."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Zoomknapper"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Viser zoomknapper på kortet."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "Slå til for at aktivere zoom ind og ud på kortet med zoomknapperne."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Street View"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Viser knapper på kortet til street view."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "Slå til for at vise knapper til street view nederst til højre."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Skift til fuld skærm"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Viser knap til fuld skærm på kortet."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Slå til for at vise fuld skærm på kortet."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google Maps API-nøgle"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Tilføj din Google Maps API-nøgle. Hvis du opdaterer denne API-nøgle, bliver alle dine kort indstillet til at benytte den nye nøgle."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Tilføj din Google Maps API-nøgle. Hvis du opdaterer denne API-nøgle, bliver "
+"alle dine kort indstillet til at benytte den nye nøgle."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Hent din nøgle"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Har du brug for hjælp?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Indtast Google API-nøgle ..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Gemt"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standard"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Sølv"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Mørk"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Nat"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Aubergine"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1228,9 @@ msgstr "Medier til højre"
 msgid "Media on left"
 msgstr "Medier til venstre"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Mediekort"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Tilføj et billede eller en video med et forskudt kort side om side."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "billede"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1244,18 @@ msgstr "Viser kortskygge."
 msgid "Toggle to add a card shadow."
 msgstr "Slå til for at tilføje en kortskygge."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s Skygge"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Viser %s-skygge."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Slå til for at tilføje en %s-skygge"
 
@@ -1545,40 +1279,171 @@ msgstr "Giv slip for at erstatte medie"
 msgid "Edit media"
 msgstr "Rediger medie"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s-tabeller"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist-webadresse"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Aftale %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Karrusel"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist-webadresse"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Farveindstillinger"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Viser prisen for dette billede."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Slå til for at vise gist-metadata."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Viser knappen til opfordring til handling."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Slå til for at vise gist-metadata."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Funktionsindstillinger"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Medier til venstre"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Medier til højre"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Søjlestørrelse"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gist-indstillinger"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Pristabel"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Pristabel"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Pristabel"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Pristabel"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Tilføj pristabeller."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "start"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Aftale %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "sammenligning"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Indstillinger for pristabel"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabeller"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1461,171 @@ msgstr "Aftale A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Pristabelobjekt"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "En kolonne placeret i pristabelblokken."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Tilføj baggrund til %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Kolonne"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "En umiddelbart underordnet række."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Bredde"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Kolonneindstillinger"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Plads omkring objektbeholderen."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Bredde"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Skift layout"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "en"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "to"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "tre"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "fire"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Tilføj baggrund til %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "En kolonne"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "To kolonner"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Tre kolonner"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Fire kolonner"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Rækkelayout"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Række"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Vælg nu et layout for denne række med %s kolonner."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Vælg antallet af kolonner i denne række."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Vælg rækkekolonner"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Vælg rækkelayout"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Tilbage til kolonner"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Vælg en struktureret wrapper til kolonneblokke, og tilføj de indholdsblokke du gerne vil have i kolonnerne."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Vælg en struktureret wrapper til kolonneblokke, og tilføj de indholdsblokke "
+"du gerne vil have i kolonnerne."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "rækker"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "kolonner"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "layouts"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Layout"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Rækkeindstillinger"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Ingen"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1635,9 @@ msgstr "Firkant"
 msgid "Circle"
 msgstr "Cirkel"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Serviceydelser"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Vælg op til fire kolonner med tjenesteydelser at vise."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "funktioner"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1659,7 @@ msgstr "Viser knapperne til opfordring til handling."
 msgid "Toggle to show call to action buttons."
 msgstr "Slå til for at vise knapperne til opfordring til handling."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Tjeneste"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Et enkelt tjenesteemne i en blok med tjenesteydelser."
 
@@ -1785,264 +1680,229 @@ msgid "Toggle to show a call to action button."
 msgstr "Slå til for at vise knappen til opfordring til handling."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Vend vandret"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Vend lodret"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Figuropdeler"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "Tilføj en figuropdeler så du kan se visuel forskel på farver."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "separator"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Figurfarve"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Indstillinger for opdeler"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Højde på figur i pixels"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Højde på baggrund i pixels"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Retning"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Figurfarve"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Del på Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Del på Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Del på Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Del på Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Del på LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Del via e-mail"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Del på Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Del på Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Del på Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Del"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "social"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Tilføj links til social deling så du får flere “synes godt om” og delinger."
+msgstr ""
+"Tilføj links til social deling så du får flere “synes godt om” og delinger."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Sociale farver"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Ikonstørrelse"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Cirkelstørrelse"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Knapstørrelse"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Ikoner"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "E-mail"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Farver på knapper til deling er aktiveret."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Slå til for at bruge de officielle farver fra hver sociale medier-platform."
+msgstr ""
+"Slå til for at bruge de officielle farver fra hver sociale medier-platform."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Sociale farver"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Tilføj Facebook-profil"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Tilføj Twitter-profil"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Tilføj Instagram-profil"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Tilføj Pintrest-profil"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Tilføj LinkedIn-profil"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Tilføj YouTube-profil"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Tilføj Yelp-profil"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Tilføj Houzz-profil"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Sociale profiler"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "links"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Vis links til profiler på sociale medier."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Profillinks"
 
@@ -2057,18 +1917,6 @@ msgstr "Fjern baggrund"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Baggrund"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Auto"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Cover"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Indeholder"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1974,6 @@ msgstr "Fjern baggrund"
 msgid "Remove "
 msgstr "Fjern "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Gentag ikke"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Gentag vandret"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Gentag lodret"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Flyt billede bagud"
@@ -2150,17 +1986,14 @@ msgstr "Flyt billede fremad"
 msgid "Link To"
 msgstr "Hyperlink til"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s galleri"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Upload et billede"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Lys"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2007,110 @@ msgstr "Vedhæftningsside"
 msgid "Custom URL"
 msgstr "Brugerdefineret URL-adresse"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Retning"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Procentdel"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Nulstil"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Vælg enheder"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s enheder"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Slå aktiverede indstillinger for %s fra"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s top"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s højre"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s nederst"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s venstre"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Stands synkronisering"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Synkroniser"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Synkroniser enheder"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Til toppen"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Højre"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Nederst"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Venstre"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Avancerede indstillinger for %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Avanceret"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Standardindstilling"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Layout"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2129,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Slå til for at aktivere fuldskærmstilstand."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Overskrift %d"
@@ -2263,43 +2138,16 @@ msgstr "Overskrift %d"
 msgid "Custom color picker"
 msgstr "Brugerdefineret farve-vælger"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Original"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Gråtoneskala"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sepia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Mæthed"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Svag"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Anvend filter"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Vælg retning"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Højde"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Mobil %s"
@@ -2333,7 +2181,8 @@ msgid "Five Seconds"
 msgstr "Fem sekunder"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Seks sekunder"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2201,22 @@ msgstr "Ni sekunder"
 msgid "Ten Seconds"
 msgstr "Ti sekunder"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Pilnavigation"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Priknavigation"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "sekunder"
@@ -2361,22 +2226,27 @@ msgid "second"
 msgstr "sekund"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Går videre efter %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Gå automatisk videre til det næste dias."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Træk og svip aktiveret på computere og mobile enheder."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Slå til for at aktivere trækkefunktionen på computere eller mobile enheder."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Slå til for at aktivere trækkefunktionen på computere eller mobile enheder."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2257,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Slå til for at vise pile til diasnavigation."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Viser pile til priknavigation."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Slå til for at vise priknavigation."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Plads i objektbeholderen"
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Skift for at sætte videoen på mute."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Skift for at sætte videoen på sløjfe."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Indstillinger for skyder."
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Automatisk afspilning"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Overgangshastighed"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Trækbar"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Pilnavigation"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Priknavigation"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Brug stort forbogstav"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2344,6 @@ msgstr "Ingen bundafstand"
 msgid "Change typography"
 msgstr "Skift typografi"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Fed"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Store bogstaver"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Små bogstaver"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Stablet på mobil"
@@ -2487,25 +2360,29 @@ msgstr "Slå til for at stable elementer ovenpå hinanden til mindre skærme."
 msgid "Remove Top Spacing"
 msgstr "Fjern topafstand"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Topmargin er fjernet i denne blok."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Slå til for at tilføje en kortskygge."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Slå til for at fjerne alle marginer øverst i denne blok."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Slå til for at vise priknavigation."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Fjern bundafstand"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Bundmargin er fjernet i denne blok."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Slå til for at tilføje en kortskygge."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Slå til for at fjerne alle marginer nederst i denne blok."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Slå til for at vise priknavigation."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2396,14 @@ msgstr "Viser i fuld bredde."
 msgid "Toggle to display button as full width."
 msgstr "Slå til for at vise knap i fuld bredde."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Cirkelformet"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Hero-indstillinger"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Skygge"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Afkrydsningsfelt"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Store bogstaver"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2429,793 @@ msgstr "Denne blok er føjet til siden og kan ikke deaktiveres i øjeblikket"
 msgid "Disable all"
 msgstr "Deaktivér alle"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Ingen \"%s\"-blokke fundet."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s gallerier"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Vis åben"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Tilføj harmonikatitel ..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Harmonikaemne"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "faneblade"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "ofte stillede spørgsmål"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "bemærkning"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "besked"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografi"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "link"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "del"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "afstand"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "serviceydelser"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menu"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restaurant"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "e-mail"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "mail"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Efternavn"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Tekstområde"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Flerlinjet tekst"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "e-mail"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "om"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "kontakt"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galleri"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "fotos"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Nat"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animeret"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "kode"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "knap"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "opfordring til handling"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "tekst"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "afsnit"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "ikoner"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "kunder"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "beviser"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "anbefalinger"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "adresse"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "kort"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "billede"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "adresse"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "start"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "sammenligning"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "rækker"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "kolonner"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "layouts"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "funktioner"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "separator"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "social"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "links"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Vis åben"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Tilføj harmonikaemne"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Harmonika"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Skriv tekst ..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Skriv titel ..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Advarsel"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Forfatter"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Knapper"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Klik for at tweete"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynamisk HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Funktion"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Funktioner"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Fødevare"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Mad & drikke"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "E-mail"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Navn"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Besked"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Formular"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Karrusel"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Mursten"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Stablet"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist-webadresse"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Fremhævning"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Ikon"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logoer og badges"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Kort"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Mediekort"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Karrusel"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Pristabel"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Pristabelobjekt"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Kolonne"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Række"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Serviceydelser"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Tjeneste"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Figuropdeler"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Del"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Sociale profiler"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Info"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Handlingen lykkedes"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Advarsel"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Fejl"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Prik"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Linje"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Fuld bredde"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Net"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Liste"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Standardindstilling"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Lag"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Kontur"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Udfyldt"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Stablet"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Gentag vandret"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Bølgende"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Bakker"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Bølger"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Kantet"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Skrå"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Afrundet"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Trekant"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Spids"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Maske"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Ikon"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Tekst"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Ikon og tekst"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Cirkelformet"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Nederst til venstre"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Øverst til venstre"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Giv slip for at tilføje som avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Forfatter"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3237,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "Dette er en fremhævelsesblok du kan bruge til at fremhæve indhold."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "Tilføj helteoverskrift ..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Tilføj heltemateriale, som typisk er et introduktionsafsnit på en side sammen med én eller to opfordringer til handling."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Tilføj heltemateriale, som typisk er et introduktionsafsnit på en side "
+"sammen med én eller to opfordringer til handling."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Tilføj primær handling ..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Tilføj sekundær handling ..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3279,126 @@ msgstr "Tilføj indhold ..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Erstat denne tekst med en beskrivende tekst som passer til kortbilledet. Tilføj derefter flere blokke til kortet, såsom knapper, lister eller billeder."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Erstat denne tekst med en beskrivende tekst som passer til kortbilledet. "
+"Tilføj derefter flere blokke til kortet, såsom knapper, lister eller "
+"billeder."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Skriv titel ..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Skriv beskrivelse ..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Indstillinger for knap"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Brugerdefineret"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Stablet på mobil"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Dynamiske HR-indstillinger"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Ingen"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Ingen"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Lille"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Stor"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Ekstra stor"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Ingen"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Lille"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Stor"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3180,7 +3838,8 @@ msgstr "sjov fest glad fejring smag mad"
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "kronblad duft lugt dejlig afslapning landskab havearbejde udendørs udenfor"
+msgstr ""
+"kronblad duft lugt dejlig afslapning landskab havearbejde udendørs udenfor"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3259,8 +3918,12 @@ msgstr "musik podcast sang kunstner kreativ medie audio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "mikrofon podcast computer enhed musik mikrofon sang kunstner kreativ medie audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"mikrofon podcast computer enhed musik mikrofon sang kunstner kreativ medie "
+"audio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3947,12 @@ msgstr "film videografi instruktør producer medie kreativ"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "video videografi instruktør producer medier kreativ kamera fotograf fotografi blænde"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"video videografi instruktør producer medier kreativ kamera fotograf "
+"fotografi blænde"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3969,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "palet design farver kunstner kreativ medie maling pensel"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standard"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Sølv"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Mørk"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Nat"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Aubergine"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Cirkelformet"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Skygge"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Standardindstilling"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Ingen"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Afkrydsningsfelt"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Menutitel ..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Lille"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Stor"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Ekstra stor"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Auto"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Cover"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Indeholder"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Øverst til venstre"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Øverst i midten"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Øverst til højre"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "I midten til venstre"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Centrum"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "I midten til højre"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Nederst til venstre"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Nederst i midten"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Nederst til højre"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Gentag ikke"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Gentag"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Gentag vandret"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Gentag lodret"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Link Rel"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Mørk"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Lys"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Ingen"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Billede"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Pixel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Procentdel"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Original"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Gråtoneskala"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Mediefil"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Mæthed"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Vintage-filter"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Vintage-filter"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Brug stort forbogstav"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Fed"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Standardindstilling"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Store bogstaver"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Små bogstaver"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4317,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks er en suite af professionelle <strong>blokke til opbygning af websider</strong> til WordPress Gutenberg block editor. Vores blokke er hyperfokuserede på at gøre udviklere i stand til at lave smukke og indholdsrige sider i WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks er en suite af professionelle <strong>blokke til opbygning af "
+"websider</strong> til WordPress Gutenberg block editor. Vores blokke er "
+"hyperfokuserede på at gøre udviklere i stand til at lave smukke og "
+"indholdsrige sider i WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4335,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Snyder du?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Efterlad en anmeldelse"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s år"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "et år"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s uger"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "en uge"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s dage"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "en dag"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s timer"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "en time"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minutter"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "et minut"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s sekunder"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "et sekund"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPress Plugin"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Har du glæde af %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Nu har du brugt %1$s i %2$s. Vil du skrive en anmeldelse så vi ved hvad du synes? Vil ville virkelig sætte pris på det!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Efterlad en anmeldelse"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Nu har du brugt %1$s i %2$s. Vil du skrive en anmeldelse så vi ved hvad du "
+"synes? Vil ville virkelig sætte pris på det!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Nej tak/det har jeg gjort."
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Tak fordi du valgte CoBlocks, den førende sidebygger til det nye WordPress blokredigeringsprogram."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Tak fordi du valgte CoBlocks, den førende sidebygger til det nye WordPress "
+"blokredigeringsprogram."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Du har lige tilføjet en masse nyttige blokke og et nyt sæt reskaber til sidebygning til WordPress-redigeringsprogrammet. CoBlocks giver dig en stribe funktioner som ændrer spillereglerne: %1$s mange blokke%2$s, en %1$s sidebygningsoplevelse %2$s og %1$s brugerdefineret typografistyring%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Du har lige tilføjet en masse nyttige blokke og et nyt sæt reskaber til "
+"sidebygning til WordPress-redigeringsprogrammet. CoBlocks giver dig en "
+"stribe funktioner som ændrer spillereglerne: %1$s mange blokke%2$s, en %1$s "
+"sidebygningsoplevelse %2$s og %1$s brugerdefineret typografistyring%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Her er nogle videoer til at hjælpe dig i gang:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Se hvordan du opretter din første side med %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Se hvordan du opretter din første side"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Se hvordan du bruger blokkene Række og Figuropdeler"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Se hvordan man anvender blokken Media Card"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Kan du lide hvad du ser? %1$sAbonner på vores YouTube-kanal%2$s. Så fortæller vi dig når der kommer nye videoselvstudier."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Kan du lide hvad du ser? %1$sAbonner på vores YouTube-kanal%2$s. Så "
+"fortæller vi dig når der kommer nye videoselvstudier."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Hvis du har spørgsmål eller tilbagemeldinger, kan du fortælle os om dem på %1$sTwitter%4$s eller vores %2$sFacebook-gruppe %4$s. Du kan også %3$sabonnere på vores nyhedsbrev%4$s hvis du vil holde dig ajour på alt hvad der er nyt og på vej hos CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Hvis du har spørgsmål eller tilbagemeldinger, kan du fortælle os om dem på "
+"%1$sTwitter%4$s eller vores %2$sFacebook-gruppe %4$s. Du kan også "
+"%3$sabonnere på vores nyhedsbrev%4$s hvis du vil holde dig ajour på alt hvad "
+"der er nyt og på vej hos CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "God fornøjelse!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Kom godt i gang med CoBlocks her:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4512,27 @@ msgstr "Sitenøgle til Google reCaptcha til at beskytte mod formularspam"
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "Hemmelig nøgle til Google reCaptcha til at beskytte mod formularspam"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Navn"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Første"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Sidste"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Besked"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Indsend"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Din meddelelse blev sendt:"
 
@@ -3490,3 +4547,85 @@ msgstr "Del på LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "Meddelelsestype"
+
+#~ msgid "Edit image"
+#~ msgstr "Rediger billede"
+
+#~ msgid "Remove image"
+#~ msgstr "Fjern billede"
+
+#~ msgid "Heading..."
+#~ msgstr "Overskrift ..."
+
+#~ msgid "Author Name"
+#~ msgstr "Forfatterens navn"
+
+#~ msgid "Write biography..."
+#~ msgstr "Skriv biografi"
+
+#~ msgid "Add an author biography."
+#~ msgstr "Tilføj en forfatterbiografi."
+
+#~ msgid "%s Settings"
+#~ msgstr "%s indstillinger"
+
+#~ msgid "Caption Color"
+#~ msgstr "Tekstfarve"
+
+#~ msgid "Highlight text."
+#~ msgstr "Fremhæv tekst."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s-tabeller"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Indstillinger for pristabel"
+
+#~ msgid "Tables"
+#~ msgstr "Tabeller"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "En kolonne placeret i pristabelblokken."
+
+#~ msgid "Sepia"
+#~ msgstr "Sepia"
+
+#~ msgid "Dim"
+#~ msgstr "Svag"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Vælg retning"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Topmargin er fjernet i denne blok."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "Slå til for at fjerne alle marginer øverst i denne blok."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Bundmargin er fjernet i denne blok."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "Slå til for at fjerne alle marginer nederst i denne blok."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Tilføj primær handling ..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Tilføj sekundær handling ..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Kom godt i gang med CoBlocks her:"

--- a/languages/coblocks-de_DE.po
+++ b/languages/coblocks-de_DE.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Offene anzeigen"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Akkordeontitel hinzufügen…"
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Akkordeonelement"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Ausblendbare Akkordeonelemente zu Akkordeons hinzufügen"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "Registerkarten"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "Häufig gestellte Fragen"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "Umschalten, um dieses Akkordeonelement standardmäßig zu öffnen."
 msgid "Accordion Item Settings"
 msgstr "Einstellungen für Akkordeonelement"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Offene anzeigen"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Farbeinstellungen"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Hintergrundfarbe"
@@ -103,14 +63,6 @@ msgstr "Hintergrundfarbe"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Titeltextfarbe"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Akkordeonelement hinzufügen"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Akkordeon"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +78,85 @@ msgstr "Unterstützung für Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Füge Unterstützung für Internet Explorer hinzu, indem du ein JavaScript-Polyfill lädst."
+msgstr ""
+"Füge Unterstützung für Internet Explorer hinzu, indem du ein JavaScript-"
+"Polyfill lädst."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Unterstützung für Internet Explorer durch Laden eines JavaScript-Polyfills auf dieser Seite."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Unterstützung für Internet Explorer durch Laden eines JavaScript-Polyfills "
+"auf dieser Seite."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Warnung"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Fehler"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Meldungstyp"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Standard"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Info"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Erfolgreich"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Titel schreiben…"
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Text schreiben…"
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Meldung"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Bereitstellen kontextbezogener Feedbackmeldungen."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "Mitteilung"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "Nachricht"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Textfarbe"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Bild bearbeiten"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Galerie bearbeiten"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Bild entfernen"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Bildtext schreiben…"
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Ablegen, um Avatar hinzuzufügen"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Überschrift…"
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Name des Verfassers"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Biografie schreiben…"
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Formulareinstellungen"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Verfasser"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Fordere Besucher mit mehreren nebeneinander angeordneten Schaltflächen auf, "
+"aktiv zu werden."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Fügt eine Biografie für den Verfasser hinzu."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "Biografie"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "Profil"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Schaltflächen"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Fordere Besucher mit mehreren nebeneinander angeordneten Schaltflächen auf, aktiv zu werden."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "Link"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "Handlungsaufforderung"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Schaltflächeneinstellungen"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Auf Mobilgeräten stapeln"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +174,25 @@ msgstr "Twitter-Benutzername"
 msgid "Username"
 msgstr "Benutzername"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Schaltfläche hinzufügen…"
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Zitat zum Twittern hinzufügen…"
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Zum Twittern klicken"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Füge ein Zitat hinzu, das Leser twittern können."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "teilen"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twittern"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +200,20 @@ msgid "Text Settings"
 msgstr "Texteinstellungen"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Schaltflächenfarbe"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynamic HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
-msgstr "Fügt einen Abstandshalter zwischen den Blöcken hinzu, dessen Größe du ändern kannst."
-
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "Abstandshalter"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Einstellungen für Dynamic HR"
+msgstr ""
+"Fügt einen Abstandshalter zwischen den Blöcken hinzu, dessen Größe du ändern "
+"kannst."
 
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Höhe in Pixel"
 
@@ -347,92 +225,72 @@ msgstr "Höhe des dynamischen Trennelements in Pixel."
 msgid "Color"
 msgstr "Farbe"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Als Hintergrund hinzufügen"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Feature"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
-msgstr "Eine einzelne untergeordnete Spalte innerhalb eines übergeordneten Funktionsblocks."
+msgstr ""
+"Eine einzelne untergeordnete Spalte innerhalb eines übergeordneten "
+"Funktionsblocks."
 
 #: src/blocks/features/feature/inspector.js:68
 msgid "Feature Settings"
 msgstr "Funktionseinstellungen"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Innenabstand"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Funktionen"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Füge bis zu drei Spalten mit kurzen Anmerkungen zu deinem Produkt oder Service hinzu."
+msgstr ""
+"Füge bis zu drei Spalten mit kurzen Anmerkungen zu deinem Produkt oder "
+"Service hinzu."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "Services"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Rand"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Spaltenzwischenraum"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Der Raum zwischen den einzelnen Spalten"
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Klein"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Mittel"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +300,8 @@ msgstr "Groß"
 msgid "Features Settings"
 msgstr "Funktionseinstellungen"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Spalten"
 
@@ -455,76 +313,72 @@ msgstr "Menübereich hinzufügen"
 msgid "Menu title..."
 msgstr "Menütitel…"
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Grid"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Liste"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Zum Ersetzen Bild ablegen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Bild entfernen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Titel hinzufügen…"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Pikant"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Scharf"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetarisch"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Glutenfrei"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescetarisch"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Vegan"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Beschreibung hinzufügen…"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0,00 USD"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Lebensmittelartikel"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Ein Lebensmittelartikel im Block „Essen und Trinken“"
 
@@ -560,62 +414,46 @@ msgstr "Umschalten, um den Preis für diesen Artikel anzuzeigen."
 msgid "Item Attributes"
 msgstr "Artikelattribute"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Pikanter"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Bildeinstellungen"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Alt-Text (alternativer Text)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Beschreibt den Zweck des Bildes."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Freilassen, wenn das Bild ausschließlich dekorativen Zwecken dient."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Fokus"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Essen und Trinken"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Zeigt eine Speisekarte oder Preisliste an."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "Restaurant"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "Menü"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Stile"
@@ -648,134 +486,86 @@ msgstr "Zeigt den Preis für jeden Artikel an."
 msgid "Toggle to show the price of each item."
 msgstr "Umschalten, um den Preis für jeden Artikel anzuzeigen."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "E-Mail"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "E-Mail"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "Mail"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Feld für eine E-Mail-Adresse."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Nachricht"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Textbereich"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Mehrzeiliger Text"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Textfeld für längere Antworten."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s ist keine gültige E-Mail-Adresse."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s und %s sind keine gültigen E-Mail-Adressen."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s sind keine gültigen E-Mail-Adressen."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Betreff"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Formulareinstellungen"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Füge deine reCAPTCHA-Site- und -Geheimschlüssel hinzu, um dein Formular vor Spam zu schützen."
+msgstr ""
+"Füge deine reCAPTCHA-Site- und -Geheimschlüssel hinzu, um dein Formular vor "
+"Spam zu schützen."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Schlüssel generieren"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Meine Schlüssel"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Hilfe erhalten"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Siteschlüssel"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Geheimer Schlüssel"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Speichern"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Speichern"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Entfernen"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Erste"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Letzte"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Name"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Ein Textfeld für Namen."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Feld für eine E-Mail-Adresse."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Beschriftung hinzufügen…"
 
@@ -783,41 +573,38 @@ msgstr "Beschriftung hinzufügen…"
 msgid "Required"
 msgstr "Erforderlich"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Einstellungen für Namensfeld"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Nachname"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Die Felder für Vor- und Nachname werden angezeigt."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Umschalten, um ein Feld für den Nachnamen hinzuzufügen."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Formular"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Ein Textfeld für Namen."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Textfeld für längere Antworten."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Hiermit fügst du deiner Seite ein einfaches Formular hinzu."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "E-Mail"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "über"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "Kontakt"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Betreff"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +614,219 @@ msgstr "Text hinzufügen…"
 msgid "Button Text Color"
 msgstr "Schaltflächentextfarbe"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Galerie bearbeiten"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Karussell"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "Bild %1$d von %2$d in Galerie"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Bildtext schreiben…"
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Karussell"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Zeigt mehrere Bilder in einer ansprechenden Karussellgalerie an."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "Galerie"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "Fotos"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s Einstellungen"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Zeilenhöhe"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Pfeile zur Punktnavigation werden angezeigt."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Umschalten, um Medienbeschriftungen anzuzeigen."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Farbeinstellungen"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Größe"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Gerundete Ecken"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Bildtextfarbe"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Übernehmen"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Masonry"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Beschreibung verfassen…"
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Zeigt mehrere Bilder in einer organisierten Masonry-Galerie an"
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Zeigt mehrere Bilder in einer ansprechenden Karussellgalerie an."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Spaltenbreite"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Bildeinstellungen"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Fügt den Galerieelementen gerundete Ecken hinzu."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Schatten"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Beschriftungen"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Beschriftungsstil"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Für jedes Medienelement werden Beschriftungen angezeigt."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Umschalten, um Medienbeschriftungen anzuzeigen."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Masonry"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Zeigt mehrere Bilder in einer organisierten Masonry-Galerie an"
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Umschalten, um Optionen zur Detailsteuerung zu aktivieren."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Karteneinstellungen"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Spaltenbreite"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Fügt den Galerieelementen gerundete Ecken hinzu."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Hell"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Gestapelt"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Zeigt mehrere Bilder gestapelt in einer einzelnen Spalte an."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Bilder in voller Breite"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Bild in voller Breite"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Feldschatten"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Bilder in voller Breite sind aktiviert."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Umschalten, um den vorhandenen Galeriebereich mit Bildern in voller Breite zu füllen."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Umschalten, um den vorhandenen Galeriebereich mit Bildern in voller Breite "
+"zu füllen."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Artikeleinstellungen"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Bilder in voller Breite"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Bild in voller Breite"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "GIF entfernen"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Das ALT-Attribut dieser GIF-Datei ist leer."
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Auf Giphy findest du das perfekte GIF"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Nach GIFs suchen"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Entscheide dich für ein beliebiges GIF."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animiert"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +852,11 @@ msgstr "GitHub-Datei"
 msgid "File"
 msgstr "Datei"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Diesen Gist auf GitHub anzeigen"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist-URL"
 
@@ -1024,12 +869,9 @@ msgid "Loading Gist"
 msgstr "Gist wird geladen"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "GitHub-Gists durch Hinzufügen des Gist-Links einbetten"
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "Code"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +894,161 @@ msgid "Gist Meta"
 msgstr "Gist-Metadaten"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Layout ändern"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Hintergrund zu %s hinzufügen"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Ein einleitender Bereich einer Seite, unterstützt von einem kurzen Text und "
+"einer Handlungsaufforderung."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Ein einleitender Bereich einer Seite, unterstützt von einem kurzen Text und einer Handlungsaufforderung."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "Schaltfläche"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "Handlungsaufforderung"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Inhaltsbreite in Pixel"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Hero-Einstellungen"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Platz im Container."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Oben links"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Oben zentriert"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Oben rechts"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Mitte links"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Mitte zentriert"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Mitte rechts"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Unten links"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Unten zentriert"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Unten rechts"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Hervorgehobenen Text hinzufügen…"
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Hervorheben"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Hebt Text hervor."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "Text"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "Absatz"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Symbol"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Fügt ein stilisiertes grafisches Symbol hinzu, um einen Sachverhalt zu kommunizieren."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "Symbole"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Extrem groß"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr ""
+"Fügt ein stilisiertes grafisches Symbol hinzu, um einen Sachverhalt zu "
+"kommunizieren."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Symboleinstellungen"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Erweiterte %s-Einstellungen ausschalten"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Benutzerdefinierte Größe für %s"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Erweiterte Einstellungen für %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Benutzerdefiniert"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Erweitert"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Radius"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Symbolsuche"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Keine Ergebnisse gefunden."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Link-Einstellungen"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "Link-URL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Link Rel"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Wird in neuer Registerkarte geöffnet"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "In neuer Registerkarte öffnen"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Symbolfarbe"
 
@@ -1261,30 +1057,21 @@ msgid "Edit logos"
 msgstr "Logos bearbeiten"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logos und Kennzeichen"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Du kannst Bilder verschieben, neue hochladen oder Dateien aus deiner Bibliothek auswählen."
+msgstr ""
+"Du kannst Bilder verschieben, neue hochladen oder Dateien aus deiner "
+"Bibliothek auswählen."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Füge Logos, Badges und Zertifikate hinzu, um deine Glaubwürdigkeit zu unterstreichen."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "Kunden"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "Nachweis"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "Kundenaussagen"
+msgstr ""
+"Füge Logos, Badges und Zertifikate hinzu, um deine Glaubwürdigkeit zu "
+"unterstreichen."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1093,148 @@ msgstr "Standort bearbeiten"
 msgid "Map style"
 msgstr "Kartenstil"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "API-Schlüssel ungültig oder zu viele Anfragen"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Maps-Karte"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Gib einen Standort oder eine Adresse ein, um in Google Maps einen Marker zu setzen."
+msgstr ""
+"Gib einen Standort oder eine Adresse ein, um in Google Maps einen Marker zu "
+"setzen."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Nach einem Ort oder einer Adresse suchen…"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Übernehmen"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Karte"
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
+msgstr ""
+"Füge eine Adresse hinzu und setze einen Marker auf einer Google Maps-Karte."
 
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
-msgstr "Füge eine Adresse hinzu und setze einen Marker auf einer Google Maps-Karte."
-
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "Adresse"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "Maps"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "Google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Kartenstil auswählen"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Karteneinstellungen"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Zoomstufe"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Höhe der Karte in Pixel"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Zoomstufe"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Markergröße"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Optionen zur Detailsteuerung sind aktiviert."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Umschalten, um Optionen zur Detailsteuerung zu aktivieren."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Kartensteuerelemente"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Kartentyp"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "Die Umschaltung zwischen Standard- und Satellitendarstellung der Karte ist aktiviert."
+msgstr ""
+"Die Umschaltung zwischen Standard- und Satellitendarstellung der Karte ist "
+"aktiviert."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Umschalten, um die Umschaltung zwischen Standard- und Satellitenkarten zu aktivieren."
+msgstr ""
+"Umschalten, um die Umschaltung zwischen Standard- und Satellitenkarten zu "
+"aktivieren."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Zoomsteuerelemente"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Die Zoomsteuerelemente für die Karte werden angezeigt."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Umschalten, um das Vergrößern und Verkleinern der Kartenansicht mit den Zoomsteuerelementen zu aktivieren."
+msgstr ""
+"Umschalten, um das Vergrößern und Verkleinern der Kartenansicht mit den "
+"Zoomsteuerelementen zu aktivieren."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Street View"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Das Kartensteuerelement für Street View wird angezeigt."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "Umschalten, um das Street View-Steuerelement unten rechts anzuzeigen."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Vollbildumschalter"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Das Vollbild-Kartensteuerelement wird angezeigt."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Umschalten, um das Vollbild-Kartensteuerelement anzuzeigen."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google Maps-API-Schlüssel"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Füge deinen Google Maps-API-Schlüssel hinzu. Wenn du diesen API-Schlüssel aktualisierst, wird die Verwendung des neuen Schlüssels für alle deine Karten festgelegt."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Füge deinen Google Maps-API-Schlüssel hinzu. Wenn du diesen API-Schlüssel "
+"aktualisierst, wird die Verwendung des neuen Schlüssels für alle deine "
+"Karten festgelegt."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Schlüssel abrufen"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Brauchst du Hilfe?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Google-API-Schlüssel eingeben…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Gespeichert"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standard"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Silber"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Dunkel"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Nacht"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Aubergine"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1244,11 @@ msgstr "Medien auf der rechten Seite"
 msgid "Media on left"
 msgstr "Medien auf der linken Seite"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Medienkarte"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
-msgstr "Hier kannst du ein Bild oder ein Video mithilfe einer versetzten Karte hinzufügen und nebeneinander anordnen."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "Bild"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "Video"
+msgstr ""
+"Hier kannst du ein Bild oder ein Video mithilfe einer versetzten Karte "
+"hinzufügen und nebeneinander anordnen."
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1262,18 @@ msgstr "Der Kartenschatten wird angezeigt."
 msgid "Toggle to add a card shadow."
 msgstr "Umschalten, um einen Kartenschatten hinzuzufügen"
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Schatten für %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Der Schatten für %s wird angezeigt."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Umschalten, um einen Schatten für %s hinzuzufügen"
 
@@ -1545,40 +1297,171 @@ msgstr "Ziehen und Ablegen, um Medien zu ersetzen"
 msgid "Edit media"
 msgstr "Medien bearbeiten"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s Tabellen"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist-URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "%s-Paket"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Karussell"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist-URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Farbeinstellungen"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Zeigt den Preis für diesen Artikel an."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Umschalten, um die Metadaten zum Gist anzuzeigen."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Die Schaltfläche mit der Handlungsaufforderung wird angezeigt."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Umschalten, um die Metadaten zum Gist anzuzeigen."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Funktionseinstellungen"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Medien auf der linken Seite"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Medien auf der rechten Seite"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Spaltenbreite"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gist-Einstellungen"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Preisübersicht"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Preisübersicht"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Preisübersicht"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Preisübersicht"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Hiermit fügst du Preisübersichten hinzu."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "Landing"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "%s-Paket"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "Vergleich"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Einstellungen für Preisübersichten"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabellen"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1479,171 @@ msgstr "Plan A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Element in Preisübersicht"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Eine im Preisübersichtsblock angeordnete Spalte."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Hintergrund zu %s hinzufügen"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Spalte"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Ein einer Zeile direkt untergeordnetes Element."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Breite"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Spalteneinstellungen"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Platz um den Container"
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Breite"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Layout ändern"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "1"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "2"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "3"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "4"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Hintergrund zu %s hinzufügen"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Eine Spalte"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Zwei Spalten"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Drei Spalten"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Vier Spalten"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Zeilenlayout"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Zeile"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Wähle jetzt ein Layout für diese %s-Spaltenzeile aus"
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Wähle die Anzahl der Spalten für diese Zeile aus."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Wähle Zeilenspalten aus"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Wähle das Zeilenlayout aus"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Zurück zu Spalten"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Füge einen strukturierten Wrapper für Spaltenblöcke und nachfolgend die gewünschten Inhaltsblöcke den Spalten hinzu."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Füge einen strukturierten Wrapper für Spaltenblöcke und nachfolgend die "
+"gewünschten Inhaltsblöcke den Spalten hinzu."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "Zeilen"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "Spalten"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "Layouts"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Layout"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Zeileneinstellungen"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Keine"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1653,9 @@ msgstr "Quadrat"
 msgid "Circle"
 msgstr "Kreis"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Services"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Füge bis zu vier Spalten für die Darstellung von Services hinzu."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "Funktionen"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1677,7 @@ msgstr "Schaltflächen mit Handlungsaufforderungen werden angezeigt."
 msgid "Toggle to show call to action buttons."
 msgstr "Umschalten, um Schaltflächen mit Handlungsaufforderungen anzuzeigen."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Service"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Ein einzelnes Serviceelement in einem Serviceblock."
 
@@ -1782,267 +1695,237 @@ msgstr "Die Schaltfläche mit der Handlungsaufforderung wird angezeigt."
 
 #: src/blocks/services/service/inspector.js:24
 msgid "Toggle to show a call to action button."
-msgstr "Umschalten, um eine Schaltfläche mit einer Handlungsaufforderung anzuzeigen."
+msgstr ""
+"Umschalten, um eine Schaltfläche mit einer Handlungsaufforderung anzuzeigen."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Horizontal spiegeln"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Vertikal spiegeln"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Formtrennlinie"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Füge eine Formtrennlinie hinzu, um Seitenbereiche optisch voneinander zu trennen."
+msgstr ""
+"Füge eine Formtrennlinie hinzu, um Seitenbereiche optisch voneinander zu "
+"trennen."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "Trennelement"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Formfarbe"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Trennlinieneinstellungen"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Höhe der Form in Pixel"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Hintergrundhöhe in Pixel"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Ausrichtung"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Formfarbe"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Auf Twitter teilen"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Auf Facebook teilen"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Auf Twitter teilen"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Auf Pinterest teilen"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Auf LinkedIn teilen"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Per E-Mail teilen"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Auf Tumblr teilen"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Auf Google teilen"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Auf Reddit teilen"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Teilen"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "Soziale Netzwerke"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Füge Links zum Teilen in sozialen Netzwerken hinzu, um Likes und Shares zu bekommen."
+msgstr ""
+"Füge Links zum Teilen in sozialen Netzwerken hinzu, um Likes und Shares zu "
+"bekommen."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Farben von sozialen Netzwerken"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Symbolgröße"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Kreisgröße"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Schaltflächengröße"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Symbole"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "E-Mail"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Farben für Teilen-Schaltflächen sind aktiviert."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Umschalten, um die offiziellen Farben des jeweiligen sozialen Netzwerks zu verwenden."
+msgstr ""
+"Umschalten, um die offiziellen Farben des jeweiligen sozialen Netzwerks zu "
+"verwenden."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Farben von sozialen Netzwerken"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Facebook-Profil hinzufügen"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Twitter-Profil hinzufügen"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Instagram-Profil hinzufügen"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Pinterest-Profil hinzufügen"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "LinkedIn-Profil hinzufügen"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "YouTube-Profil hinzufügen"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Yelp-Profil hinzufügen"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Houzz-Profil hinzufügen"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Profile in sozialen Netzwerken"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "Links"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Zeige Links auf die Profile in sozialen Netzwerken an."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Profillinks"
 
@@ -2057,18 +1940,6 @@ msgstr "Hintergrund entfernen"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Hintergrund"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Auto"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Titelbild"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Enthält"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1997,6 @@ msgstr "Hintergrund entfernen"
 msgid "Remove "
 msgstr "Entfernen "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Keine Wiederholung"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Horizontal wiederholen"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Vertikal wiederholen"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Bild nach hinten verschieben"
@@ -2150,17 +2009,14 @@ msgstr "Bild nach vorne verschieben"
 msgid "Link To"
 msgstr "Link zu"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s-Galerie"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Bild hochladen"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Hell"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2030,110 @@ msgstr "Anhangsseite"
 msgid "Custom URL"
 msgstr "Benutzerdefinierte URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Geviertstrich"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Ausrichtung"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Prozentsatz"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Zurücksetzen"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Einheiten auswählen"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s Einheiten"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Erweiterte %s-Einstellungen ausschalten"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s oben"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s rechts"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s unten"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s links"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Synchronisierung aufheben"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Synchronisieren"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Einheiten synchronisieren"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Seitenanfang"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Rechts"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Unten"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Links"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Erweiterte Einstellungen für %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Erweitert"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Standard"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Layout"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2152,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Umschalten, um den Vollbildmodus zu aktivieren."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Überschrift %d"
@@ -2263,43 +2161,16 @@ msgstr "Überschrift %d"
 msgid "Custom color picker"
 msgstr "Color Picker für benutzerdefinierte Farben"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Original"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Graustufen"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sepia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Sättigung"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Abblenden"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Filter anwenden"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Ausrichtung auswählen"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Höhe"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Mobil %s"
@@ -2333,7 +2204,8 @@ msgid "Five Seconds"
 msgstr "5 Sekunden"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "6 Sekunden"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2224,22 @@ msgstr "9 Sekunden"
 msgid "Ten Seconds"
 msgstr "10 Sekunden"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Pfeilnavigation"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Punktnavigation"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "Sekunden"
@@ -2361,21 +2249,25 @@ msgid "second"
 msgstr "Sekunde"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Weiter nach %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Automatisch weiter zur nächsten Folie."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Ziehen und Schnipsen auf Desktop- und Mobilgeräten aktiviert."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
 msgstr "Umschalten, um das Ziehen auf Desktop- und Mobilgeräten zu aktivieren."
 
 #: src/components/slider-panel/index.js:35
@@ -2387,44 +2279,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Umschalten, um Pfeile zur Foliennavigation anzuzeigen."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Pfeile zur Punktnavigation werden angezeigt."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Umschalten, um Pfeile zur Punktnavigation anzuzeigen."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Platz im Container."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Umschalten, um das Video stummzuschalten."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Umschalten, um das Video in eine Endlosschleife wiederzugeben."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Schiebreglereinstellungen"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Autom. Wiedergabe"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Überblendgeschwindigkeit"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Ziehbar"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Pfeilnavigation"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Punktnavigation"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Groß schreiben"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2366,6 @@ msgstr "Kein Abstand nach unten"
 msgid "Change typography"
 msgstr "Typografie ändern"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Fett"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Großbuchstaben"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Kleinbuchstaben"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Auf Mobilgeräten stapeln"
@@ -2481,31 +2376,37 @@ msgstr "Responsivität ist aktiviert."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Umschalten, um Elemente auf kleineren Geräte anzeigen übereinander zu stapeln."
+msgstr ""
+"Umschalten, um Elemente auf kleineren Geräte anzeigen übereinander zu "
+"stapeln."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Abstand nach oben entfernen"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Der obere Rand wird bei diesem Block entfernt."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Umschalten, um einen Kartenschatten hinzuzufügen"
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Umschalten, um einen ggf. auf diesen Block angewendeten oberen Rand zu entfernen."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Umschalten, um Pfeile zur Punktnavigation anzuzeigen."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Unteren Rand entfernen"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Der untere Rand wird bei diesem Block entfernt."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Umschalten, um einen Kartenschatten hinzuzufügen"
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Umschalten, um einen ggf. auf diesen Block angewendeten unteren Rand zu entfernen."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Umschalten, um Pfeile zur Punktnavigation anzuzeigen."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2420,14 @@ msgstr "Die Anzeige erfolgt in voller Breite."
 msgid "Toggle to display button as full width."
 msgstr "Für Anzeige in voller Breite umschalten."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Kreisförmig"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Hero-Einstellungen"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Schatten"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Kontrollkästchen"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Großbuchstaben"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2447,801 @@ msgstr "Nach einem Block suchen"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Dieser Block wurde der Seite hinzugefügt und kann gegenwärtig nicht deaktiviert werden."
+msgstr ""
+"Dieser Block wurde der Seite hinzugefügt und kann gegenwärtig nicht "
+"deaktiviert werden."
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Alle deaktivieren"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Keine Blöcke des Typs „%s“ gefunden."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s Galerien"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Offene anzeigen"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Akkordeontitel hinzufügen…"
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Akkordeonelement"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "Registerkarten"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "Häufig gestellte Fragen"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "Mitteilung"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "Nachricht"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "Biografie"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "Profil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "Link"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "Handlungsaufforderung"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "teilen"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twittern"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "Abstandshalter"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "Services"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "Menü"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "Restaurant"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "E-Mail"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "Mail"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Nachname"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Textbereich"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Mehrzeiliger Text"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "E-Mail"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "über"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "Kontakt"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "Galerie"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "Fotos"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Nacht"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animiert"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "Code"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "Schaltfläche"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "Handlungsaufforderung"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "Text"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "Absatz"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "Symbole"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "Kunden"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "Nachweis"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "Kundenaussagen"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "Adresse"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "Maps"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "Google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "Bild"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "Video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "Adresse"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "Landing"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "Vergleich"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "Zeilen"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "Spalten"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "Layouts"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "Funktionen"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "Trennelement"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "Soziale Netzwerke"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "Links"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Offene anzeigen"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Akkordeonelement hinzufügen"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Akkordeon"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Text schreiben…"
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Titel schreiben…"
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Meldung"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Verfasser"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Schaltflächen"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Zum Twittern klicken"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynamic HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Feature"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Funktionen"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Lebensmittelartikel"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Essen und Trinken"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "E-Mail"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Name"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Nachricht"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Formular"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Karussell"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Masonry"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Gestapelt"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist-URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Hervorheben"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Symbol"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logos und Kennzeichen"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Karte"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Medienkarte"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Karussell"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Preisübersicht"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Element in Preisübersicht"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Spalte"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Zeile"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Services"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Service"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Formtrennlinie"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Teilen"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Profile in sozialen Netzwerken"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Info"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Erfolgreich"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Warnung"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Fehler"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Punkt"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Zeile"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Volle Breite"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Grid"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Liste"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Standard"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Ebenen"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Kontur"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Gefüllt"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Gestapelt"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Horizontal wiederholen"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Wellig"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Hügel"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Wellen"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Abgewinkelt"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Geneigt"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Abgerundet"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Dreieck"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Spitz"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Maske"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Symbol"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Text"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Symbol und Text"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Kreisförmig"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Unten links"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Oben links"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Ablegen, um Avatar hinzuzufügen"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Verfasser"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3263,31 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "Dies ist ein Feature-Block, mit dem du Merkmale hervorheben kannst."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "Hero-Überschrift hinzufügen…"
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Füge Hero-Inhalt hinzu. Normalerweise handelt es sich dabei um einen einleitenden Bereich für deiner Seite, der mit ein oder zwei Handlungsaufforderungen verknüpft ist."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Füge Hero-Inhalt hinzu. Normalerweise handelt es sich dabei um einen "
+"einleitenden Bereich für deiner Seite, der mit ein oder zwei "
+"Handlungsaufforderungen verknüpft ist."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Primäre Handlung hinzufügen…"
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Sekundäre Handlung hinzufügen…"
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3306,126 @@ msgstr "Inhalt hinzufügen…"
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Ersetze diesen Text mit einem aussagekräftigen Werbetext, der zum Kartenbild passt. Füge dann weitere Blöcke zu dieser Karte hinzu, etwa Schaltflächen, Listen oder Bilder."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Ersetze diesen Text mit einem aussagekräftigen Werbetext, der zum Kartenbild "
+"passt. Füge dann weitere Blöcke zu dieser Karte hinzu, etwa Schaltflächen, "
+"Listen oder Bilder."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Titel schreiben…"
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Beschreibung verfassen…"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Schaltflächeneinstellungen"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Benutzerdefiniert"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Auf Mobilgeräten stapeln"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Einstellungen für Dynamic HR"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Keine"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Keine"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Klein"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Mittel"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Groß"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Sehr groß"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Keine"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Klein"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Mittel"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Groß"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3160,7 +3845,9 @@ msgstr "Welt Öffentlichkeit Global Erde Position Karte"
 #: src/blocks/icon/svgs.js:258
 msgctxt "tags"
 msgid "location map public business corporation building town skyscraper"
-msgstr "Position Karte Öffentlichkeit Unternehmen Konzern Entwicklung Stadt Wolkenkratzer"
+msgstr ""
+"Position Karte Öffentlichkeit Unternehmen Konzern Entwicklung Stadt "
+"Wolkenkratzer"
 
 #: src/blocks/icon/svgs.js:263
 msgctxt "tags"
@@ -3180,7 +3867,9 @@ msgstr "Spaß Party Fröhlich Feier Geschmack Essen"
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "Blütenblatt Duft Geruch Schön Entspannen Landschaft Gartenarbeit Outdoor Draußen"
+msgstr ""
+"Blütenblatt Duft Geruch Schön Entspannen Landschaft Gartenarbeit Outdoor "
+"Draußen"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3259,8 +3948,12 @@ msgstr "Musik Mikrofon Song Künstler Kreativ Medien Audio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "Mikrofon Podcast Computer Gerät Musik Mikrofon Song Künstler Kreativ Medien Audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"Mikrofon Podcast Computer Gerät Musik Mikrofon Song Künstler Kreativ Medien "
+"Audio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3977,12 @@ msgstr "Film Videografie Regisseur Produzent Medien Kreativ"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "Video Videografie Regisseur Produzent Medien Kreativ Kamera Fotograf Fotografie Blende"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"Video Videografie Regisseur Produzent Medien Kreativ Kamera Fotograf "
+"Fotografie Blende"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3999,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "Palette Design Farben Künstler Kreativ Medien Malen Pinsel"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standard"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Silber"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Dunkel"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Nacht"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Aubergine"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Kreisförmig"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Schatten"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Standard"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Keine"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Kontrollkästchen"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Menütitel…"
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Klein"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Mittel"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Groß"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Sehr groß"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Auto"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Titelbild"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Enthält"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Oben links"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Oben zentriert"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Oben rechts"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Mitte links"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Mitte zentriert"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Mitte rechts"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Unten links"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Unten zentriert"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Unten rechts"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Keine Wiederholung"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Wiederholen"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Horizontal wiederholen"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Vertikal wiederholen"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Link Rel"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Dunkel"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Hell"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Keine"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Bild"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Pixel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Geviertstrich"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Prozentsatz"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Original"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Graustufen"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Mediendatei"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Sättigung"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Vintage-Filter"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Vintage-Filter"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Groß schreiben"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Fett"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Standard"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Großbuchstaben"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Kleinbuchstaben"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4347,16 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks ist eine Suite mit <strong>Inhaltsblöcken für die Entwicklung von Webseiten</strong>, die im Gutenberg-Blockeditor von WordPress eingesetzt werden können. Mit unseren Blöcken legen wir den Schwerpunkt ganz gezielt darauf, den Nutzern die Erstellung ansprechender und funktionaler Webseiten in WordPress zu ermöglichen."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks ist eine Suite mit <strong>Inhaltsblöcken für die Entwicklung von "
+"Webseiten</strong>, die im Gutenberg-Blockeditor von WordPress eingesetzt "
+"werden können. Mit unseren Blöcken legen wir den Schwerpunkt ganz gezielt "
+"darauf, den Nutzern die Erstellung ansprechender und funktionaler Webseiten "
+"in WordPress zu ermöglichen."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4366,175 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Du schwindelst doch!"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Bewertung hinterlassen"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s Jahre"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "ein Jahr"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s Wochen"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "eine Woche"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s Tage"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "ein Tag"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s Stunden"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "eine Stunde"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s Minuten"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "eine Minute"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s Sekunden"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "eine Sekunde"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s-WordPress-Plugin"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Gefällt dir %s gut?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Du benutzt %1$s jetzt seit %2$s. Möchtest du vielleicht eine Bewertung abgeben, damit wir deine Meinung erfahren? Wir würden das sehr zu schätzen wissen!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Bewertung hinterlassen"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Du benutzt %1$s jetzt seit %2$s. Möchtest du vielleicht eine Bewertung "
+"abgeben, damit wir deine Meinung erfahren? Wir würden das sehr zu schätzen "
+"wissen!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Nein danke/Habe ich bereits"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Vielen Dank dafür, dass du CoBlocks verwendest, den Premium-Seitengenerator für den neuen WordPress-Blockeditor."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Vielen Dank dafür, dass du CoBlocks verwendest, den Premium-Seitengenerator "
+"für den neuen WordPress-Blockeditor."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Du hast eine Menge nützlicher Blöcke und ein neues Seitengenerator-Toolkit zum WordPress-Editor hinzugefügt. Mit CoBlocks bekommst du Funktionen, die Webdesign von Grund auf neu definieren: %1$sjede Menge Blöcke%2$s, einen %1$sbenutzerfreundlichen Seitengenerator%2$s und %1$sSteuerelemente zur detaillierten Anpassung der Typografie%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Du hast eine Menge nützlicher Blöcke und ein neues Seitengenerator-Toolkit "
+"zum WordPress-Editor hinzugefügt. Mit CoBlocks bekommst du Funktionen, die "
+"Webdesign von Grund auf neu definieren: %1$sjede Menge Blöcke%2$s, einen "
+"%1$sbenutzerfreundlichen Seitengenerator%2$s und %1$sSteuerelemente zur "
+"detaillierten Anpassung der Typografie%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
-msgstr "Hier findest du ein paar Videos, die dir beim Einstieg gute Dienste leisten werden:"
+msgstr ""
+"Hier findest du ein paar Videos, die dir beim Einstieg gute Dienste leisten "
+"werden:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "So erstellst du deine erste Seite mit %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "So erstellst du deine erste Seite"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "So verwendest du Zeilen- und Formtrennlinien-Blöcke."
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Sieh dir an, wie der Medienkartenblock verwendet wird"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Gefällt dir das? %1$sDann abonniere unseren YouTube-Kanal%2$s, und wir halten dich auf dem Laufenden, wann immer ein neues Video-Tutorial veröffentlicht wird."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Gefällt dir das? %1$sDann abonniere unseren YouTube-Kanal%2$s, und wir "
+"halten dich auf dem Laufenden, wann immer ein neues Video-Tutorial "
+"veröffentlicht wird."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Falls du Fragen hast oder uns Feedback geben möchtest, kannst du das auf %1$sTwitter%4$s oder in unserer %2$sFacebook-Gruppe%4$s tun. Wir würden uns auch sehr freuen, wenn du %3$sunseren Newsletter abonnierst%4$s, um immer aktuelle Neuigkeiten über CoBlocks zu erhalten."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Falls du Fragen hast oder uns Feedback geben möchtest, kannst du das auf "
+"%1$sTwitter%4$s oder in unserer %2$sFacebook-Gruppe%4$s tun. Wir würden uns "
+"auch sehr freuen, wenn du %3$sunseren Newsletter abonnierst%4$s, um immer "
+"aktuelle Neuigkeiten über CoBlocks zu erhalten."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Viel Spaß!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Hier kannst du mit CoBlocks loslegen:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4542,36 @@ msgstr "Blöcke aktivieren oder deaktivieren"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "Siteschlüssel für Google reCAPTCHA, um deine Formulare vor Spam zu schützen"
+msgstr ""
+"Siteschlüssel für Google reCAPTCHA, um deine Formulare vor Spam zu schützen"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
-msgstr "Geheimer Schlüssel für Google reCAPTCHA, um deine Formulare vor Spam zu schützen"
+msgstr ""
+"Geheimer Schlüssel für Google reCAPTCHA, um deine Formulare vor Spam zu "
+"schützen"
+
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Name"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Erste"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Letzte"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Nachricht"
 
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Absenden"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Deine Mitteilung wurde versandt:"
 
@@ -3490,3 +4586,89 @@ msgstr "Auf LinkedIn teilen"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Meldungstyp"
+
+#~ msgid "Edit image"
+#~ msgstr "Bild bearbeiten"
+
+#~ msgid "Remove image"
+#~ msgstr "Bild entfernen"
+
+#~ msgid "Heading..."
+#~ msgstr "Überschrift…"
+
+#~ msgid "Author Name"
+#~ msgstr "Name des Verfassers"
+
+#~ msgid "Write biography..."
+#~ msgstr "Biografie schreiben…"
+
+#~ msgid "Add an author biography."
+#~ msgstr "Fügt eine Biografie für den Verfasser hinzu."
+
+#~ msgid "%s Settings"
+#~ msgstr "%s Einstellungen"
+
+#~ msgid "Caption Color"
+#~ msgstr "Bildtextfarbe"
+
+#~ msgid "Highlight text."
+#~ msgstr "Hebt Text hervor."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s Tabellen"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Einstellungen für Preisübersichten"
+
+#~ msgid "Tables"
+#~ msgstr "Tabellen"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Eine im Preisübersichtsblock angeordnete Spalte."
+
+#~ msgid "Sepia"
+#~ msgstr "Sepia"
+
+#~ msgid "Dim"
+#~ msgstr "Abblenden"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Ausrichtung auswählen"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Der obere Rand wird bei diesem Block entfernt."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Umschalten, um einen ggf. auf diesen Block angewendeten oberen Rand zu "
+#~ "entfernen."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Der untere Rand wird bei diesem Block entfernt."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Umschalten, um einen ggf. auf diesen Block angewendeten unteren Rand zu "
+#~ "entfernen."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Primäre Handlung hinzufügen…"
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Sekundäre Handlung hinzufügen…"
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Hier kannst du mit CoBlocks loslegen:"

--- a/languages/coblocks-el.po
+++ b/languages/coblocks-el.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Προβολή ανοικτών"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Προσθήκη τίτλου ακορντεόν"
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Στοιχείο ακορντεόν"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Προσθέστε συμπτυσσόμενα στοιχείων ακορντεόν στα ακορντεόν."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "καρτέλες"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "συχνές ερωτήσεις"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,40 @@ msgstr "Η προεπιλογή είναι το στοιχείο ακορντε�
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Κάντε εναλλαγή ώστε αυτό το στοιχείο ακορντεόν να είναι ανοικτό ως προεπιλογή."
+msgstr ""
+"Κάντε εναλλαγή ώστε αυτό το στοιχείο ακορντεόν να είναι ανοικτό ως "
+"προεπιλογή."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Ρυθμίσεις στοιχείου ακορντεόν"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Προβολή ανοικτού"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Ρυθμίσεις χρώματος"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Χρώμα φόντου"
@@ -103,14 +65,6 @@ msgstr "Χρώμα φόντου"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Χρώμα κειμένου τίτλου"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Προσθήκη στοιχείου ακορντεόν"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Ακορντεόν"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +80,85 @@ msgstr "Υποστήριξη Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Προσθέστε υποστήριξη για τον Internet Explorer με τη φόρτωση ενός JavaScript polyfill."
+msgstr ""
+"Προσθέστε υποστήριξη για τον Internet Explorer με τη φόρτωση ενός JavaScript "
+"polyfill."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Παρέχεται υποστήριξη για τον Internet Explorer με τη φόρτωση ενός JavaScript polyfill σε αυτή τη σελίδα."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Παρέχεται υποστήριξη για τον Internet Explorer με τη φόρτωση ενός JavaScript "
+"polyfill σε αυτή τη σελίδα."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Προειδοποίηση"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Σφάλμα"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Τύπος ειδοποίησης"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Προεπιλογή"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Πληροφορίες"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Επιτυχία"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Γράψτε τον τίτλο..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Γράψτε το κείμενο..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Ειδοποίηση"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Παρέχετε μηνύματα ανάδρασης ανάλογα με το συγκείμενο."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "προειδοποίηση"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "μήνυμα"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Χρώμα κειμένου"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Επεξεργασία εικόνας"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Επεξεργασία συλλογής"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Αφαίρεση εικόνας"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Γράψτε μια λεζάντα..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Αποθέστε για προσθήκη ως avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Επικεφαλίδα..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Όνομα συντάκτη"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Γράψτε το βιογραφικό..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Ρυθμίσεις φορμών"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Συντάκτης"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Προτρέψτε τους επισκέπτες να αναλάβουν δράση με πολλά κουμπιά, το ένα δίπλα "
+"στο άλλο."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Προσθέστε ένα βιογραφικό συντάκτη."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "βιογραφικό"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "προφίλ"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Κουμπιά"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Προτρέψτε τους επισκέπτες να αναλάβουν δράση με πολλά κουμπιά, το ένα δίπλα στο άλλο."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "σύνδεση"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "πρόσκληση σε δράση"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Ρυθμίσεις κουμπιών"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Στοίβαξη σε κινητό"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +176,27 @@ msgstr "Όνομα χρήστη Twitter"
 msgid "Username"
 msgstr "Όνομα χρήστη"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Προσθήκη κουμπιού..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Προσθήκη μιας φράσης για τουιτάρισμα..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Κλικ για τουιτάρισμα"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
-msgstr "Προσθέστε μια φράση την οποία μπορούν να τουιτάρουν οι αναγνώστες μέσω του Twitter."
+msgstr ""
+"Προσθέστε μια φράση την οποία μπορούν να τουιτάρουν οι αναγνώστες μέσω του "
+"Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "διαμοιρασμός"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +204,19 @@ msgid "Text Settings"
 msgstr "Ρυθμίσεις κειμένου"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Χρώμα κουμπιού"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Δυναμικό HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
-msgstr "Προσθέστε έναν αποστάτη με δυνατότητα αλλαγή μεγέθους μεταξύ άλλων μπλοκ."
-
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "αποστάτης"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Ρυθμίσεις δυναμικού HR"
+msgstr ""
+"Προσθέστε έναν αποστάτη με δυνατότητα αλλαγή μεγέθους μεταξύ άλλων μπλοκ."
 
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Ύψος σε pixel"
 
@@ -347,17 +228,12 @@ msgstr "Το ύψος του δυναμικού στοιχείου διαχωρ�
 msgid "Color"
 msgstr "Χρώμα"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Προσθήκη ως φόντου"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Χαρακτηριστικό"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "Μια μοναδική θυγατρική στήλη μέσα σε ένα γονικό μπλοκ χαρακτηριστικών."
 
@@ -366,73 +242,56 @@ msgid "Feature Settings"
 msgstr "Ρυθμίσεις χαρακτηριστικού"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Γέμισμα"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Χαρακτηριστικά"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Προσθέστε έως τρεις στήλες σύντομων σημειώσεων για το προϊόν ή την υπηρεσία σας."
+msgstr ""
+"Προσθέστε έως τρεις στήλες σύντομων σημειώσεων για το προϊόν ή την υπηρεσία "
+"σας."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "υπηρεσίες"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Περιθώριο"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Κενό"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Διάστημα ανάμεσα σε κάθε στήλη."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Μικρό"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Μεσαίο"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +301,8 @@ msgstr "Μεγάλο"
 msgid "Features Settings"
 msgstr "Ρυθμίσεις χαρακτηριστικών"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Στήλες"
 
@@ -455,76 +314,72 @@ msgstr "Προσθήκη ενότητας μενού"
 msgid "Menu title..."
 msgstr "Τίτλος μενού..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Πλέγμα"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Λίστα"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Αποθέστε την εικόνα για αντικατάσταση"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Αφαίρεση εικόνας"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Προσθήκη τίτλου..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Πικάντικο"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Καυτερό"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Για χορτοφάγους"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Χωρίς γλουτένη"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Για χορτοφάγους/ψαροφάγους"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Για βίγκαν"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Προσθήκη περιγραφής..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0,00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Στοιχείο τροφίμου"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Ένα στοιχείο τροφίμου και ποτού μέσα σε μπλοκ Τρόφιμα και ποτά."
 
@@ -560,62 +415,46 @@ msgstr "Κάντε εναλλαγή για προβολή της τιμής γι
 msgid "Item Attributes"
 msgstr "Χαρακτηριστικά στοιχείου"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Πιο καυτερό"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Ρυθμίσεις εικόνων"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Κείμενο Alt (εναλλακτικό κείμενο)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Περιγράψτε τον σκοπό της εικόνας"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Αφήστε το κενό αν η εικόνα είναι απλά διακοσμητική."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Σημείο εστίασης"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Τρόφιμα και ποτά"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Προβολή ενός μενού ή τιμοκαταλόγου."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "εστιατόριο"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "μενού"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Στυλ"
@@ -648,134 +487,86 @@ msgstr "Προβολή της τιμής για κάθε στοιχείο"
 msgid "Toggle to show the price of each item."
 msgstr "Κάντε εναλλαγή για προβολή της τιμής για κάθε στοιχείο."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Email"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "e-mail"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "mail"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Ένα πεδίο διεύθυνσης email."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Μήνυμα"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Περιοχή κειμένου"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Πολλές γραμμές κειμένου"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Ένα πλαίσιο κειμένου για πιο μακροσκελείς απαντήσεις."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "Το %s δεν είναι έγκυρη διεύθυνση email."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "Τα %s και %s δεν είναι έγκυρες διευθύνσεις email."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "Τα %s δεν είναι έγκυρη διεύθυνση email"
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Διεύθυνση email"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Θέμα"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Ρυθμίσεις φορμών"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Προσθέστε τον κλειδί ιστότοπου reCAPTCHA και το μυστικό κλειδί σας για προστασία της φόρμας σας από spam."
+msgstr ""
+"Προσθέστε τον κλειδί ιστότοπου reCAPTCHA και το μυστικό κλειδί σας για "
+"προστασία της φόρμας σας από spam."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Δημιουργία κλειδιών"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Τα κλειδιά μου"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Λήψη βοήθειας"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Κλειδί ιστότοπου"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Μυστικό κλειδί"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Γίνεται αποθήκευση"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Κατάργηση"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Όνομα"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Επώνυμο"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Ονοματεπώνυμο"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Ένα πεδίο κειμένου για ονόματα."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Ένα πεδίο διεύθυνσης email."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Προσθήκη ετικέτας..."
 
@@ -783,41 +574,38 @@ msgstr "Προσθήκη ετικέτας..."
 msgid "Required"
 msgstr "Απαιτείται"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Ρυθμίσεις πεδίου ονόματος"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Επώνυμο"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Εμφανίζονται και τα δύο πεδία, για όνομα και επώνυμο."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Κάντε εναλλαγή για προσθήκη ενός πεδίου για το επώνυμο."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Φόρμα"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Ένα πεδίο κειμένου για ονόματα."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Ένα πλαίσιο κειμένου για πιο μακροσκελείς απαντήσεις."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Προσθέστε μια απλή φόρμα στη σελίδα σας."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "email"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "σχετικά"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "επικοινωνία"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Θέμα"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +615,220 @@ msgstr "Προσθέστε κείμενο..."
 msgid "Button Text Color"
 msgstr "Χρώμα κειμένου κουμπιού"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Επεξεργασία συλλογής"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Καρουσέλ"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "εικόνα %1$d από %2$d στη συλλογή"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Γράψτε μια λεζάντα..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Καρουσέλ"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Προβάλετε πολλές εικόνες σε μια πανέμορφη συλλογή με μορφή καρουσέλ."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "συλλογή"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "φωτογραφίες"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Ρυθμίσεις %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Ύψος γραμμής"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Προβολή κουκκίδων πλοήγησης."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Κάντε εναλλαγή για προβολή των λεζαντών πολυμέσων."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Ρυθμίσεις χρώματος"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Στρογγυλεμένες γωνίες"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Χρώμα λεζάντας"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Εφαρμογή"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Τοιχοποιία"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Γράψτε την περιγραφή..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Προβάλετε πολλές εικόνες σε μια οργανωμένη συλλογή με μορφή τοιχοποιίας."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Προβάλετε πολλές εικόνες σε μια πανέμορφη συλλογή με μορφή καρουσέλ."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Μέγεθος στήλης"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Ρυθμίσεις εικόνων"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Προσθέστε στρογγυλεμένες γωνίες στα στοιχεία της συλλογής."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Σκιά"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Λεζάντες"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Στυλ λεζάντας"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Προβολή λεζαντών για κάθε στοιχείο πολυμέσων."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Κάντε εναλλαγή για προβολή των λεζαντών πολυμέσων."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Τοιχοποιία"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr ""
+"Προβάλετε πολλές εικόνες σε μια οργανωμένη συλλογή με μορφή τοιχοποιίας."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Κάντε εναλλαγή για ενεργοποίηση των επιλογών στοιχείων ελέγχου χάρτη."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Ρυθμίσεις χάρτη"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Μέγεθος στήλης"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Προσθέστε στρογγυλεμένες γωνίες στα στοιχεία της συλλογής."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Φωτεινό"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Στοίβαξη"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Προβάλετε πολλές εικόνες σε συλλογή στοιβαγμένες σε μία μόνο στήλη."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Εικόνες πλήρους πλάτους"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Εικόνα πλήρους πλάτους"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Σκιά πλαισίου"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Οι εικόνες πλήρους πλάτους είναι ενεργοποιημένες."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Κάντε εναλλαγή για να συμπληρωθεί ο διαθέσιμος χώρος της συλλογής εξ ολοκλήρου με εικόνες πλήρους πλάτους."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Κάντε εναλλαγή για να συμπληρωθεί ο διαθέσιμος χώρος της συλλογής εξ "
+"ολοκλήρου με εικόνες πλήρους πλάτους."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Ρυθμίσεις στοιχείου"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Εικόνες πλήρους πλάτους"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Εικόνα πλήρους πλάτους"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Αφαίρεση gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Αυτό το gif έχει κενό χαρακτηριστικό alt"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Κάντε αναζήτηση για το τέλειο gif στο Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Κάντε αναζήτηση για gif"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Διαλέξτε ένα οποιοδήποτε gif."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "με κίνηση"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +854,11 @@ msgstr "Αρχείο GitHub"
 msgid "File"
 msgstr "Αρχείο"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Προβολή αυτού του gist στο GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist URL"
 
@@ -1024,12 +871,9 @@ msgid "Loading Gist"
 msgstr "Γίνεται φόρτωση Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Κάντε ενσωμάτωση GitHub gists προσθέτοντας τη σύνδεση των link."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "κωδικός"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +896,160 @@ msgid "Gist Meta"
 msgstr "Μετα-δεδομένα gist"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Αλλαγή διάταξης"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Προσθήκη φόντου στο %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Ήρωας"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Ένας χώρος εισαγωγής μιας σελίδας που συνοδεύεται από μικρή ποσότητα "
+"κειμένου και μια κλήση προς ενέργεια."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Ένας χώρος εισαγωγής μιας σελίδας που συνοδεύεται από μικρή ποσότητα κειμένου και μια κλήση προς ενέργεια."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "κουμπί"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "κλήση προς ενέργεια"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Πλάτος περιεχομένου σε pixel"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Ρυθμίσεις Hero"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Κενό διάστημα εντός του περιέκτη."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Επάνω αριστερά"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Επάνω στο κέντρο"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Επάνω δεξιά"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Κέντρο αριστερά"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Κέντρο κέντρο"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Κέντρο δεξιά"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Κάτω αριστερά"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Κάτω στο κέντρο"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Κάτω δεξιά"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Προσθήκη επισημασμένου κειμένου..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Επισήμανση"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Επισημάνετε το κείμενο."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "κείμενο"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "παράγραφος"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Εικονίδιο"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Προσθέστε ένα στυλιζαρισμένο γραφικό για να επικοινωνήσετε κάτι επιπλέον."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "εικονίδια"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Τεράστιο"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr ""
+"Προσθέστε ένα στυλιζαρισμένο γραφικό για να επικοινωνήσετε κάτι επιπλέον."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Ρυθμίσεις εικονιδίου"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Απενεργοποίηση προηγμένων ρυθμίσεων %s"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Επαναφορά"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Προσαρμοσμένο μέγεθος %s"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Προηγμένες ρυθμίσεις %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Προσαρμογή"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Προηγμένες"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Radius"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Αναζήτηση εικονιδίων"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Δεν βρέθηκαν αποτελέσματα."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Ρυθμίσεις σύνδεσης"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL συνδέσμου"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Σχετική σύνδεση"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Γίνεται άνοιγμα σε νέα καρτέλα"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Άνοιγμα σε νέα καρτέλα"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Χρώμα εικονιδίου"
 
@@ -1261,30 +1058,20 @@ msgid "Edit logos"
 msgstr "Επεξεργασία λογότυπων"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Λογότυπα και διακριτικά"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Κάντε μεταφορά εικόνων, αποστολή νέων ή επιλογή αρχείων από τη βιβλιοθήκη σας."
+msgstr ""
+"Κάντε μεταφορά εικόνων, αποστολή νέων ή επιλογή αρχείων από τη βιβλιοθήκη "
+"σας."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Προσθέστε λογότυπα, διακριτικά ή πιστοποιήσεις για αύξηση της αξιοπιστίας."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "πελάτες"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "καταξίωση"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "μαρτυρίες"
+msgstr ""
+"Προσθέστε λογότυπα, διακριτικά ή πιστοποιήσεις για αύξηση της αξιοπιστίας."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1093,148 @@ msgstr "Επεξεργασία θέσης"
 msgid "Map style"
 msgstr "Στυλ χάρτη"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Μη έγκυρο κλειδί API ή υπερβολικός αριθμός αιτημάτων"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Χάρτης Google"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Καταχωρήστε μια τοποθεσία ή διεύθυνση για να προστεθεί μια καρφίτσα σε έναν χάρτη Google."
+msgstr ""
+"Καταχωρήστε μια τοποθεσία ή διεύθυνση για να προστεθεί μια καρφίτσα σε έναν "
+"χάρτη Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Κάντε αναζήτηση για έναν τόπο ή μια διεύθυνση..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Εφαρμογή"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Χάρτης"
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
+msgstr ""
+"Προσθέστε μια διεύθυνση για να προστεθεί καρφίτσα σε έναν χάρτη Google."
 
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
-msgstr "Προσθέστε μια διεύθυνση για να προστεθεί καρφίτσα σε έναν χάρτη Google."
-
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "διεύθυνση"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "χάρτες"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Επιλογή στυλ χάρτη"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Ρυθμίσεις χάρτη"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Επίπεδο ζουμ"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Ύψος χάρτη σε pixel"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Επίπεδο ζουμ"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Μέγεθος σημαντήρα"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Οι επιλογές λεπτομερούς στοιχείων ελέγχου είναι ενεργοποιημένες."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Κάντε εναλλαγή για ενεργοποίηση των επιλογών στοιχείων ελέγχου χάρτη."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Στοιχεία ελέγχου χάρτη"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Τύπος χάρτη"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "Η μετάβαση μεταξύ τυπικής προβολής και προβολής δορυφορικού χάρτη είναι ενεργοποιημένη."
+msgstr ""
+"Η μετάβαση μεταξύ τυπικής προβολής και προβολής δορυφορικού χάρτη είναι "
+"ενεργοποιημένη."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Κάντε εναλλαγή για ενεργοποίηση της μετάβασης μεταξύ τυπικής προβολής και προβολής δορυφορικού χάρτη."
+msgstr ""
+"Κάντε εναλλαγή για ενεργοποίηση της μετάβασης μεταξύ τυπικής προβολής και "
+"προβολής δορυφορικού χάρτη."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Στοιχεία ελέγχου ζουμ"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Προβολή των στοιχείων ελέγχου ζουμ χάρτη."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Κάντε εναλλαγή για ενεργοποίηση της μεγέθυνσης και σμίκρυνσης του χάρτη με τα στοιχεία ελέγχου ζουμ."
+msgstr ""
+"Κάντε εναλλαγή για ενεργοποίηση της μεγέθυνσης και σμίκρυνσης του χάρτη με "
+"τα στοιχεία ελέγχου ζουμ."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Street View"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Προβολή του στοιχείου ελέγχου χάρτη Street View."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Κάντε εναλλαγή για προβολή του στοιχείου ελέγχου Street View κάτω δεξιά."
+msgstr ""
+"Κάντε εναλλαγή για προβολή του στοιχείου ελέγχου Street View κάτω δεξιά."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Εναλλαγή πλήρους οθόνης"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Προβολή του στοιχείου ελέγχου χάρτη πλήρους οθόνης."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Κάντε εναλλαγή για προβολή του στοιχείου ελέγχου χάρτη πλήρους οθόνης."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Κλειδί API Χαρτών Google"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Προσθέστε το κλειδί σας API για τους Χάρτες Google. Αν ενημερώσετε αυτό το κλειδί API όλοι οι χάρτες σας θα ρυθμιστούν να χρησιμοποιούν το νέο κλειδί."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Προσθέστε το κλειδί σας API για τους Χάρτες Google. Αν ενημερώσετε αυτό το "
+"κλειδί API όλοι οι χάρτες σας θα ρυθμιστούν να χρησιμοποιούν το νέο κλειδί."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Ανάκτηση του κλειδιού σας"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Θέλετε βοήθεια;"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Καταχώρηση κλειδιού Google API..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Αποθηκεύτηκε"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Κανονικό"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Ασημί"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Ρετρό"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Σκοτεινό"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Νυχτερινό"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Μελιτζανί"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1244,9 @@ msgstr "Πολυμέσα στα δεξιά"
 msgid "Media on left"
 msgstr "Πολυμέσα στα αριστερά"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Κάρτα πολυμέσων"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Προσθέστε μια εικόνα ή ένα βίντεο με μια κάρτα μετατόπισης πλάι-πλάι."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "εικόνα"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "βίντεο"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1260,18 @@ msgstr "Προβολή σκιάς κάρτας."
 msgid "Toggle to add a card shadow."
 msgstr "Κάντε εναλλαγή για προσθήκη σκιάς κάρτας."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Σκιά %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Προβολή σκιάς %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Κάντε εναλλαγή για προσθήκη σκιάς %s."
 
@@ -1545,40 +1295,171 @@ msgstr "Αποθέστε το πολυμέσο για αντικατάσταση
 msgid "Edit media"
 msgstr "Επεξεργασία πολυμέσου"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Πίνακες %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Πρόγραμμα %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Καρουσέλ"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Ρυθμίσεις χρώματος"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Προβολή της τιμής για αυτό το στοιχείο."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Κάντε εναλλαγή για προβολή των μετα-δεδομένων του gist."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Προβολή του κουμπιού κλήσης προς ενέργεια."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Κάντε εναλλαγή για προβολή των μετα-δεδομένων του gist."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Ρυθμίσεις χαρακτηριστικού"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Πολυμέσα στα αριστερά"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Πολυμέσα στα δεξιά"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Μέγεθος στήλης"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Ρυθμίσεις gist"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Πίνακας τιμών"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Πίνακας τιμών"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Πίνακας τιμών"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Πίνακας τιμών"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Προσθήκη πινάκων τιμών."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "είσοδος"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Πρόγραμμα %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "σύγκριση"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Ρυθμίσεις πίνακα τιμών"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Πίνακες"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1477,171 @@ msgstr "Πρόγραμμα Α"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Στοιχείο πίνακα τιμών"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Μια στήλη τοποθετημένη εντός του μπλοκ πίνακα τιμών."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Προσθήκη φόντου στο %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Στήλη"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Ένα άμεσο θυγατρικό στοιχείο μιας γραμμής."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Πλάτος"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Ρυθμίσεις στήλης"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Κενό διάστημα γύρω από τον περιέκτη."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Πλάτος"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Αλλαγή διάταξης"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "μίας"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "δύο"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "τριών"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "τεσσάρων"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Προσθήκη φόντου στο %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Μία στήλη"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Δύο στήλες"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Τρεις στήλες"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Τέσσερις στήλες"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Διάταξη γραμμής"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Γραμμή"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Και τώρα επιλέξτε μια διάταξη για αυτή τη γραμμή %s στήλης/στηλών."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Επιλέξτε τον αριθμό στηλών για αυτή τη γραμμή."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Επιλογή στηλών γραμμής"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Επιλογή διάταξης γραμμής"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Επιστροφή στις στήλες"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Προσθέστε ένα δομημένο wrapper για τα στοιχεία στηλών και, στη συνέχεια, προσθέστε τα στοιχεία περιεχομένου που επιθυμείτε στις στήλες."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Προσθέστε ένα δομημένο wrapper για τα στοιχεία στηλών και, στη συνέχεια, "
+"προσθέστε τα στοιχεία περιεχομένου που επιθυμείτε στις στήλες."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "γραμμές"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "στήλες"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "διατάξεις"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Διάταξη"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Ρυθμίσεις γραμμής"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Κανένα"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1651,9 @@ msgstr "Τετράγωνο"
 msgid "Circle"
 msgstr "Κύκλος"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Υπηρεσίες"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Προσθέστε έως τέσσερις στήλες υπηρεσιών για προβολή."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "χαρακτηριστικά"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1675,7 @@ msgstr "Προβολή των κουμπιών κλήσης προς ενέργ�
 msgid "Toggle to show call to action buttons."
 msgstr "Κάντε εναλλαγή για προβολή των κουμπιών κλήσης προς ενέργεια."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Υπηρεσία"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Ένα στοιχείο μίας μόνο υπηρεσίας εντός ενός μπλοκ υπηρεσιών."
 
@@ -1785,264 +1696,233 @@ msgid "Toggle to show a call to action button."
 msgstr "Κάντε εναλλαγή για προβολή ενός κουμπιού κλήσης προς ενέργεια."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Οριζόντια αναστροφή"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Κατακόρυφη αναστροφή"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Διαχωριστικό σχήματος"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Προσθέστε ένα διαχωριστικό σχήματος για να είναι διακριτές στο μάτι οι ενότητες της σελίδας."
+msgstr ""
+"Προσθέστε ένα διαχωριστικό σχήματος για να είναι διακριτές στο μάτι οι "
+"ενότητες της σελίδας."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "διαχωριστικό"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Χρώμα σχήματος"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Ρυθμίσεις διαχωριστικού"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Ύψος σχήματος σε pixel"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Ύψος φόντου σε pixel"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Προσανατολισμός"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Χρώμα σχήματος"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Διαμοιρασμός στο Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Διαμοιρασμός στο Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Διαμοιρασμός στο Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Διαμοιρασμός στο Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Διαμοιρασμός στο LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Διαμοιρασμός μέσω Email"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Διαμοιρασμός στο Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Διαμοιρασμός στο Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Διαμοιρασμός στο Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Κοινή χρήση"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "κοινωνικά δίκτυα"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Προσθέστε συνδέσεις διαμοιρασμού σε κοινωνικά δίκτυα για να δηλώσουν άλλοι χρήστες ότι τους αρέσει και να το διαμοιραστούν."
+msgstr ""
+"Προσθέστε συνδέσεις διαμοιρασμού σε κοινωνικά δίκτυα για να δηλώσουν άλλοι "
+"χρήστες ότι τους αρέσει και να το διαμοιραστούν."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Χρώματα κοινωνικών δικτύων"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Μέγεθος εικονιδίου"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Μέγεθος κύκλου"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Μέγεθος κουμπιού"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Εικονίδια"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Τα χρώματα κουμπιού διαμοιρασμού είναι ενεργοποιημένα."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Κάντε εναλλαγή για χρήση των επίσημων χρωμάτων κάθε πλατφόρμας μέσων κοινωνικής δικτύωσης."
+msgstr ""
+"Κάντε εναλλαγή για χρήση των επίσημων χρωμάτων κάθε πλατφόρμας μέσων "
+"κοινωνικής δικτύωσης."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Χρώματα κοινωνικών δικτύων"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Προσθήκη προφίλ στο Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Προσθήκη προφίλ στο Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Προσθήκη προφίλ στο Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Προσθήκη προφίλ στο Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Προσθήκη προφίλ στο LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Προσθήκη προφίλ στο YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Προσθήκη προφίλ στο Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Προσθήκη προφίλ στο Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Προφίλ κοινωνικών δικτύων"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "συνδέσεις"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Προβολή συνδέσεων προς τα προφίλ σε μέσα κοινωνικής δικτύωσης."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Συνδέσεις προφίλ"
 
@@ -2057,18 +1937,6 @@ msgstr "Αφαίρεση φόντου"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Φόντο"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Αυτόματη"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Κάλυψη"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Συμπερίληψη"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1994,6 @@ msgstr "Αφαίρεση φόντου"
 msgid "Remove "
 msgstr "Αφαίρεση "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Χωρίς επανάληψη"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Επανάληψη οριζόντια"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Επανάληψη κατακόρυφα"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Μετακίνηση εικόνας πίσω"
@@ -2150,17 +2006,14 @@ msgstr "Μετακίνηση εικόνας εμπρός"
 msgid "Link To"
 msgstr "Σύνδεση προς"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Συλλογή %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Αποστολή μιας εικόνας"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Φωτεινό"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2027,110 @@ msgstr "Σελίδα συνημμένου"
 msgid "Custom URL"
 msgstr "Προσαρμοσμένο URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Προσανατολισμός"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Ποσοστό"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Επαναφορά"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Επιλογή μονάδων"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "Μονάδες: %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Απενεργοποίηση προηγμένων ρυθμίσεων %s"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "Επάνω: %s"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "Δεξιά: %s"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "Κάτω: %s"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "Αριστερά: %s"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Κατάργηση συγχρονισμού"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Συγχρονισμός"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Συγχρονισμός μονάδων"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Επάνω"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Δεξιά"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Κάτω"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Αριστερά"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Προηγμένες ρυθμίσεις %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Προηγμένες"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Προεπιλογή"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Διάταξη"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2149,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Κάντε εναλλαγή για ενεργοποίηση της λειτουργίας πλήρους οθόνης."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Επικεφαλίδα %d"
@@ -2263,43 +2158,16 @@ msgstr "Επικεφαλίδα %d"
 msgid "Custom color picker"
 msgstr "Επιλογέας προσαρμοσμένων χρωμάτων"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Πρωτότυπο"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Κλίμακα του γκρίζου"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Σέπια"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Κορεσμός"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Αμυδρή"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Αντίκα"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Εφαρμογή φίλτρου"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Επιλογή προσανατολισμού"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Ύψος"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Κινητό %s"
@@ -2333,7 +2201,8 @@ msgid "Five Seconds"
 msgstr "Πέντε δευτερόλεπτα"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Έξι δευτερόλεπτα"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2221,22 @@ msgstr "Εννέα δευτερόλεπτα"
 msgid "Ten Seconds"
 msgstr "Δέκα δευτερόλεπτα"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Πλοήγηση με βέλη"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Πλοήγηση με κουκκίδες"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "δευτερόλεπτα"
@@ -2361,22 +2246,30 @@ msgid "second"
 msgstr "δευτερόλεπτο"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Προώθηση μετά από %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Αυτόματη προώθηση στην επόμενη διαφάνεια."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
-msgstr "Η μεταφορά και στιγμιαία μετακίνηση έχουν ενεργοποιηθεί σε επιτραπέζιες και κινητές συσκευές."
+#, fuzzy
+msgid "Dragging and flicking enabled."
+msgstr ""
+"Η μεταφορά και στιγμιαία μετακίνηση έχουν ενεργοποιηθεί σε επιτραπέζιες και "
+"κινητές συσκευές."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Κάντε εναλλαγή για ενεργοποίηση της λειτουργικότητας μεταφοράς σε επιτραπέζιες και κινητές συσκευές."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Κάντε εναλλαγή για ενεργοποίηση της λειτουργικότητας μεταφοράς σε "
+"επιτραπέζιες και κινητές συσκευές."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2280,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Κάντε εναλλαγή για προβολή βελών πλοήγησης μεταξύ των διαφανειών."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Προβολή κουκκίδων πλοήγησης."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Κάντε εναλλαγή για προβολή κουκκίδων πλοήγησης."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Κενό διάστημα εντός του περιέκτη."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Εναλλαγή για σίγαση του βίντεο."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Κάντε εναλλαγή για συνεχή αναπαραγωγή του βίντεο."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Ρυθμίσεις εναλλαγής διαφανειών"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Αυτόματη αναπαραγωγή"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Ταχύτητα μετάβασης"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Δυνατότητα μεταφοράς"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Πλοήγηση με βέλη"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Πλοήγηση με κουκκίδες"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Όλα κεφαλαία"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Κανονικό"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2367,6 @@ msgstr "Χωρίς διάστημα κάτω"
 msgid "Change typography"
 msgstr "Αλλαγή τυπογραφικών στοιχείων"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Έντονη γραφή"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Κεφαλαία"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Πεζά"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Στοίβαξη σε κινητό"
@@ -2481,31 +2377,37 @@ msgstr "Η σχεδίαση μεταβαλλόμενου μεγέθους είν
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Κάντε εναλλαγή για στοίβαξη των στοιχείων το ένα επάνω στο άλλο σε μικρότερα πλαίσια προβολής."
+msgstr ""
+"Κάντε εναλλαγή για στοίβαξη των στοιχείων το ένα επάνω στο άλλο σε μικρότερα "
+"πλαίσια προβολής."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Κατάργηση διαστήματος επάνω"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Το επάνω περιθώριο έχει αφαιρεθεί από αυτό το μπλοκ."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Κάντε εναλλαγή για προσθήκη σκιάς κάρτας."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Κάντε εναλλαγή για κατάργηση οποιουδήποτε περιθωρίου έχει εφαρμοστεί στο επάνω μέρος αυτού του μπλοκ."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Κάντε εναλλαγή για προβολή κουκκίδων πλοήγησης."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Κατάργηση διαστήματος κάτω"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Το κάτω περιθώριο έχει αφαιρεθεί από αυτό το μπλοκ."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Κάντε εναλλαγή για προσθήκη σκιάς κάρτας."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Κάντε εναλλαγή για κατάργηση οποιουδήποτε περιθωρίου έχει εφαρμοστεί στο κάτω μέρος αυτού του μπλοκ."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Κάντε εναλλαγή για προβολή κουκκίδων πλοήγησης."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2421,14 @@ msgstr "Προβολή σε πλήρες πλάτος."
 msgid "Toggle to display button as full width."
 msgstr "Κάντε εναλλαγή για προβολή του κουμπιού σε πλήρες πλάτος."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Κυκλικό"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Ρυθμίσεις Hero"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Σκιά"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Πλαίσιο ελέγχου"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Κεφαλαία"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2448,801 @@ msgstr "Αναζήτηση ενός μπλοκ"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Αυτό το μπλοκ προστέθηκε στη σελίδα και δεν μπορεί προς το παρόν να απενεργοποιηθεί"
+msgstr ""
+"Αυτό το μπλοκ προστέθηκε στη σελίδα και δεν μπορεί προς το παρόν να "
+"απενεργοποιηθεί"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Απενεργοποίηση όλων"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Δεν βρέθηκαν μπλοκ τύπου \"%s\"."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Συλλογές %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Προβολή ανοικτών"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Προσθήκη τίτλου ακορντεόν"
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Στοιχείο ακορντεόν"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "καρτέλες"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "συχνές ερωτήσεις"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "προειδοποίηση"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "μήνυμα"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "βιογραφικό"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "προφίλ"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "σύνδεση"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "πρόσκληση σε δράση"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "διαμοιρασμός"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "αποστάτης"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "υπηρεσίες"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "μενού"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "εστιατόριο"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "e-mail"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "mail"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Επώνυμο"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Περιοχή κειμένου"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Πολλές γραμμές κειμένου"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "email"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "σχετικά"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "επικοινωνία"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "συλλογή"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "φωτογραφίες"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Νυχτερινό"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "με κίνηση"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "κωδικός"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "κουμπί"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "κλήση προς ενέργεια"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "κείμενο"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "παράγραφος"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "εικονίδια"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "πελάτες"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "καταξίωση"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "μαρτυρίες"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "διεύθυνση"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "χάρτες"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "εικόνα"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "βίντεο"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "διεύθυνση"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "είσοδος"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "σύγκριση"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "γραμμές"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "στήλες"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "διατάξεις"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "χαρακτηριστικά"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "διαχωριστικό"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "κοινωνικά δίκτυα"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "συνδέσεις"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Προβολή ανοικτού"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Προσθήκη στοιχείου ακορντεόν"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Ακορντεόν"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Γράψτε το κείμενο..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Γράψτε τον τίτλο..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Ειδοποίηση"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Συντάκτης"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Κουμπιά"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Κλικ για τουιτάρισμα"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Δυναμικό HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Χαρακτηριστικό"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Χαρακτηριστικά"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Στοιχείο τροφίμου"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Τρόφιμα και ποτά"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Ονοματεπώνυμο"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Μήνυμα"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Φόρμα"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Καρουσέλ"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Τοιχοποιία"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Στοίβαξη"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Ήρωας"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Επισήμανση"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Εικονίδιο"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Λογότυπα και διακριτικά"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Χάρτης"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Κάρτα πολυμέσων"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Καρουσέλ"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Πίνακας τιμών"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Στοιχείο πίνακα τιμών"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Στήλη"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Γραμμή"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Υπηρεσίες"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Υπηρεσία"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Διαχωριστικό σχήματος"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Κοινή χρήση"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Προφίλ κοινωνικών δικτύων"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Πληροφορίες"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Επιτυχία"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Προειδοποίηση"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Σφάλμα"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Κουκκίδες"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Γραμμή"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Πλήρους πλάτους"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Πλέγμα"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Λίστα"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Προεπιλογή"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Επίπεδα"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Με περίγραμμα"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Με γέμισμα"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Στοίβαξη"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Επανάληψη οριζόντια"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Κυματιστό"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Λοφάκια"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Κύματα"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Λοξό"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Βουναλάκι"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Στρογγυλεμένο"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Τρίγωνο"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Κοιλάδα"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Κάλυψη"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Εικονίδιο"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Κείμενο"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Εικονίδιο και κείμενο"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Κυκλικό"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Κάτω αριστερά"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Επάνω αριστερά"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Αποθέστε για προσθήκη ως avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Συντάκτης"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3262,34 @@ msgstr "Προσθήκη χαρακτηριστικού"
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Αυτό είναι ένα μπλοκ χαρακτηριστικών με το οποίο μπορείτε να επισημάνετε τα χαρακτηριστικά."
+msgstr ""
+"Αυτό είναι ένα μπλοκ χαρακτηριστικών με το οποίο μπορείτε να επισημάνετε τα "
+"χαρακτηριστικά."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Προσθήκη επικεφαλίδας-ήρωα..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Προσθήκη επικεφαλίδας-ήρωα..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Προσθήκη περιεχομένου-ήρωα, που συνήθως είναι ένας χώρος εισαγωγής μιας "
+"σελίδας που συνοδεύεται από μια ή δύο κλήσεις προς ενέργεια."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Προσθήκη περιεχομένου-ήρωα, που συνήθως είναι ένας χώρος εισαγωγής μιας σελίδας που συνοδεύεται από μια ή δύο κλήσεις προς ενέργεια."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Προσθήκη κύριας ενέργειας..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Προσθήκη δευτερεύουσας ενέργειας..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3308,126 @@ msgstr "Προσθήκη περιεχομένου..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Αντικαταστήστε αυτό το κείμενο με περιγραφικό κείμενο που συνοδεύει την εικόνα της κάρτας. Στη συνέχεια, προσθέστε κι άλλα μπλοκ σε αυτή την κάρτα, όπως κουμπιά, λίστες ή εικόνες."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Αντικαταστήστε αυτό το κείμενο με περιγραφικό κείμενο που συνοδεύει την "
+"εικόνα της κάρτας. Στη συνέχεια, προσθέστε κι άλλα μπλοκ σε αυτή την κάρτα, "
+"όπως κουμπιά, λίστες ή εικόνες."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Γράψτε τον τίτλο..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Γράψτε την περιγραφή..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Κανονικό"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Ρυθμίσεις κουμπιών"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Προσαρμογή"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Στοίβαξη σε κινητό"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Ρυθμίσεις δυναμικού HR"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Κανένα"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Κανένα"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Μικρό"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Μεσαίο"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Μεγάλο"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Πολύ μεγάλο"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Κανένα"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Μικρό"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Μεσαίο"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Μεγάλο"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3080,7 +3767,9 @@ msgstr "κώδικας ελληνικά μαθηματικά"
 #: src/blocks/icon/svgs.js:143
 msgctxt "tags"
 msgid "drawing doodle art creative type font pencil marker"
-msgstr "σχεδίαση ζωγραφική μονοκοντυλιά τέχνη δημιουργικό γραφή γραμματοσειρά μολύβι μαρκαδόρος"
+msgstr ""
+"σχεδίαση ζωγραφική μονοκοντυλιά τέχνη δημιουργικό γραφή γραμματοσειρά μολύβι "
+"μαρκαδόρος"
 
 #: src/blocks/icon/svgs.js:15
 msgctxt "tags"
@@ -3125,7 +3814,8 @@ msgstr "usb σύνδεση διανομέας συσκευή κοινωνικά 
 #: src/blocks/icon/svgs.js:20
 msgctxt "tags"
 msgid "music microphone podcast song artist creative media audio"
-msgstr "μουσική μικρόφωνο podcast τραγούδι καλλιτέχνης δημιουργικό πολυμέσα ήχος"
+msgstr ""
+"μουσική μικρόφωνο podcast τραγούδι καλλιτέχνης δημιουργικό πολυμέσα ήχος"
 
 #: src/blocks/icon/svgs.js:209
 msgctxt "tags"
@@ -3180,7 +3870,8 @@ msgstr "κέφι πάρτι χαρά γιορτή γεύση τρόφιμα"
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "πέταλα μυρωδιά άρωμα όμορφα ριλάξ τοπίο κηπουρική ύπαιθρος εξωτερικός χώρος"
+msgstr ""
+"πέταλα μυρωδιά άρωμα όμορφα ριλάξ τοπίο κηπουρική ύπαιθρος εξωτερικός χώρος"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3210,7 +3901,8 @@ msgstr "γλώσσα υδρόγειος κόσμος ομιλία"
 #: src/blocks/icon/svgs.js:319
 msgctxt "tags"
 msgid "music microphone song artist creative media audio badge"
-msgstr "μουσική μικρόφωνο τραγούδι καλλιτέχνης δημιουργικό πολυμέσα ήχος διακριτικό"
+msgstr ""
+"μουσική μικρόφωνο τραγούδι καλλιτέχνης δημιουργικό πολυμέσα ήχος διακριτικό"
 
 #: src/blocks/icon/svgs.js:32
 msgctxt "tags"
@@ -3259,8 +3951,12 @@ msgstr "μουσική μικρόφωνο τραγούδι καλλιτέχνη�
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "μικρόφωνο podcast υπολογιστής συσκευή μουσική μικρόφωνο τραγούδι καλλιτέχνης δημιουργικό πολυμέσα ήχος"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"μικρόφωνο podcast υπολογιστής συσκευή μουσική μικρόφωνο τραγούδι καλλιτέχνης "
+"δημιουργικό πολυμέσα ήχος"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3980,12 @@ msgstr "φιλμ βιντεοσκόπηση σκηνοθέτης παραγωγ�
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "βίντεο βιντεοσκόπηση σκηνοθέτης παραγωγός πολυμέσα δημιουργικό κάμερα φωτογράφος φωτογραφία διάφραγμα"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"βίντεο βιντεοσκόπηση σκηνοθέτης παραγωγός πολυμέσα δημιουργικό κάμερα "
+"φωτογράφος φωτογραφία διάφραγμα"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +4002,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "παλέτα σχέδιο χρώματα καλλιτέχνης δημιουργικό πολυμέσα πινέλο ρολό"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Κανονικό"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Ασημί"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Ρετρό"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Σκοτεινό"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Νυχτερινό"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Μελιτζανί"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Κυκλικό"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Σκιά"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Προεπιλογή"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Κανένα"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Πλαίσιο ελέγχου"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Τίτλος μενού..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Μικρό"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Μεσαίο"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Μεγάλο"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Πολύ μεγάλο"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Αυτόματη"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Κάλυψη"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Συμπερίληψη"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Επάνω αριστερά"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Επάνω στο κέντρο"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Επάνω δεξιά"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Κέντρο αριστερά"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Κέντρο κέντρο"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Κέντρο δεξιά"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Κάτω αριστερά"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Κάτω στο κέντρο"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Κάτω δεξιά"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Χωρίς επανάληψη"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Επανάληψη"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Επανάληψη οριζόντια"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Επανάληψη κατακόρυφα"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Σχετική σύνδεση"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Σκοτεινό"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Φωτεινό"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Κανένα"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Εικόνα"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Pixel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Ποσοστό"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Πρωτότυπο"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Κλίμακα του γκρίζου"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Αρχείο πολυμέσων"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Κορεσμός"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Φίλτρο αντίκας"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Φίλτρο αντίκας"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Όλα κεφαλαία"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Κανονικό"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Έντονη γραφή"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Προεπιλογή"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Κεφαλαία"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Πεζά"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4350,16 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "Το CoBlocks είναι μια οικογένεια επαγγελματικών <strong>μπλοκ περιεχομένου κατασκευής σελίδων</strong> για το πρόγραμμα επεξεργασίας μπλοκ WordPress Gutenberg. Τα μπλοκ μας είναι ιδιαίτερα εστιασμένα στο να δίνουν την δυνατότητα στους σχεδιαστές να κατασκευάζουν πανέμορφες και πλούσιες σελίδες στο WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"Το CoBlocks είναι μια οικογένεια επαγγελματικών <strong>μπλοκ περιεχομένου "
+"κατασκευής σελίδων</strong> για το πρόγραμμα επεξεργασίας μπλοκ WordPress "
+"Gutenberg. Τα μπλοκ μας είναι ιδιαίτερα εστιασμένα στο να δίνουν την "
+"δυνατότητα στους σχεδιαστές να κατασκευάζουν πανέμορφες και πλούσιες σελίδες "
+"στο WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4369,173 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Πανεύκολο, σωστά;"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Αφήστε μια κριτική"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s έτη"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "ένα έτος"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s εβδομάδες"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "μία εβδομάδα"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s ημέρες"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "μία ημέρα"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s ώρες"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "μία ώρα"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s λεπτά"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "ένα λεπτό"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s δευτερόλεπτα"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "ένα δευτερόλεπτο"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Προσθήκη WordPress %s"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Σας αρέσει το %s;"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Χρησιμοποιείτε το %1$s για %2$s μέχρι στιγμής. Θα θέλατε να μας αφήσετε μια κριτική και να μας πείτε πώς σας φαίνεται; Θα το εκτιμήσουμε ιδιαίτερα!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Αφήστε μια κριτική"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Χρησιμοποιείτε το %1$s για %2$s μέχρι στιγμής. Θα θέλατε να μας αφήσετε μια "
+"κριτική και να μας πείτε πώς σας φαίνεται; Θα το εκτιμήσουμε ιδιαίτερα!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Όχι ευχαριστώ / Το έχω ήδη κάνει"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Ευχαριστούμε που επιλέξατε το CoBlocks, την εφαρμογή κατασκευής ποιοτικών σελίδων για το νέο πρόγραμμα επεξεργασίας μπλοκ του WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Ευχαριστούμε που επιλέξατε το CoBlocks, την εφαρμογή κατασκευής ποιοτικών "
+"σελίδων για το νέο πρόγραμμα επεξεργασίας μπλοκ του WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Μόλις προσθέσατε πολλά χρήσιμα μπλοκ και ένα νέο κιτ εργαλείων κατασκευής σελίδων στο πρόγραμμα επεξεργασίας του WordPress. Το CoBlocks σας παρέχει ένα απαράμιλλο σύνολο δυνατοτήτων: %1$sδεκάδες μπλοκ%2$s, μια %1$sεμπειρία κατασκευής σελίδων%2$s και %1$sπροσαρμοσμένα στοιχεία ελέγχου τυπογραφίας%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Μόλις προσθέσατε πολλά χρήσιμα μπλοκ και ένα νέο κιτ εργαλείων κατασκευής "
+"σελίδων στο πρόγραμμα επεξεργασίας του WordPress. Το CoBlocks σας παρέχει "
+"ένα απαράμιλλο σύνολο δυνατοτήτων: %1$sδεκάδες μπλοκ%2$s, μια %1$sεμπειρία "
+"κατασκευής σελίδων%2$s και %1$sπροσαρμοσμένα στοιχεία ελέγχου τυπογραφίας"
+"%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Ακολουθούν μερικά βίντεο που θα σας βοηθήσουν να ξεκινήσετε:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Παρακολουθήστε πώς να δημιουργήσετε την πρώτη σας σελίδα με το %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Παρακολουθήστε πώς να δημιουργήσετε την πρώτη σας σελίδα"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
-msgstr "Παρακολουθήστε πώς να χρησιμοποιήσετε τα μπλοκ διαχωριστικού γραμμής και διαχωριστικού σχήματος"
+msgstr ""
+"Παρακολουθήστε πώς να χρησιμοποιήσετε τα μπλοκ διαχωριστικού γραμμής και "
+"διαχωριστικού σχήματος"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Παρακολουθήστε πώς γίνεται χρήση του μπλοκ κάρτας πολυμέσων"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Σας αρέσει αυτό που βλέπετε; %1$sΕγγραφείτε στο κανάλι μας στο YouTube%2$sκαι θα σας ενημερώσουμε πότε κυκλοφορούν νέα βίντεο εκμάθησης."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Σας αρέσει αυτό που βλέπετε; %1$sΕγγραφείτε στο κανάλι μας στο YouTube"
+"%2$sκαι θα σας ενημερώσουμε πότε κυκλοφορούν νέα βίντεο εκμάθησης."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Αν έχετε απορίες ή σχόλια, ενημερώστε μας στο %1$sTwitter%4$s ή στην %2$sομάδα μας στο Facebook%4$s. Επίσης, %3$sεγγραφείτε για να λαμβάνετε το ενημερωτικό δελτίο μας%4$s αν θέλετε να είστε ενήμεροι για το τι νέο υπάρχει και τι επιφυλάσσει το μέλλον στο CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Αν έχετε απορίες ή σχόλια, ενημερώστε μας στο %1$sTwitter%4$s ή στην "
+"%2$sομάδα μας στο Facebook%4$s. Επίσης, %3$sεγγραφείτε για να λαμβάνετε το "
+"ενημερωτικό δελτίο μας%4$s αν θέλετε να είστε ενήμεροι για το τι νέο υπάρχει "
+"και τι επιφυλάσσει το μέλλον στο CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Απολαύστε το!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Ξεκινήστε με το CoBlocks εδώ:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4549,27 @@ msgstr "Κλειδί ιστότοπου Google reCaptcha για προστασί
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "Μυστικό κλειδί Google reCaptcha για προστασία φόρμας από spam"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Ονοματεπώνυμο"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Όνομα"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Επώνυμο"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Μήνυμα"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Υποβολή"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Το μήνυμά σας στάλθηκε:"
 
@@ -3490,3 +4584,89 @@ msgstr "Διαμοιρασμός στο LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "Τύπος ειδοποίησης"
+
+#~ msgid "Edit image"
+#~ msgstr "Επεξεργασία εικόνας"
+
+#~ msgid "Remove image"
+#~ msgstr "Αφαίρεση εικόνας"
+
+#~ msgid "Heading..."
+#~ msgstr "Επικεφαλίδα..."
+
+#~ msgid "Author Name"
+#~ msgstr "Όνομα συντάκτη"
+
+#~ msgid "Write biography..."
+#~ msgstr "Γράψτε το βιογραφικό..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Προσθέστε ένα βιογραφικό συντάκτη."
+
+#~ msgid "%s Settings"
+#~ msgstr "Ρυθμίσεις %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Χρώμα λεζάντας"
+
+#~ msgid "Highlight text."
+#~ msgstr "Επισημάνετε το κείμενο."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Πίνακες %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Ρυθμίσεις πίνακα τιμών"
+
+#~ msgid "Tables"
+#~ msgstr "Πίνακες"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Μια στήλη τοποθετημένη εντός του μπλοκ πίνακα τιμών."
+
+#~ msgid "Sepia"
+#~ msgstr "Σέπια"
+
+#~ msgid "Dim"
+#~ msgstr "Αμυδρή"
+
+#~ msgid "Vintage"
+#~ msgstr "Αντίκα"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Επιλογή προσανατολισμού"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Το επάνω περιθώριο έχει αφαιρεθεί από αυτό το μπλοκ."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Κάντε εναλλαγή για κατάργηση οποιουδήποτε περιθωρίου έχει εφαρμοστεί στο "
+#~ "επάνω μέρος αυτού του μπλοκ."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Το κάτω περιθώριο έχει αφαιρεθεί από αυτό το μπλοκ."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Κάντε εναλλαγή για κατάργηση οποιουδήποτε περιθωρίου έχει εφαρμοστεί στο "
+#~ "κάτω μέρος αυτού του μπλοκ."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Προσθήκη κύριας ενέργειας..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Προσθήκη δευτερεύουσας ενέργειας..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Κανονικό"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Ξεκινήστε με το CoBlocks εδώ:"

--- a/languages/coblocks-es_ES.po
+++ b/languages/coblocks-es_ES.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Mostrar abierto"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Agregar título acordeón..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Artículo acordeón"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Agregar artículos de acordeón desplegables a los acordeones."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "pestañas"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "Preguntas frecuentes"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,40 @@ msgstr "El artículo acordeón está abierto de manera predeterminada."
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Alterna para configurar el artículo acordeón como abierto de manera predeterminada."
+msgstr ""
+"Alterna para configurar el artículo acordeón como abierto de manera "
+"predeterminada."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Configuración del Artículo acordeón"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Mostrar abierto"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Configuración de color"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Color de fondo"
@@ -104,17 +66,10 @@ msgstr "Color de fondo"
 msgid "Title Text Color"
 msgstr "Color del texto del título"
 
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Agregar Artículo acordeón"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Acordeón"
-
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
-msgstr "Organizar el contenido dentro de los artículos de acordeón desplegables."
+msgstr ""
+"Organizar el contenido dentro de los artículos de acordeón desplegables."
 
 #: src/blocks/accordion/inspector.js:27
 msgid "Accordion Settings"
@@ -126,143 +81,85 @@ msgstr "Asistencia técnica de Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Agregar asistencia técnica para Internet Explorer cargando un polyfill de JavaScript."
+msgstr ""
+"Agregar asistencia técnica para Internet Explorer cargando un polyfill de "
+"JavaScript."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Asistencia técnica para Internet Explorer cargando un polyfill de JavaScript en esta página."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Asistencia técnica para Internet Explorer cargando un polyfill de JavaScript "
+"en esta página."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Advertencia"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Error"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Tipo de alerta"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Predeterminado"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Info"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Éxito"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Escribir título..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Escribir texto..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Alerta"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Proporcionar mensajes de comentarios contextuales."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "aviso"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "mensaje"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Color de texto"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Editar imagen"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Editar galería"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Eliminar imagen"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Escribir leyenda..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Suéltalo para agregarlo como avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Encabezado..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Nombre del autor"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Escribir biografía..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Configuración del campo \"de\""
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Autor"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Indicar a los visitantes que tomen acciones con múltiples botones, lado a "
+"lado."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Agregar biografía del autor"
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografía"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "perfil"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Botones"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Indicar a los visitantes que tomen acciones con múltiples botones, lado a lado."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "enlace"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Configuración de Botones"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Apilar en el móvil"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +177,25 @@ msgstr "Nombre de usuario de Twitter"
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Agregar botón..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Agregar una cita para tuitear..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Hacer clic para tuitear"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Agregar una cita para que los lectores la compartan en Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "compartir"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +203,18 @@ msgid "Text Settings"
 msgstr "Configuración del texto"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Color de botón"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynamic HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Agregar un espaciador adaptable entre otros bloques."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "espaciador"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Configuración de Dynamic HR"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Altura en píxeles"
 
@@ -347,92 +226,70 @@ msgstr "Altura para el elemento separador dinámico en píxeles."
 msgid "Color"
 msgstr "Color"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Agregar como fondo"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Característica"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
-msgstr "Una columna secundaria única en un bloque de características originales."
+msgstr ""
+"Una columna secundaria única en un bloque de características originales."
 
 #: src/blocks/features/feature/inspector.js:68
 msgid "Feature Settings"
 msgstr "Configuración de las características"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Relleno"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Características"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Agregar hasta tres columnas de notas pequeñas para tu producto o servicio."
+msgstr ""
+"Agregar hasta tres columnas de notas pequeñas para tu producto o servicio."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "servicios"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Margen"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Margen interno"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Espacio entre cada columna."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Pequeño"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Mediano"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +299,8 @@ msgstr "Grande"
 msgid "Features Settings"
 msgstr "Configuración de las características"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Columnas"
 
@@ -455,76 +312,72 @@ msgstr "Agregar sección de menú"
 msgid "Menu title..."
 msgstr "Título del menú..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Cuadrícula"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Lista"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Soltar imagen para remplazar"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Eliminar imagen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Agregar título..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Picante"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Caliente"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetariano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Sin gluten"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescetarianismo"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Vegano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Agregar descripción..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0.00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Producto alimenticio"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Un alimento o bebida dentro del bloque de Alimentos y Bebidas."
 
@@ -560,62 +413,46 @@ msgstr "Alternar para mostrar el precio para este artículo."
 msgid "Item Attributes"
 msgstr "Atributos del artículo"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Más picante"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Configuración de imágenes"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Texto alternativo"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Describe el propósito de la imagen"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Dejar vacío si la imagen es solo decorativa."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Punto focal"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Alimentos y bebidas"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Mostrar un menú o lista de precios."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restaurante"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menú"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Estilos"
@@ -648,134 +485,86 @@ msgstr "Mostrando el precio de cada artículo"
 msgid "Toggle to show the price of each item."
 msgstr "Alternar para mostrar el precio de cada artículo."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Correo electrónico"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "correo electrónico"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "correo"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Un campo de dirección de correo electrónico."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Mensaje"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Área de texto"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Texto de varias líneas"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Un cuadro de texto para respuestas más largas."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s no es una dirección de correo electrónico válida."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s y %s no son direcciones de correo electrónico válidas."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s no son una dirección de correo electrónico válida."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "nombre@ejemplo.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Asunto"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Configuración del campo \"de\""
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "reCAPTCHA de Google"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Agregar tu sitio de reCAPTCHA y claves secretas para proteger tu formulario del spam."
+msgstr ""
+"Agregar tu sitio de reCAPTCHA y claves secretas para proteger tu formulario "
+"del spam."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Generar claves"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Mis claves"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Obtener ayuda"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Clave del sitio"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Clave secreta"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Guardando"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Guardar"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Quitar"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Primera"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Última"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Nombre"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Un campo de texto para nombres."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Un campo de dirección de correo electrónico."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Agregar etiqueta..."
 
@@ -783,41 +572,38 @@ msgstr "Agregar etiqueta..."
 msgid "Required"
 msgstr "Obligatorio"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Configuración del campo de nombre"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Apellido"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Mostrar los campos del nombre y del apellido."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Alternar para agregar un campo de apellido."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Formulario"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Un campo de texto para nombres."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Un cuadro de texto para respuestas más largas."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Agregar un formulario simple a tu página."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "correo electrónico"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "acerca de"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "contacto"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Asunto"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +613,219 @@ msgstr "Agregar texto..."
 msgid "Button Text Color"
 msgstr "Color de texto del botón"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Editar galería"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Carrusel"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "imagen %1$d de %2$d en galería"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Escribir leyenda..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Carrusel"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Mostrar múltiples imágenes en una galería de carrusel hermosa."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galería"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "fotos"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Configuración %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Altura del renglón"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Mostrando flechas de navegación por puntos."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Alternar para mostrar leyendas de medios."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Configuración de color"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Esquinas redondeadas"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Color de la leyenda"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Aplicar"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Albañilería"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Escribir descripción..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Mostrar múltiples imágenes en una galería de albañilería organizada."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Mostrar múltiples imágenes en una galería de carrusel hermosa."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Tamaño de la columna"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Configuración de imágenes"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Agregar esquinas redondeadas a los artículos de la galería."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Sombra"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Leyendas"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Estilo de la leyenda"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Mostrando leyendas para cada artículo de medios."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Alternar para mostrar leyendas de medios."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Albañilería"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Mostrar múltiples imágenes en una galería de albañilería organizada."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Alternar para habilitar las opciones del control del mapa."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Configuración del mapa"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Tamaño de la columna"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Agregar esquinas redondeadas a los artículos de la galería."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Luz"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Apilado"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Mostrar múltiples imágenes en una galería apilada de una columna."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Imágenes de ancho completo"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Imagen de ancho completo"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Sombra de la casilla"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Las imágenes de ancho completo están habilitadas."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Alternar para llenar el área de la galería disponible completamente con imágenes de ancho completo."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Alternar para llenar el área de la galería disponible completamente con "
+"imágenes de ancho completo."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Configuración de ‌‌artículos"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Imágenes de ancho completo"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Imagen de ancho completo"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Eliminar gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Este gif tiene un atributo alt vacío"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Buscar el gif perfecto en Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Buscar gifs"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Elegir un gif, cualquier gif."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animado"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +851,11 @@ msgstr "Archivo GitHub"
 msgid "File"
 msgstr "Archivo"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Ver este gist en GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL del Gist"
 
@@ -1024,12 +868,9 @@ msgid "Loading Gist"
 msgstr "Cargando Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Insertar gists de GitHub agregando el enlace del gist."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "código"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +893,159 @@ msgid "Gist Meta"
 msgstr "Metagist"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Cambiar el diseño"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Agregar fondo a %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Un área introductoria de una página acompañada por una pequeña cantidad de "
+"texto y un llamado a la acción."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Un área introductoria de una página acompañada por una pequeña cantidad de texto y un llamado a la acción."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "botón"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "llamado a la acción"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Ancho del contenido en píxeles"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Configuración de ‌Hero"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Espacio dentro del recipiente."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Arriba, izquierda"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Arriba, centro"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Arriba, derecha"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Centro, izquierda"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Centro, centro"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Centro, derecha"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Abajo, izquierda"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Abajo, centro"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Abajo, derecha"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Agregar texto destacado..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Destacar"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Texto destacado."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "texto"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "párrafo"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Ícono"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Agregar un símbolo gráfico estilizado para comunicar algo más."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "iconos"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Enorme"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Agregar un símbolo gráfico estilizado para comunicar algo más."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Configuración de icono"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Apagar configuración de %s avanzadas"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Restablecer"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Personalizar el tamaño de %s"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Configuración de %s avanzada"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Personalizado"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Avanzado"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Radio"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Búsqueda de iconos"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "No se encontraron resultados."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Configuración del enlace"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "Enlace URL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Rel del enlace"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Abriendo en una pestaña nueva"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Abrir en una pestaña nueva"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Colores de los íconos"
 
@@ -1261,30 +1054,19 @@ msgid "Edit logos"
 msgstr "Editar logotipos"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logotipos y distintivos"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Arrastrar imágenes, cargar nuevas o seleccionar archivos de tu biblioteca."
+msgstr ""
+"Arrastrar imágenes, cargar nuevas o seleccionar archivos de tu biblioteca."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Agregar logotipos, distintivos o certificados para construir credibilidad."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "clientes"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "prueba"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "Testimonios"
+msgstr ""
+"Agregar logotipos, distintivos o certificados para construir credibilidad."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1088,143 @@ msgstr "Editar ubicación"
 msgid "Map style"
 msgstr "Estilo del mapa"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Clave API inválido o demasiadas solicitudes"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Map"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Ingresar una ubicación o dirección para soltar un pin en un mapa de Google."
+msgstr ""
+"Ingresar una ubicación o dirección para soltar un pin en un mapa de Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Buscar un lugar o dirección..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Aplicar"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Mapa"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Agregar una dirección y dejar un pin en un mapa de Google."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "dirección"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "mapas"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Seleccionar Estilo del mapa"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Configuración del mapa"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Nivel del zoom"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Altura para el mapa en píxeles"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Nivel del zoom"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Tamaño del marcador"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Están habilitadas las opciones del control detallado."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Alternar para habilitar las opciones del control del mapa."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Controles del mapa"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Tipo de mapa"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "Está habilitado el cambio de las vistas del mapa estándar y satelital."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "Alternar para habilitar cambiar entre los mapas estándar y satelital."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Controles de zoom"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Mostrando controles del zoom del mapa."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Alternar para habilitar las opciones del zoom de acercar y alejar en el mapa con los controles del zoom."
+msgstr ""
+"Alternar para habilitar las opciones del zoom de acercar y alejar en el mapa "
+"con los controles del zoom."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Vista en el nivel de la calle"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Mostrando el control del mapa de vista en el nivel de la calle."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Alternar para mostrar el control de vista en el nivel de la calle abajo a la derecha."
+msgstr ""
+"Alternar para mostrar el control de vista en el nivel de la calle abajo a la "
+"derecha."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Alternar a pantalla completa"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Mostrar el control del mapa en pantalla completa."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Alternar para mostrar el control del mapa en pantalla completa."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Clave API de Google Maps"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Agrega tu clave API de Google Maps. Actualizar esta clave API hará que todos tus mapas usen la clave nueva."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Agrega tu clave API de Google Maps. Actualizar esta clave API hará que todos "
+"tus mapas usen la clave nueva."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Recuperar tu correo"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "¿Necesitas ayuda?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Ingresa la clave API de Google..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Guardado"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Estándar"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Plateado"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Oscuro"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Noche"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Berenjena"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1234,9 @@ msgstr "Medios de comunicación a la derecha"
 msgid "Media on left"
 msgstr "Medios de comunicación a la izquierda"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Tarjetas de medios"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Agregar una imagen o video con una tarjeta offset lado a lado."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "imagen"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1250,18 @@ msgstr "Mostrando sombra de la tarjeta."
 msgid "Toggle to add a card shadow."
 msgstr "Alternar para agregar la sombra de una tarjeta."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s Sombra"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Mostrando %s sombra."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Alternar para agregar una %s sombra"
 
@@ -1545,40 +1285,171 @@ msgstr "Soltar para remplazar medios de comunicación"
 msgid "Edit media"
 msgstr "Editar medios"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s Tablas"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL del Gist"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Plan %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Carrusel"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL del Gist"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Configuración de color"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Mostrar el precio para este artículo."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Alternar para mostrar los metadatos del gist."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Mostrando el botón de llamado a la acción."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Alternar para mostrar los metadatos del gist."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Configuración de las características"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Medios de comunicación a la izquierda"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Medios de comunicación a la derecha"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Tamaño de la columna"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Configuración del gist"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Tabla de precios"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Tabla de precios"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Tabla de precios"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Tabla de precios"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Agregar tablas de precios."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "aterrizaje"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Plan %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "comparación"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Configuración de la Tabla de precios"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tablas"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1467,171 @@ msgstr "Plan A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Artículo de la tabla de precios"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Una columna colocada dentro del bloque de la tabla de precios."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Agregar fondo a %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Columna"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Una fila inmediatamente secundaria."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Ancho"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Configuración de la columna"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Espacio alrededor del contenedor."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Ancho"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Cambiar el diseño"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "uno"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "dos"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "tres"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "cuatro"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Agregar fondo a %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Una columna"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Dos columnas"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Tres columnas"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Cuatro columnas"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Disposición de la fila"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Fila"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Ahora selecciona un diseño para esta fila de %s columnas."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Selecciona la cantidad de columnas para esta fila."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Selecciona las columnas de la fila"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Selecciona el diseño de la fila"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Volver a las columnas"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Agrega una capa estructurada para los bloques de columnas, luego agrega los bloques de contenido que quieres a las columnas."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Agrega una capa estructurada para los bloques de columnas, luego agrega los "
+"bloques de contenido que quieres a las columnas."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "filas"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "columnas"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "diseños"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Disposición"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Configuración de ‌‌las filas"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Ninguna"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1641,9 @@ msgstr "Cuadrado"
 msgid "Circle"
 msgstr "Círculo"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Servicios"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Agrega hasta cuatro columnas de servicios para mostrar."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "características"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1665,7 @@ msgstr "Mostrando los botones de llamado a la acción."
 msgid "Toggle to show call to action buttons."
 msgstr "Alternar para mostrar los botones de llamado a la acción."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Servicio"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Un solo artículo de servicio dentro de un bloque de servicios."
 
@@ -1785,264 +1686,233 @@ msgid "Toggle to show a call to action button."
 msgstr "Alternar para mostrar un botón de llamado a la acción."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Voltear a horizontal"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Voltear a vertical"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Divisor de formas"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Agregar un divisor de formas para distinguir visualmente las secciones de la página."
+msgstr ""
+"Agregar un divisor de formas para distinguir visualmente las secciones de la "
+"página."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "separador"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Color de la forma"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Configuración del divisor"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Altura de la forma en píxeles"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Altura del fondo en píxeles"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Orientación"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Color de la forma"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Compartir en Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Compartir en Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Compartir en Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Compartir en Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Compartir en LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Compartir por correo electrónico"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Compartir en Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Compartir en Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Compartir en Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Compartir"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "social"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Agregar enlaces para compartir en redes sociales para obtener “me gusta” y para que compartan tus publicaciones."
+msgstr ""
+"Agregar enlaces para compartir en redes sociales para obtener “me gusta” y "
+"para que compartan tus publicaciones."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Colores sociales"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Tamaño del icono"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Tamaño del círculo"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Tamaño del botón"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Iconos"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Correo electrónico"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Están habilitados los colores del botón de compartir."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Alternar para usar los colores oficiales de cada plataforma de redes sociales."
+msgstr ""
+"Alternar para usar los colores oficiales de cada plataforma de redes "
+"sociales."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Colores sociales"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Agregar perfil de Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Agregar perfil de Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Agregar perfil de Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Agregar perfil de Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Agregar perfil de LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Agregar perfil de YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Agregar perfil de Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Agregar perfil de Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Perfiles sociales"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "enlaces"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Mostrar enlaces a los perfiles de redes sociales."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Enlaces del perfil"
 
@@ -2057,18 +1927,6 @@ msgstr "Eliminar fondo"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Fondo"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Auto"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Portada"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Contiene"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1984,6 @@ msgstr "Eliminar fondo"
 msgid "Remove "
 msgstr "Quitar "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "No repetir"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Repetir horizontalmente"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Repetir verticalmente"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Mover imagen hacia atrás"
@@ -2150,17 +1996,14 @@ msgstr "Mover imagen hacia adelante"
 msgid "Link To"
 msgstr "Enlazar a"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s Galería"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Cargar imagen"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Luz"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2017,110 @@ msgstr "Página de adjuntos"
 msgid "Custom URL"
 msgstr "URL personalizado"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Píxel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Orientación"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Porcentaje"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Restablecer"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Seleccionar unidades"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "Unidades de %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Apagar configuración de %s avanzadas"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s superior"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s derecho"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s inferior"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s izquierdo"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "No sincronizar"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Sincronizar"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Unidades de sincronización"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Arriba"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Derecha"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Abajo"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Izquierda"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Configuración de %s avanzada"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Predeterminado"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Disposición"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2139,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Alternar para habilitar el modo de pantalla completa."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Encabezado %d"
@@ -2263,43 +2148,16 @@ msgstr "Encabezado %d"
 msgid "Custom color picker"
 msgstr "Personalizar selector de color"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Original"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Escala de grises"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sepia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Saturación"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Dim"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Aplicar filtro"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Seleccionar orientación"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Altura"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Móvil %s"
@@ -2333,7 +2191,8 @@ msgid "Five Seconds"
 msgstr "Cinco segundos"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Seis segundos"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2211,22 @@ msgstr "Nueve segundos"
 msgid "Ten Seconds"
 msgstr "Diez segundos"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Navegación por flechas"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Navegación por puntos"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "segundos"
@@ -2361,22 +2236,29 @@ msgid "second"
 msgstr "segundo"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Avanzar después %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Avanzar automáticamente a la siguiente diapositiva."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
-msgstr "Arrastrar y mover habilitado en el escritorio y en los dispositivos móviles."
+#, fuzzy
+msgid "Dragging and flicking enabled."
+msgstr ""
+"Arrastrar y mover habilitado en el escritorio y en los dispositivos móviles."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Alternar para habilitar la funcionalidad de arrastrar en el escritorio y en los dispositivos móviles."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Alternar para habilitar la funcionalidad de arrastrar en el escritorio y en "
+"los dispositivos móviles."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2269,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Alternar para mostrar flechas de navegación de diapositivas."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Mostrando flechas de navegación por puntos."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Alternar para mostrar la navegación por puntos."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Espacio dentro del recipiente."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Alternar para silenciar el video."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Alternar para repetir el video."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Configuración del deslizador"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Reproducción automática"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Velocidad de transición"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Arrastrable"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Navegación por flechas"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Navegación por puntos"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Capitalizar"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2356,6 @@ msgstr "No hay espaciado inferior"
 msgid "Change typography"
 msgstr "Cambiar tipografía"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Negrita"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Mayúscula"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Minúscula"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Apilar en el móvil"
@@ -2481,31 +2366,36 @@ msgstr "Está habilitada la reacción inmediata."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Alternar para apilar elementos uno sobre otro en ventanas más pequeñas."
+msgstr ""
+"Alternar para apilar elementos uno sobre otro en ventanas más pequeñas."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Eliminar el espaciado superior"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "El margen superior está eliminado en este bloque."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Alternar para agregar la sombra de una tarjeta."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Alternar para eliminar cualquier margen aplicado en la parte superior de este bloque."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Alternar para mostrar la navegación por puntos."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Eliminar el espaciado inferior"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "El margen inferior está eliminado en este bloque."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Alternar para agregar la sombra de una tarjeta."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Alternar para eliminar cualquier margen aplicado a la parte inferior de este bloque."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Alternar para mostrar la navegación por puntos."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2409,14 @@ msgstr "Mostrar como ancho completo."
 msgid "Toggle to display button as full width."
 msgstr "Alternar para mostrar el botón como ancho completo."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Circular"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Configuración de ‌Hero"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Sombra"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Casilla de verificación"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Mayúscula"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2436,800 @@ msgstr "Buscar un bloque"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Este bloque está agregado a la página y no se puede deshabilitar actualmente"
+msgstr ""
+"Este bloque está agregado a la página y no se puede deshabilitar actualmente"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Deshabilitar todo"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "No se encontraron “%s” bloques."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Galerías %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Mostrar abierto"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Agregar título acordeón..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Artículo acordeón"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "pestañas"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "Preguntas frecuentes"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "aviso"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "mensaje"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografía"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "perfil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "enlace"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "compartir"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "espaciador"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "servicios"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menú"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restaurante"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "correo electrónico"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "correo"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Apellido"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Área de texto"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Texto de varias líneas"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "correo electrónico"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "acerca de"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "contacto"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galería"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "fotos"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Noche"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animado"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "código"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "botón"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "llamado a la acción"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "texto"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "párrafo"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "iconos"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "clientes"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "prueba"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "Testimonios"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "dirección"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "mapas"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "imagen"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "dirección"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "aterrizaje"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "comparación"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "filas"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "columnas"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "diseños"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "características"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "separador"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "social"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "enlaces"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Mostrar abierto"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Agregar Artículo acordeón"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Acordeón"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Escribir texto..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Escribir título..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Alerta"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Autor"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Botones"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Hacer clic para tuitear"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynamic HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Característica"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Características"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Producto alimenticio"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Alimentos y bebidas"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Correo electrónico"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Nombre"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Mensaje"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Formulario"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Carrusel"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Albañilería"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Apilado"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL del Gist"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Destacar"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Ícono"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logotipos y distintivos"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Mapa"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Tarjetas de medios"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Carrusel"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Tabla de precios"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Artículo de la tabla de precios"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Columna"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Fila"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Servicios"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Servicio"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Divisor de formas"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Compartir"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Perfiles sociales"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Info"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Éxito"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Advertencia"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Error"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Punto"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Línea"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Ancho completo"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Cuadrícula"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Lista"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Predeterminado"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Capas"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Delineado"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Llenado"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Apilado"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Repetir horizontalmente"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Ondeado"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Colinas"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Olas"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "En ángulo"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Inclinado"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Redondeado"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Triángulo"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Puntiagudo"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Máscara"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Ícono"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Texto"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Icono y texto"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Circular"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Abajo, izquierda"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Arriba, izquierda"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Suéltalo para agregarlo como avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Autor"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3249,34 @@ msgstr "Agregar contenido de característica"
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Este es un bloque de característica que puedes usar para destacar características."
+msgstr ""
+"Este es un bloque de característica que puedes usar para destacar "
+"características."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Agregar encabezado hero..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Agregar encabezado hero..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Agregar encabezado hero, que típicamente es un área introductoria de una "
+"página acompañada por un llamado a la acción o dos."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Agregar encabezado hero, que típicamente es un área introductoria de una página acompañada por un llamado a la acción o dos."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Agregar acción principal..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Agregar acción secundaria..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3295,126 @@ msgstr "Agregar contenido..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Remplaza este texto con una copia descriptiva para que vaya con la imagen de la tarjeta. Después agrega más bloques a esta tarjeta, como botones, listas o imágenes."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Remplaza este texto con una copia descriptiva para que vaya con la imagen de "
+"la tarjeta. Después agrega más bloques a esta tarjeta, como botones, listas "
+"o imágenes."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Escribir título..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Escribir descripción..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Configuración de Botones"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Personalizado"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Apilar en el móvil"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Configuración de Dynamic HR"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Ninguna"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Ninguna"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Pequeño"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Mediano"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Grande"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Extra grande"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Ninguna"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Pequeño"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Mediano"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Grande"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3105,7 +3779,8 @@ msgstr "computadora manzana monitor dispositivo pc escritorio oficina"
 #: src/blocks/icon/svgs.js:182
 msgctxt "tags"
 msgid "computer ipad surface apple montior device pc desk office"
-msgstr "computadora ipad superficie apple monitor dispositivo pc escritorio oficina"
+msgstr ""
+"computadora ipad superficie apple monitor dispositivo pc escritorio oficina"
 
 #: src/blocks/icon/svgs.js:187
 msgctxt "tags"
@@ -3180,7 +3855,8 @@ msgstr "diversión fiesta feliz celebración probar comida"
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "pétalo aroma olor agradable relajarse paisaje jardinería exterior afuera"
+msgstr ""
+"pétalo aroma olor agradable relajarse paisaje jardinería exterior afuera"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3259,8 +3935,12 @@ msgstr "música micrófono canción artista creativo medios audio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "micrófono podcast computadora dispositivo música micrófono canción artista creativo medios audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"micrófono podcast computadora dispositivo música micrófono canción artista "
+"creativo medios audio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3964,12 @@ msgstr "película videografía director productor medios creativos"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "video videografía director productor medios creativos cámara fotógrafo fotografía apertura"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"video videografía director productor medios creativos cámara fotógrafo "
+"fotografía apertura"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3986,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "paleta diseño colores artista creativo medios pintura pincel"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Estándar"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Plateado"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Oscuro"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Noche"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Berenjena"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Circular"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Sombra"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Predeterminado"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Ninguna"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Casilla de verificación"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Título del menú..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Pequeño"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Mediano"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Grande"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Extra grande"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Auto"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Portada"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Contiene"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Arriba, izquierda"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Arriba, centro"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Arriba, derecha"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Centro, izquierda"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Centro, centro"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Centro, derecha"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Abajo, izquierda"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Abajo, centro"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Abajo, derecha"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "No repetir"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Repetir"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Repetir horizontalmente"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Repetir verticalmente"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Rel del enlace"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Oscuro"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Luz"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Ninguna"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Imagen"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Píxel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Porcentaje"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Original"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Escala de grises"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Archivo de medios"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Saturación"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Filtro vintage"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Filtro vintage"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Capitalizar"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Negrita"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Predeterminado"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Mayúscula"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Minúscula"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4334,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks es una suite de <strong>bloques de contenido para construir páginas</strong> profesional para el editor de bloques Gutenberg de WordPress. Nuestros bloques están hiper centrados en empoderar marcadores para desarrollar páginas hermosas en WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks es una suite de <strong>bloques de contenido para construir "
+"páginas</strong> profesional para el editor de bloques Gutenberg de "
+"WordPress. Nuestros bloques están hiper centrados en empoderar marcadores "
+"para desarrollar páginas hermosas en WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4352,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "¿Haciendo trampa?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Escribe una reseña"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s años"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "un año"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s semanas"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "una semana"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s días"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "un día"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s horas"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "una hora"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minutos"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "un minuto"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s segundos"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "un segundo"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Complemento de WordPress %s"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "¿Estás disfrutando %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Has estado usando %1$s por %2$s ahora. ¿Podrías dejar una reseña para contarnos qué te parece? ¡Lo apreciaríamos mucho!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Escribe una reseña"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Has estado usando %1$s por %2$s ahora. ¿Podrías dejar una reseña para "
+"contarnos qué te parece? ¡Lo apreciaríamos mucho!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "No, gracias / Ya lo he hecho"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Gracias por elegir CoBlocks, el mejor creador de páginas para el editor de bloques de WordPress nuevo."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Gracias por elegir CoBlocks, el mejor creador de páginas para el editor de "
+"bloques de WordPress nuevo."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Has agregado muchos bloques útiles y un kit de herramientas de creador de páginas nuevo al editor de WordPress. CoBlocks te ofrece nuevas funciones para cambiar el juego: %1$s decenas de bloques%2$s, una %1$s experiencia para crear páginas %2$s y %1$s controles de tipografía a medida%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Has agregado muchos bloques útiles y un kit de herramientas de creador de "
+"páginas nuevo al editor de WordPress. CoBlocks te ofrece nuevas funciones "
+"para cambiar el juego: %1$s decenas de bloques%2$s, una %1$s experiencia "
+"para crear páginas %2$s y %1$s controles de tipografía a medida%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Aquí hay algunos videos para que puedas comenzar:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Mira cómo crear tu primera página con %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Mira cómo crear tu primera página"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Mira cómo usar los bloques divisores de filas y formas"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Mira como usar el bloqueo de Media Card"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "¿Te gusta lo que ves? %1$sSuscríbete a nuestro canal de YouTube%2$s y te avisaremos cuando publiquemos videos de tutoriales nuevos."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"¿Te gusta lo que ves? %1$sSuscríbete a nuestro canal de YouTube%2$s y te "
+"avisaremos cuando publiquemos videos de tutoriales nuevos."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Si tienes preguntas o comentarios, puedes escribirnos en %1$sTwitter%4$s o en nuestro grupo de %2$sFacebook %4$s. Además, %3$spuedes suscribirte a nuestro boletín informativo%4$s si quieres estar actualizado con lo último y lo que se viene de CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Si tienes preguntas o comentarios, puedes escribirnos en %1$sTwitter%4$s o "
+"en nuestro grupo de %2$sFacebook %4$s. Además, %3$spuedes suscribirte a "
+"nuestro boletín informativo%4$s si quieres estar actualizado con lo último y "
+"lo que se viene de CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "¡Disfrútalo!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Comienza ahora con CoBlocks aquí:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4523,37 @@ msgstr "Habilita o deshabilita bloques"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "Clave del sitio de reCaptcha de Google para la protección contra spam en los formularios"
+msgstr ""
+"Clave del sitio de reCaptcha de Google para la protección contra spam en los "
+"formularios"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
-msgstr "Clave secreta de reCaptcha de Google para la protección de spam en los formularios"
+msgstr ""
+"Clave secreta de reCaptcha de Google para la protección de spam en los "
+"formularios"
+
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Nombre"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Primera"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Última"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Mensaje"
 
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Enviar"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Tu mensaje se ha enviado:"
 
@@ -3490,3 +4568,89 @@ msgstr "Compartir en LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Tipo de alerta"
+
+#~ msgid "Edit image"
+#~ msgstr "Editar imagen"
+
+#~ msgid "Remove image"
+#~ msgstr "Eliminar imagen"
+
+#~ msgid "Heading..."
+#~ msgstr "Encabezado..."
+
+#~ msgid "Author Name"
+#~ msgstr "Nombre del autor"
+
+#~ msgid "Write biography..."
+#~ msgstr "Escribir biografía..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Agregar biografía del autor"
+
+#~ msgid "%s Settings"
+#~ msgstr "Configuración %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Color de la leyenda"
+
+#~ msgid "Highlight text."
+#~ msgstr "Texto destacado."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s Tablas"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Configuración de la Tabla de precios"
+
+#~ msgid "Tables"
+#~ msgstr "Tablas"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Una columna colocada dentro del bloque de la tabla de precios."
+
+#~ msgid "Sepia"
+#~ msgstr "Sepia"
+
+#~ msgid "Dim"
+#~ msgstr "Dim"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Seleccionar orientación"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "El margen superior está eliminado en este bloque."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Alternar para eliminar cualquier margen aplicado en la parte superior de "
+#~ "este bloque."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "El margen inferior está eliminado en este bloque."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Alternar para eliminar cualquier margen aplicado a la parte inferior de "
+#~ "este bloque."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Agregar acción principal..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Agregar acción secundaria..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Comienza ahora con CoBlocks aquí:"

--- a/languages/coblocks-fi.po
+++ b/languages/coblocks-fi.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Näyttö avoimena"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Lisää haitarinäkymän nimi..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Haitarinäkymän kohde"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Lisää kutistettavissa olevia kohteita haitarinäkymiin."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "välilehdet"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "UKK (usein kysytyt kysymykset)"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,40 @@ msgstr "Haitarinäkymän kohde on oletuksena auki."
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Käytä vaihtopainiketta, jos haluat asettaa tämän haitarinäkymän kohteen oletusarvoisesti avoimeksi."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat asettaa tämän haitarinäkymän kohteen "
+"oletusarvoisesti avoimeksi."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Haitarinäkymän kohteiden asetukset"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Näyttö avoimena"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Väriasetukset"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Taustaväri"
@@ -104,17 +66,10 @@ msgstr "Taustaväri"
 msgid "Title Text Color"
 msgstr "Nimiketekstin väri"
 
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Lisää haitarinäkymän kohde"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Haitarinäkymä"
-
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
-msgstr "Järjestä sisältö kutistettavissa olevien haitarinäkymäkohteiden sisällä."
+msgstr ""
+"Järjestä sisältö kutistettavissa olevien haitarinäkymäkohteiden sisällä."
 
 #: src/blocks/accordion/inspector.js:27
 msgid "Accordion Settings"
@@ -126,143 +81,84 @@ msgstr "Internet Explorer -tuki"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Lisää Internet Explorer -tuki lataamalla JavaScript-muotoinen polyfill-koodi."
+msgstr ""
+"Lisää Internet Explorer -tuki lataamalla JavaScript-muotoinen polyfill-koodi."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Internet Explorerin tuki voidaan lisätä lataamalla JavaScript-muotoinen polyfill-koodi tälle sivulle."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Internet Explorerin tuki voidaan lisätä lataamalla JavaScript-muotoinen "
+"polyfill-koodi tälle sivulle."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Varoitus"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Virhe"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Hälytystyyppi"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Oletus"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Tiedot"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Onnistui"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Kirjoita nimi..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Kirjoita teksti..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Hälytys"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Tarjoa kontekstiin perustuvia palauteviestejä."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "ilmoitus"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "viesti"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Tekstin väri"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Muokkaa kuvaa"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Muokkaa galleriaa"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Poista kuva"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Kirjoita kuvateksti..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Pudota, jos haluat lisätä avatar-hahmona"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Otsikko..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Kirjoittajan nimi"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Kirjoita lyhyt elämäkerta..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Lomakkeen asetukset"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Kirjoittaja"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Kehota vierailijoita suorittamaan tiettyjä toimintoja vierekkäin "
+"esitettävien painikkeiden avulla."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Lisää kirjoittajan elämäkerta."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "elämäkerta"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profiili"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Painikkeet"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Kehota vierailijoita suorittamaan tiettyjä toimintoja vierekkäin esitettävien painikkeiden avulla."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "linkki"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Painikkeiden asetukset"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Esitä pinona mobiililaitteessa"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -270,7 +166,9 @@ msgstr "Painikkeiden esittäminen pinona mobiililaitteissa."
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Toggle to stack buttons on mobile."
-msgstr "Käytä vaihtopainiketta, jos haluat esittää painikkeet pinona mobiililaitteissa."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat esittää painikkeet pinona "
+"mobiililaitteissa."
 
 #: src/blocks/click-to-tweet/controls.js:44
 msgid "Twitter Username"
@@ -280,31 +178,25 @@ msgstr "Twitter-käyttäjänimi"
 msgid "Username"
 msgstr "Käyttäjänimi"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Lisää painike..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Lisää lainaus twiittiin..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Twiittaa napsauttamalla"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Lisää lainaus, jonka lukijat voivat jakaa Twitterin kautta."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "jaa"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +204,18 @@ msgid "Text Settings"
 msgstr "Tekstin asetukset"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Painikkeen väri"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynaaminen HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Lisää kooltaan muokattavissa oleva tyhjä väli muiden lohkojen väliin."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "tyhjä väli"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Dynaamisen HR:n asetukset"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Korkeus kuvapisteinä"
 
@@ -347,17 +227,12 @@ msgstr "Dynaamisen erotinelementin korkeus kuvapisteinä"
 msgid "Color"
 msgstr "Väri"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Lisää taustana"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Ominaisuus"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "Yksittäinen alatason palsta ylätason ominaisuuslohkon sisällä."
 
@@ -366,73 +241,56 @@ msgid "Feature Settings"
 msgstr "Ominaisuuden asetukset"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Sisämarginaalit"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Ominaisuudet"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Lisää enimmillään kolme palstaa pieniä muistiinpanoja, jotka koskevat tarjoamaasi tuotetta tai palvelua."
+msgstr ""
+"Lisää enimmillään kolme palstaa pieniä muistiinpanoja, jotka koskevat "
+"tarjoamaasi tuotetta tai palvelua."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "palvelut"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Marginaali"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Sidontareunus"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Tila kunkin palstan välissä."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Pieni"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Keskikokoinen"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +300,8 @@ msgstr "Suuri"
 msgid "Features Settings"
 msgstr "Ominaisuuksien asetukset"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Palstat"
 
@@ -455,76 +313,72 @@ msgstr "Lisää valikko-osio"
 msgid "Menu title..."
 msgstr "Valikon nimi..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Ruudukko"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Lista"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Korvaa pudottamalla kuva"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Poista kuva"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Lisää otsikko..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Mausteinen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Tulinen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Kasvisruokaa"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Gluteeniton"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Kasvis- ja kalaruokaa"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Vegaaninen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Lisää kuvaus..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0,00 $"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Ruokatuote"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Ruoka- tai juomatuote Ruoka ja juoma -lohkossa."
 
@@ -560,62 +414,46 @@ msgstr "Käytä vaihtopainiketta, jos haluat näyttää tämän tuotteen hinnan.
 msgid "Item Attributes"
 msgstr "Tuotteen ominaisuudet"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Mausteisempi"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Kuvan asetukset"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Vaihtoehtoinen teksti"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Kuvaile tämän kuvan tarkoitus"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Jätä tyhjäksi, jos kyseessä on vain kuvituskuva."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Keskipiste"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Ruoka ja juomat"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Näytä ruokalista tai hinnasto"
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "ravintola"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "valikko"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Tyylit"
@@ -648,134 +486,86 @@ msgstr "Kunkin tuotteen hinta näytetään."
 msgid "Toggle to show the price of each item."
 msgstr "Käytä vaihtopainiketta, jos haluat näyttää kunkin tuotteen hinnan."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Sähköposti"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "sähköposti"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "sähköposti"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Sähköpostiosoitteen kenttä."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Viesti"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Tekstialue"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Usean rivin teksti"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Tekstiruutu pidempiä vastauksia varten."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "‌‌%s ei ole kelvollinen sähköpostiosoite."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s ja %s eivät ole kelvollisia sähköpostiosoitteita."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "‌‌%s eivät ole kelvollisia sähköpostiosoitteita."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Sähköpostiosoite"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "nimi@esimerkki.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Aihe"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Lomakkeen asetukset"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Lisäämällä reCAPTCHA-todennuksen ja salaiset avaimet voit suojata lomakkeesi roskapostilta."
+msgstr ""
+"Lisäämällä reCAPTCHA-todennuksen ja salaiset avaimet voit suojata lomakkeesi "
+"roskapostilta."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Luo avaimet"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Omat avaimet"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Pyydä ohjeita"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Sivustoavain"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Salainen avain"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Tallennetaan"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Tallenna"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Poista"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Etunimi"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Sukunimi"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Nimi"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Tekstikenttä nimiä varten."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Sähköpostiosoitteen kenttä."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Lisää selite..."
 
@@ -783,41 +573,38 @@ msgstr "Lisää selite..."
 msgid "Required"
 msgstr "Vaaditaan"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Nimi-kentän asetukset"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Sukunimi"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Sekä Etunimi- että Sukunimi-kenttä näytetään."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Käytä vaihtopainiketta, jos haluat lisätä Sukunimi-kentän."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Lomake"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Tekstikenttä nimiä varten."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Tekstiruutu pidempiä vastauksia varten."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Lisää sivustoosi yksinkertainen lomake."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "sähköposti"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "tietoja"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "yhteystieto"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Aihe"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +614,220 @@ msgstr "Lisää teksti..."
 msgid "Button Text Color"
 msgstr "Painiketekstin väri"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Muokkaa galleriaa"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Karuselli"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "Kuva %1$d / %2$d galleriassa"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Kirjoita kuvateksti..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Karuselli"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Esitä kuvavalikoima näyttävässä karusellinäkymässä."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galleria"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "valokuvat"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s – asetukset"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Rivin korkeus"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Pistenavigointinuolet näytetään."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Käytä vaihtopainiketta, jos haluat näyttää mediasisällön kuvatekstit."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Väriasetukset"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Koko"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Pyöristetyt kulmat"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Kuvatekstin väri"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Käytä"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Tiiliseinä"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Kirjoita kuvaus..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Esitä kuvavalikoima järjestellyssä tiiliseinänäkymässä."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Esitä kuvavalikoima näyttävässä karusellinäkymässä."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Palstan koko"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Kuvan asetukset"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Lisää pyöristetyt kulmat gallerian kuviin."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Varjostus"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Kuvatekstit"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Kuvatekstien tyyli"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Kuvatekstit näytetään kullekin mediakohteelle."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Käytä vaihtopainiketta, jos haluat näyttää mediasisällön kuvatekstit."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Tiiliseinä"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Esitä kuvavalikoima järjestellyssä tiiliseinänäkymässä."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat ottaa kartan ohjaussäätimet käyttöön."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Kartan asetukset"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Palstan koko"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Lisää pyöristetyt kulmat gallerian kuviin."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Kevyt"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Pinottu"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Esitä kuvavalikoima yhdestä palstasta koostuvasta pinonäkymässä."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Täyden leveyden kuvat"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Täyden leveyden kuva"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Ruudun varjostus"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Täyden leveyden kuvat on otettu käyttöön."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Käytä vaihtopainiketta, jos haluat täyttää käytettävissä olevan galleria-alueen täyden leveyden kuvilla."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat täyttää käytettävissä olevan galleria-"
+"alueen täyden leveyden kuvilla."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Tuotteen asetukset"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Täyden leveyden kuvat"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Täyden leveyden kuva"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Poista gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Tämän gif-kuvan alt-määrite on tyhjä"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Etsi tilanteeseen täydellisesti sopiva gif-animaatio Giphy-palvelusta"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Etsi gif-tiedostoja"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Valitse mikä tahansa haluamasi gif"
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animaatio"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +853,11 @@ msgstr "GitHub-tiedosto"
 msgid "File"
 msgstr "Tiedosto"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Tarkastele tätä GiST-koodikatkelmaa GitHub-palvelussa"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "GiST-koodikatkelman URL"
 
@@ -1024,12 +870,9 @@ msgid "Loading Gist"
 msgstr "Ladataan GiST-koodikatkelmaa"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Upota GitHub-palvelun GiST-koodikatkelmia lisäämällä GiST-linkki."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "koodi"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +895,159 @@ msgid "Gist Meta"
 msgstr "GiST-metatiedot"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Muuta asettelua"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Lisää tausta: %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Sankariosio"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Sivun esittelyosio, joka sisältää pienen määrän tekstiä sekä "
+"toimintakehotteen."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Sivun esittelyosio, joka sisältää pienen määrän tekstiä sekä toimintakehotteen."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "painike"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "toimintakehote"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Sisällön leveys kuvapisteinä"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Sankariosion asetukset"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Tila osiosäilön sisällä."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Ylävasen"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Yläosan keskellä"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Yläoikea"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Keskiosan vasemmalla"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Keskiosan keskellä"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Keskiosan oikealla"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Alavasen"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Alaosan keskellä"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Alaoikea"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Lisää korostettu teksti..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Korostus"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Korostustekstin väri."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "teksti"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "kappale"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "kuvake"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Lisää stilisoitu graafinen symboli haluamasi viestin välittämiseksi."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "kuvakkeet"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Valtava"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Lisää stilisoitu graafinen symboli haluamasi viestin välittämiseksi."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Kuvakkeen asetukset"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Poista %s-lisäasetukset käytöstä"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Palauta"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Mukautettu %s-koko"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "%s-lisäasetukset"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Mukautettu"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Lisäasetukset"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Säde"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Kuvakehaku"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Tuloksia ei löytynyt."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Linkin asetukset"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "Linkin URL-osoite"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Linkkisuhde"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Avataan uudessa välilehdessä"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Avaa uudessa välilehdessä"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Kuvakkeen väri"
 
@@ -1261,30 +1056,21 @@ msgid "Edit logos"
 msgstr "Muokkaa logoja"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logot ja merkit"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Vedä kuvia haluamaasi kohtaan, siirrä uusia kuvia palvelimeen tai valitse tiedostoja omasta kirjastostasi."
+msgstr ""
+"Vedä kuvia haluamaasi kohtaan, siirrä uusia kuvia palvelimeen tai valitse "
+"tiedostoja omasta kirjastostasi."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Lisäämällä logoja, merkkejä ja sertifikaatteja voit rakentaa luotettavaa vaikutelmaa."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "asiakkaat"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "todisteet"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "asiakaskokemukset"
+msgstr ""
+"Lisäämällä logoja, merkkejä ja sertifikaatteja voit rakentaa luotettavaa "
+"vaikutelmaa."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1092,147 @@ msgstr "Muokkaa sijaintia"
 msgid "Map style"
 msgstr "Kartan tyyli"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Virheellinen API-avain tai liikaa pyyntöjä"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Map"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "Pudota nuppineula Google-kartalle antamalla sijainti tai osoite."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Etsi paikkaa tai osoitetta..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Käytä"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Kartta"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Lisää osoite ja pudota nuppineula Google-kartalle."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "osoite"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "kartat"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Valitse kartan tyyli"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Kartan asetukset"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Zoomaustaso"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Kartan korkeus kuvapisteinä"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Zoomaustaso"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Merkinnän koko"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Tarkat säätötoiminnot on otettu käyttöön."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
-msgstr "Käytä vaihtopainiketta, jos haluat ottaa kartan ohjaussäätimet käyttöön."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat ottaa kartan ohjaussäätimet käyttöön."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Kartan säätötoiminnot"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Kartan tyyppi"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "Siirtyminen vakiotyyppisten ja satelliittikarttojen välillä on otettu käyttöön."
+msgstr ""
+"Siirtyminen vakiotyyppisten ja satelliittikarttojen välillä on otettu "
+"käyttöön."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Käytä vaihtopainiketta, jos haluat ottaa käyttöön siirtymisen vakiotyyppisten ja satelliittikarttojen välillä."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat ottaa käyttöön siirtymisen "
+"vakiotyyppisten ja satelliittikarttojen välillä."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Zoomausohjaimet"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Kartan zoomausohjaimet näytetään."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Käytä vaihtopainiketta, jos haluat ottaa käyttöön kartan lähentämisen ja loitontamisen zoomausohjaimilla."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat ottaa käyttöön kartan lähentämisen ja "
+"loitontamisen zoomausohjaimilla."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Katunäkymä"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Katunäkymäohjain näytetään."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Käytä vaihtopainiketta, jos haluat näyttää katunäkymäohjaimet oikeassa alakulmassa."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat näyttää katunäkymäohjaimet oikeassa "
+"alakulmassa."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Koko näytön tila"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Koko näytön karttaohjain näytetään."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Käytä vaihtopainiketta, jos haluat näyttää koko näytön karttaohjaimen."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google Maps -API-avain"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Lisää Google Maps -API-avaimesi. Tämän API-avaimen päivittäminen määrittää kaikki karttasi käyttämään uutta avainta."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Lisää Google Maps -API-avaimesi. Tämän API-avaimen päivittäminen määrittää "
+"kaikki karttasi käyttämään uutta avainta."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Nouda avaimesi"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Tarvitsetko apua?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Anna Google-API-avain…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Tallennettu"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Vakio"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Hopea"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Tumma"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Yö"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Tumma violetti"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1242,9 @@ msgstr "Mediasisältö oikealla"
 msgid "Media on left"
 msgstr "Mediasisältö vasemmalla"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Mediakortti"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Lisää kuva tai video ja sen vierellä esitettävä kortti."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "kuva"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1258,18 @@ msgstr "Kortin varjostus näytetään."
 msgid "Toggle to add a card shadow."
 msgstr "Käytä vaihtopainiketta, jos haluat lisätä kortin varjostuksen."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s – varjostus"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Varjostus näytetään – %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Käytä vaihtopainiketta, jos haluat lisätä varjostuksen (%s)."
 
@@ -1545,40 +1293,171 @@ msgstr "Korvaa media pudottamalla sisältö tähän"
 msgid "Edit media"
 msgstr "Muokkaa mediaa"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s – taulukot"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "GiST-koodikatkelman URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Sopimus %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Karuselli"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "GiST-koodikatkelman URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Väriasetukset"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Tämän tuotteen hinta näytetään."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Käytä vaihtopainiketta, jos haluat näyttää GiST-metatiedot."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Toimintakehotepainike näytetään."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Käytä vaihtopainiketta, jos haluat näyttää GiST-metatiedot."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Ominaisuuden asetukset"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Mediasisältö vasemmalla"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Mediasisältö oikealla"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Palstan koko"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "GiST-asetukset"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Hinnoittelutaulukko"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Hinnoittelutaulukko"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Hinnoittelutaulukko"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Hinnoittelutaulukko"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Lisää hinnoittelutaulukot"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "saapumissivu"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Sopimus %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "vertailu"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Hinnoittelutaulukon asetukset"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Taulukot"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1475,171 @@ msgstr "Sopimus A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Hinnoittelutaulukon kohde"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Hinnoittelutaulukkolohkon sisään sijoitettu palsta."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Lisää tausta: %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Palsta"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Rivin välitön alaelementti."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Leveys"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Palsta-asetukset"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Tila osiosäilön ympärillä."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Leveys"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Muuta asettelua"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "yksi"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "kaksi"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "kolme"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "neljä"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Lisää tausta: %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Yksi palsta"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Kaksi palstaa"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Kolme palstaa"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Neljä palstaa"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Rivin asettelu"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Rivi"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Valitse seuraavaksi tämän %s palstan rivin asettelu."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Valitse palstojen lukumäärä tätä riviä varten."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Valitse rivin palstat"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Valitse rivin asettelu"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Takaisin palstoihin"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Lisää palstalohkoihin strukturoitu paketoija, ja lisää sitten haluamasi sisältölohkot palstoihin."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Lisää palstalohkoihin strukturoitu paketoija, ja lisää sitten haluamasi "
+"sisältölohkot palstoihin."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "rivit"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "palstat"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "asettelut"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Asettelu"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Riviasetukset"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Ei mitään"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1649,9 @@ msgstr "Neliö"
 msgid "Circle"
 msgstr "Ympyrä"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Palvelut"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Voit lisätä enimmillään neljä palstaa palveluiden esittämistä varten."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "ominaisuudet"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1673,7 @@ msgstr "Toimintakehotepainikkeet näytetään."
 msgid "Toggle to show call to action buttons."
 msgstr "Käytä vaihtopainiketta, jos haluat näyttää toimintakehotepainikkeet."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Palvelu"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Yksittäinen palvelukohde palveluiden lohkossa."
 
@@ -1785,264 +1694,231 @@ msgid "Toggle to show a call to action button."
 msgstr "Käytä vaihtopainiketta, jos haluat näyttää toimintakehotepainikkeen."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Käännä vaakasuunnassa"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Käännä pystysuunnassa"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Muotojakaja"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "Lisää muotojakaja, joka erottaa sivun osiot toisistaan visuaalisesti."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "erottaja"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Muodon väri"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Jakajan asetukset"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Muodon korkeus kuvapisteinä"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Taustan korkeus kuvapisteinä"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Suuntaus"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Muodon väri"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Jaa Twitterissä"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Jaa Facebookissa"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Jaa Twitterissä"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Jaa Pinterest-palvelussa"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Jaa LinkedIn-palvelussa"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Jaa sähköpostitse"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Jaa Twitterissä"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Jaa Googlen kautta"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Jaa Reddit-palvelussa"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Jaa"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "sosiaalinen"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Sisällön jakaminen sosiaalisessa mediassa auttaa sinua saamaan lisää tykkäyksiä ja jakoja."
+msgstr ""
+"Sisällön jakaminen sosiaalisessa mediassa auttaa sinua saamaan lisää "
+"tykkäyksiä ja jakoja."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Sosiaalisen median värit"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Kuvakkeen koko"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Ympyrän koko"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Painikkeen koko"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Kuvakkeet"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook-"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Sähköposti"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Jakopainikkeiden värit on otettu käyttöön."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Käytä vaihtopainiketta, jos haluat käyttää kunkin sosiaalisen median virallisia värejä."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat käyttää kunkin sosiaalisen median "
+"virallisia värejä."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Sosiaalisen median värit"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Lisää Facebook-profiili"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Lisää Twitter-profiili"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Lisää Instagram-profiili"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Lisää Pinterest-profiili"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Lisää LinkedIn-profiili"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Lisää YouTube-profiili"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Lisää Yelp-profiili"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Lisää Houzz-profiili"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Sosiaalisen median profiilit"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "linkit"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Näytä linkit sosiaalisen median profiileihin."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Profiililinkit"
 
@@ -2057,18 +1933,6 @@ msgstr "Poista tausta"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Tausta"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Automaattinen"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Kansi"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Sisältää"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2116,7 +1980,8 @@ msgstr "Taustavideo toistetaan jatkuvasti."
 
 #: src/components/background/panel.js:202
 msgid "Toggle to loop the video."
-msgstr "Käytä vaihtopainiketta, jos haluat asettaa videon jatkuvasti toistettavaksi."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat asettaa videon jatkuvasti toistettavaksi."
 
 #: src/components/background/panel.js:211
 msgid "Remove background"
@@ -2125,18 +1990,6 @@ msgstr "Poista tausta"
 #: src/components/background/panel.js:232
 msgid "Remove "
 msgstr "Poista "
-
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Ei toistoa"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Toista vaakasuunnassa"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Toista pystysuunnassa"
 
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
@@ -2150,17 +2003,14 @@ msgstr "Siirrä kuvaa eteenpäin"
 msgid "Link To"
 msgstr "Linkitä kohteeseen:"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s – galleria"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Lataa kuva palvelimeen"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Kevyt"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2024,110 @@ msgstr "Liitesivu"
 msgid "Custom URL"
 msgstr "Mukautettu URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Kuvapiste"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Suuntaus"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Prosenttiosuus"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Palauta"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Valitse yksiköt"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s – yksiköt"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Poista %s-lisäasetukset käytöstä"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s – yläosa"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s – oikea"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s – alaosa"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s – vasen"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Poista synkronointi"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Synkronoi"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Synkronoi yksiköt"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Ylä"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Oikea"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Alhaalla"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Vasen"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "%s-lisäasetukset"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Lisäasetukset"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Oletus"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Asettelu"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2146,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Käytä vaihtopainiketta, jos haluat ottaa käyttöön koko näytön tilan."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Otsikko %d"
@@ -2263,43 +2155,16 @@ msgstr "Otsikko %d"
 msgid "Custom color picker"
 msgstr "Mukautettujen värien valitsin"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Alkuperäinen"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Harmaasävy"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Seepia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Värikylläisyys"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Himmeä"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Käytä suodatinta"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Valitse suuntaus"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Korkeus"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Matkapuhelin %s"
@@ -2333,7 +2198,8 @@ msgid "Five Seconds"
 msgstr "Viisi sekuntia"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Kuusi sekuntia"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2218,22 @@ msgstr "Yhdeksän sekuntia"
 msgid "Ten Seconds"
 msgstr "Kymmenen sekuntia"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Nuolinavigointi"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Pistenavigointi"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "sekuntia"
@@ -2361,22 +2243,30 @@ msgid "second"
 msgstr "sekunti"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Automaattinen siirtymä %1$d%2$s jälkeen."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Siirry automaattisesti seuraavaan diaan."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
-msgstr "Vetämis- ja sipaisukosketustoiminnot otettu käyttöön työpöytä- ja mobiililaitteissa."
+#, fuzzy
+msgid "Dragging and flicking enabled."
+msgstr ""
+"Vetämis- ja sipaisukosketustoiminnot otettu käyttöön työpöytä- ja "
+"mobiililaitteissa."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Käytä vaihtopainiketta, jos haluat ottaa käyttöön vetotoiminnon pöytäkoneissa ja mobiililaitteissa."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat ottaa käyttöön vetotoiminnon "
+"pöytäkoneissa ja mobiililaitteissa."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2277,61 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Käytä vaihtopainiketta, jos haluat näyttää diojen navigointinuolet."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Pistenavigointinuolet näytetään."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Käytä vaihtopainiketta, jos haluat pistenavigoinnin."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Tila osiosäilön sisällä."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Käytä vaihtopainiketta, jos haluat mykistää videon."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat asettaa videon jatkuvasti toistettavaksi."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Diaesityksen asetukset"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Automaattinen toisto"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Siirtymän nopeus"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Vedettävissä"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Nuolinavigointi"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Pistenavigointi"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Isot kirjaimet"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normaali"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2365,6 @@ msgstr "Ei alaosan välistystä"
 msgid "Change typography"
 msgstr "Muuta typografiaa"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Lihavoitu"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Isot kirjaimet"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Pienet kirjaimet"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Esitä pinona mobiililaitteessa"
@@ -2481,31 +2375,37 @@ msgstr "Reagoivuus on otettu käyttöön."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Käytä vaihtopainiketta, jos haluat pinota elementtejä toistensa päälle pienemmissä näyttöikkunoissa."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat pinota elementtejä toistensa päälle "
+"pienemmissä näyttöikkunoissa."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Poista yläosan välistys"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Ylämarginaali poistetaan tästä lohkosta."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Käytä vaihtopainiketta, jos haluat lisätä kortin varjostuksen."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Käytä vaihtopainiketta, jos haluat poistaa tämän lohkon päälle mahdollisesti lisätyt marginaalit."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Käytä vaihtopainiketta, jos haluat pistenavigoinnin."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Poista alaosan välistys"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Alamarginaali poistetaan tästä lohkosta."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Käytä vaihtopainiketta, jos haluat lisätä kortin varjostuksen."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Käytä vaihtopainiketta, jos haluat poistaa tämän lohkon alle mahdollisesti lisätyt marginaalit."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Käytä vaihtopainiketta, jos haluat pistenavigoinnin."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2517,23 +2417,17 @@ msgstr "Näytetään täydessä leveydessä."
 
 #: src/extensions/button-controls/index.js:74
 msgid "Toggle to display button as full width."
-msgstr "Käytä vaihtopainiketta, jos haluat näyttää painikkeen täydessä leveydessä."
+msgstr ""
+"Käytä vaihtopainiketta, jos haluat näyttää painikkeen täydessä leveydessä."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Ympyrä"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Sankariosion asetukset"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Varjostus"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Valintaruutu"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Isot kirjaimet"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2447,800 @@ msgstr "Etsi lohkoa"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Tämä lohko lisätään sivulle, eikä tätä voida tällä hetkellä poistaa käytöstä"
+msgstr ""
+"Tämä lohko lisätään sivulle, eikä tätä voida tällä hetkellä poistaa käytöstä"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Poista kaikki käytöstä"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Tämäntyyppisiä lohkoja ei löydetty: \"%s\"."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s – galleriat"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Näyttö avoimena"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Lisää haitarinäkymän nimi..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Haitarinäkymän kohde"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "välilehdet"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "UKK (usein kysytyt kysymykset)"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "ilmoitus"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "viesti"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "elämäkerta"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profiili"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "linkki"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "jaa"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "tyhjä väli"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "palvelut"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "valikko"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "ravintola"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "sähköposti"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "sähköposti"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Sukunimi"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Tekstialue"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Usean rivin teksti"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "sähköposti"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "tietoja"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "yhteystieto"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galleria"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "valokuvat"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Yö"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animaatio"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "koodi"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "painike"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "toimintakehote"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "teksti"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "kappale"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "kuvakkeet"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "asiakkaat"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "todisteet"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "asiakaskokemukset"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "osoite"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "kartat"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "kuva"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "osoite"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "saapumissivu"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "vertailu"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "rivit"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "palstat"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "asettelut"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "ominaisuudet"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "erottaja"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "sosiaalinen"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "linkit"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Näyttö avoimena"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Lisää haitarinäkymän kohde"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Haitarinäkymä"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Kirjoita teksti..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Kirjoita nimi..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Hälytys"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Kirjoittaja"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Painikkeet"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Twiittaa napsauttamalla"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynaaminen HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Ominaisuus"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Ominaisuudet"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Ruokatuote"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Ruoka ja juomat"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Sähköposti"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Nimi"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Viesti"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Lomake"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Karuselli"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Tiiliseinä"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Pinottu"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "GiST-koodikatkelman URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Sankariosio"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Korostus"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "kuvake"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logot ja merkit"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Kartta"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Mediakortti"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Karuselli"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Hinnoittelutaulukko"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Hinnoittelutaulukon kohde"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Palsta"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Rivi"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Palvelut"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Palvelu"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Muotojakaja"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Jaa"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Sosiaalisen median profiilit"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Tiedot"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Onnistui"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Varoitus"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Virhe"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Piste"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Rivi"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Täysi leveys"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Ruudukko"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Lista"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Oletus"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Kerrokset"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Ääriviivat"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Täyttö"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Pinottu"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Toista vaakasuunnassa"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Aaltoileva"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Kukkulat"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Aallot"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Kulmat"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Kalteva"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Pyöristetty"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Kolmio"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Kärki"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Maski"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Kuvake"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Teksti"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Kuvake ja teksti"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Ympyrä"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Alavasen"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Ylävasen"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Pudota, jos haluat lisätä avatar-hahmona"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Kirjoittaja"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3260,34 @@ msgstr "Lisää ominaisuuden sisältö"
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Tämä on ominaisuuslohko, jonka avulla voit tuoda esille haluamiasi ominaisuuksia."
+msgstr ""
+"Tämä on ominaisuuslohko, jonka avulla voit tuoda esille haluamiasi "
+"ominaisuuksia."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Lisää sankariosion otsikko..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Lisää sankariosion otsikko..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Lisää sankarisisältö. Tällä tarkoitetaan näkyvällä tavalla esillä olevaa "
+"sivun esittelyosiota, johon sisältyy usein mukaan myös jokin toimintakehote."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Lisää sankarisisältö. Tällä tarkoitetaan näkyvällä tavalla esillä olevaa sivun esittelyosiota, johon sisältyy usein mukaan myös jokin toimintakehote."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Lisää ensisijainen toiminta..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Lisää toissijainen toiminta..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3306,126 @@ msgstr "Lisää sisältöä..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Korvaa tämä teksti kuvauksella, joka sopii yhteen korttisi kuvan kanssa. Lisää tämän jälkeen tähän korttiin muita lohkoja, kuten painikkeita, listoja tai kuvia."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Korvaa tämä teksti kuvauksella, joka sopii yhteen korttisi kuvan kanssa. "
+"Lisää tämän jälkeen tähän korttiin muita lohkoja, kuten painikkeita, listoja "
+"tai kuvia."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Kirjoita nimi..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Kirjoita kuvaus..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normaali"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Painikkeiden asetukset"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Mukautettu"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Esitä pinona mobiililaitteessa"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Dynaamisen HR:n asetukset"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Ei mitään"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Ei mitään"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Pieni"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Keskikokoinen"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Suuri"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Erittäin suuri"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Ei mitään"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Pieni"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Keskikokoinen"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Suuri"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3125,7 +3810,8 @@ msgstr "usb liitä yhdistä laite sosiaalinen keskitin"
 #: src/blocks/icon/svgs.js:20
 msgctxt "tags"
 msgid "music microphone podcast song artist creative media audio"
-msgstr "musiikki mikrofoni podcast laulu kappale artisti luova media audio ääni"
+msgstr ""
+"musiikki mikrofoni podcast laulu kappale artisti luova media audio ääni"
 
 #: src/blocks/icon/svgs.js:209
 msgctxt "tags"
@@ -3259,8 +3945,12 @@ msgstr "musiikki mikrofoni laulu kappale artisti luova media audio ääni"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "mikrofoni podcast tietokone laite musiikki laulu kappale artisti luova media audio ääni"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"mikrofoni podcast tietokone laite musiikki laulu kappale artisti luova media "
+"audio ääni"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,13 +3974,18 @@ msgstr "filmi elokuva video videokuvaus ohjaaja tuottaja media luova"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "video videokuvaus ohjaaja tuottaja media luova kamera valokuvaaja valokuvaus aukko"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"video videokuvaus ohjaaja tuottaja media luova kamera valokuvaaja valokuvaus "
+"aukko"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
 msgid "palette design colors artist paint creative media"
-msgstr "paletti design suunnittelu värit artisti taiteilija maalaus luova media"
+msgstr ""
+"paletti design suunnittelu värit artisti taiteilija maalaus luova media"
 
 #: src/blocks/icon/svgs.js:91
 msgctxt "tags"
@@ -3300,14 +3995,350 @@ msgstr "paletti design suunnittelu värit artisti taiteilija luova media"
 #: src/blocks/icon/svgs.js:97
 msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
-msgstr "paletti design suunnittelu värit artisti taiteilija luova media maalaus sivellin"
+msgstr ""
+"paletti design suunnittelu värit artisti taiteilija luova media maalaus "
+"sivellin"
+
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Vakio"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Hopea"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Tumma"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Yö"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Tumma violetti"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Ympyrä"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Varjostus"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Oletus"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Ei mitään"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Valintaruutu"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Valikon nimi..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Pieni"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Keskikokoinen"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Suuri"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Erittäin suuri"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Automaattinen"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Kansi"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Sisältää"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Ylävasen"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Yläosan keskellä"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Yläoikea"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Keskiosan vasemmalla"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Keskiosan keskellä"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Keskiosan oikealla"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Alavasen"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Alaosan keskellä"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Alaoikea"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Ei toistoa"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Toisto"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Toista vaakasuunnassa"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Toista pystysuunnassa"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Linkkisuhde"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Tumma"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Kevyt"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Ei mitään"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Kuva"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Kuvapiste"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Prosenttiosuus"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Alkuperäinen"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Harmaasävy"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Mediatiedosto"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Värikylläisyys"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Vintage-suodatin"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Vintage-suodatin"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Isot kirjaimet"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normaali"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Lihavoitu"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Oletus"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Isot kirjaimet"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Pienet kirjaimet"
 
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4347,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks on kokoelma ammattimaisia <strong>verkkosivujen sisältölohkoja </strong> WordPressin Gutenberg-lohkoeditoria varten. Lohkomme ovat erittäin tarkoin suunniteltuja, ja niiden avulla suunnittelijat voivat luoda ainutlaatuisen näyttäviä sivuja WordPressiä käyttäen."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks on kokoelma ammattimaisia <strong>verkkosivujen sisältölohkoja </"
+"strong> WordPressin Gutenberg-lohkoeditoria varten. Lohkomme ovat erittäin "
+"tarkoin suunniteltuja, ja niiden avulla suunnittelijat voivat luoda "
+"ainutlaatuisen näyttäviä sivuja WordPressiä käyttäen."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4365,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Melkein niin kuin huijausta, vai mitä?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Jätä arvostelu"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s vuotta"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "vuosi"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s viikkoa"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "viikko"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s päivää"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "päivä"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s tuntia"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "tunti"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minuuttia"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "minuutti"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s sekuntia"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "sekunti"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPress -laajennus"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Onko %s mieleesi?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Olet nyt käyttänyt tätä tuotetta (%1$s) %2$s ajan. Voisitko jättää meille mielipiteesi siitä? Arvostaisimme tätä kovasti!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Jätä arvostelu"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Olet nyt käyttänyt tätä tuotetta (%1$s) %2$s ajan. Voisitko jättää meille "
+"mielipiteesi siitä? Arvostaisimme tätä kovasti!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Ei kiitos / olen jo tehnyt tämän"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Kiitos, että valitsit CoBlocks-paketin. Se on alan parhaimmistoa edustava verkkosivujen suunnittelutyökalu WordPressin uudelle lohkoeditorille."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Kiitos, että valitsit CoBlocks-paketin. Se on alan parhaimmistoa edustava "
+"verkkosivujen suunnittelutyökalu WordPressin uudelle lohkoeditorille."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Olet juuri lisännyt WordPress-editoriin joukon hyödyllisiä lohkoelementtejä ja kattavan uuden työkaluvalikoiman. CoBlocks tarjoaa sinulle mullistavan valikoiman uusia ominaisuuksia: %1$s kymmeniä eri lohkoja%2$s, %1$s kätevät suunnittelutoiminnot %2$s ja %1$s mukautetut typografiavalinnat%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Olet juuri lisännyt WordPress-editoriin joukon hyödyllisiä lohkoelementtejä "
+"ja kattavan uuden työkaluvalikoiman. CoBlocks tarjoaa sinulle mullistavan "
+"valikoiman uusia ominaisuuksia: %1$s kymmeniä eri lohkoja%2$s, %1$s kätevät "
+"suunnittelutoiminnot %2$s ja %1$s mukautetut typografiavalinnat%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Näiden videoiden avulla pääset helposti alkuun:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Katso, miten voit luoda ensimmäisen sivusi %s-paketin avulla"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Katso, miten voit luoda ensimmäisen sivusi"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Katso, miten käytät rivi- ja muotojakajia"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Katso video mediakorttilohkon käytöstä"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Pidätkö näkemästäsi? %1$sTilaamalla YouTube-kanavamme%2$s saat tiedon aina, kun olemme julkaisseet uusia opastusvideoita."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Pidätkö näkemästäsi? %1$sTilaamalla YouTube-kanavamme%2$s saat tiedon aina, "
+"kun olemme julkaisseet uusia opastusvideoita."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Jos sinulla on kysymyksiä tai palautetta, ota meihin yhteyttä %1$sTwitterin%4$s tai %2$sFacebook-ryhmämme%4$s kautta. Voit myös %3$stilata uutiskirjeemme%4$s, jos haluat pysyä ajan tasalla CoBlocks-pakettiin tehtävistä muutoksista ja uusista ominaisuuksista."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Jos sinulla on kysymyksiä tai palautetta, ota meihin yhteyttä %1$sTwitterin"
+"%4$s tai %2$sFacebook-ryhmämme%4$s kautta. Voit myös %3$stilata "
+"uutiskirjeemme%4$s, jos haluat pysyä ajan tasalla CoBlocks-pakettiin "
+"tehtävistä muutoksista ja uusista ominaisuuksista."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Nauti siitä!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Pääset alkuun CoBlocks-paketin käytössä täällä:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4542,27 @@ msgstr "Googlen reCAPTCHA-sivustoavain lomakkeiden roskapostisuojaukseen"
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "Googlen salainen reCAPTCHA-avain lomakkeiden roskapostisuojaukseen"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Nimi"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Etunimi"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Sukunimi"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Viesti"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Lähetä"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Viestisi lähetettiin:"
 
@@ -3490,3 +4577,89 @@ msgstr "Jaa LinkedIn-palvelussa"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Hälytystyyppi"
+
+#~ msgid "Edit image"
+#~ msgstr "Muokkaa kuvaa"
+
+#~ msgid "Remove image"
+#~ msgstr "Poista kuva"
+
+#~ msgid "Heading..."
+#~ msgstr "Otsikko..."
+
+#~ msgid "Author Name"
+#~ msgstr "Kirjoittajan nimi"
+
+#~ msgid "Write biography..."
+#~ msgstr "Kirjoita lyhyt elämäkerta..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Lisää kirjoittajan elämäkerta."
+
+#~ msgid "%s Settings"
+#~ msgstr "%s – asetukset"
+
+#~ msgid "Caption Color"
+#~ msgstr "Kuvatekstin väri"
+
+#~ msgid "Highlight text."
+#~ msgstr "Korostustekstin väri."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s – taulukot"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Hinnoittelutaulukon asetukset"
+
+#~ msgid "Tables"
+#~ msgstr "Taulukot"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Hinnoittelutaulukkolohkon sisään sijoitettu palsta."
+
+#~ msgid "Sepia"
+#~ msgstr "Seepia"
+
+#~ msgid "Dim"
+#~ msgstr "Himmeä"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Valitse suuntaus"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Ylämarginaali poistetaan tästä lohkosta."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Käytä vaihtopainiketta, jos haluat poistaa tämän lohkon päälle "
+#~ "mahdollisesti lisätyt marginaalit."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Alamarginaali poistetaan tästä lohkosta."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Käytä vaihtopainiketta, jos haluat poistaa tämän lohkon alle "
+#~ "mahdollisesti lisätyt marginaalit."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Lisää ensisijainen toiminta..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Lisää toissijainen toiminta..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normaali"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Pääset alkuun CoBlocks-paketin käytössä täällä:"

--- a/languages/coblocks-fr_FR.po
+++ b/languages/coblocks-fr_FR.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Afficher l’accordéon ouvert"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Ajouter le titre de l’accordéon..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Élément d’accordéon"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Ajoutez des éléments réductibles aux accordéons."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "onglets"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "faq"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "Basculez pour définir cet élément d’accordéon comme ouvert par dé
 msgid "Accordion Item Settings"
 msgstr "Paramètres de l’élément d’accordéon"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Affichage ouvert"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Paramètres des couleurs"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Couleur de fond"
@@ -103,14 +63,6 @@ msgstr "Couleur de fond"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Couleur du texte du titre"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Ajouter un élément d’accordéon"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Accordéon"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +78,85 @@ msgstr "Prise en charge d’Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Ajoutez la prise en charge d’Internet Explorer par le chargement d’un polyfill JavaScript."
+msgstr ""
+"Ajoutez la prise en charge d’Internet Explorer par le chargement d’un "
+"polyfill JavaScript."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Prise en charge d’Internet Explorer par le chargement d’un polyfill JavaScript.sur cette page."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Prise en charge d’Internet Explorer par le chargement d’un polyfill "
+"JavaScript.sur cette page."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Attention"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Erreur"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Type d’alerte"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Défaut"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Info"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Succès"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Écrire le titre..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Écrire le texte..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Alerte"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Fournissez des messages de feedback contextuels."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "avis"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "message"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Couleur du texte"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Modifier l’image"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Modifier la galerie"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Supprimer l’image"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Écrire la légende…"
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Déposer pour ajouter en tant qu’avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "En-tête..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Nom de l’auteur"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Écrire une biographie..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Paramètres du formulaire"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Auteur"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Invitez les visiteurs à passer à l’action à l’aide de plusieurs boutons, "
+"côte à côte."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Ajoutez une biographie de l’auteur."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biographie"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profil"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Boutons"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Invitez les visiteurs à passer à l’action à l’aide de plusieurs boutons, côte à côte."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "lien"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Paramètres des boutons"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Empilement sur mobile"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +174,26 @@ msgstr "Nom d’utilisateur Twitter"
 msgid "Username"
 msgstr "Nom d’utilisateur"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Ajouter un bouton..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Ajouter une citation au tweet..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Cliquez pour envoyer le tweet"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
-msgstr "Ajoutez une citation pour que les lecteurs puissent l’envoyer via Twitter."
+msgstr ""
+"Ajoutez une citation pour que les lecteurs puissent l’envoyer via Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "partager"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +201,18 @@ msgid "Text Settings"
 msgstr "Paramètre de texte"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Couleur du bouton"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "RH dynamique"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Ajoutez un espacement redimensionnable entre les autres blocs."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "espacement"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Paramètres RH dynamiques"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Hauteur en pixels"
 
@@ -347,92 +224,71 @@ msgstr "Hauteur de l’élément séparateur dynamique en pixels."
 msgid "Color"
 msgstr "Couleur"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Ajouter comme fond"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Fonction"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
-msgstr "Une colonne enfant particulière à l’intérieur d’un parent comporte un bloc."
+msgstr ""
+"Une colonne enfant particulière à l’intérieur d’un parent comporte un bloc."
 
 #: src/blocks/features/feature/inspector.js:68
 msgid "Feature Settings"
 msgstr "Réglages des fonctionnalités"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Remplissage"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Fonctionnalités"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Ajoutez jusqu’à trois colonnes de petites notes pour votre produit ou service."
+msgstr ""
+"Ajoutez jusqu’à trois colonnes de petites notes pour votre produit ou "
+"service."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "services"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Marge"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Petits fonds"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Espace entre les différentes colonnes."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Petit"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Moyen"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +298,8 @@ msgstr "Grand"
 msgid "Features Settings"
 msgstr "Paramètres des fonctionnalités"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -455,78 +311,76 @@ msgstr "Ajouter une section Menu"
 msgid "Menu title..."
 msgstr "Titre du menu..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Réseau"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Liste"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Déposer l’image à remplacer"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Supprimer l’image"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Ajouter le titre..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Épicé"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Très épicé"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Végétarien"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Sans gluten"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescétarien"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Végétalien"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Ajouter une description..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0.00 $"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Produit alimentaire"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
-msgstr "Un élément de type nourriture et boisson au sein du bloc Nourriture et boissons."
+msgstr ""
+"Un élément de type nourriture et boisson au sein du bloc Nourriture et "
+"boissons."
 
 #: src/blocks/food-and-drinks/food-item/inspector.js:19
 msgid "Item Settings"
@@ -560,62 +414,46 @@ msgstr "Basculez pour afficher le prix de cet élément."
 msgid "Item Attributes"
 msgstr "Attributs de l’élément"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Plus épicé"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Paramètres de l’image"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Texte alt (texte alternatif)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Décrivez la fonction de l’image"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Laissez vide si l’image est purement décorative."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Point focal"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Nourriture et boissons"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Affichez un menu ou les tarifs."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restaurant"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menu"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Styles"
@@ -648,134 +486,86 @@ msgstr "Affichage du prix de chaque élément"
 msgid "Toggle to show the price of each item."
 msgstr "Basculez pour afficher le prix de chaque élément."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Email"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "email"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "messagerie"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Champ d’adresse email."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Message"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Zone de texte"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Texte multiligne"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Zone de texte pour les réponses plus longues."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s n’est pas une adresse email valide."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s et %s ne sont pas des adresses email valides."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s ne sont pas une adresse email valide."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Adresse email"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "nom@exemple.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Objet"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Paramètres du formulaire"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Ajoutez votre clé de site et votre clé secrète reCAPTCHA pour protéger votre formulaire contre les spams."
+msgstr ""
+"Ajoutez votre clé de site et votre clé secrète reCAPTCHA pour protéger votre "
+"formulaire contre les spams."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Générer les clés"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Mes clés"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Obtenir de l’aide"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Clé de site"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Clé secrète"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Enregistrement"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Enregistrer"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Supprimer"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Première"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Dernière"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Nom"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Zone de texte pour les noms."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Champ d’adresse email."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Ajouter une étiquette…"
 
@@ -783,41 +573,38 @@ msgstr "Ajouter une étiquette…"
 msgid "Required"
 msgstr "Requis"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Paramètres du champ Nom"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Nom de famille"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Affichage des champs Prénom et Nom."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Basculez pour ajouter un champ Nom."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Formulaire"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Zone de texte pour les noms."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Zone de texte pour les réponses plus longues."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Ajoutez un formulaire simple à votre page."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "email"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "à propos de"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "détails de contact"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Objet"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +614,218 @@ msgstr "Ajouter du texte…"
 msgid "Button Text Color"
 msgstr "Couleur du texte du bouton"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Modifier la galerie"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Carrousel"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "image %1$d de %2$d dans la galerie"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Écrire la légende…"
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Carrousel"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Affichez plusieurs images dans une magnifique galerie de carrousels."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galerie"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "photos"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Paramètres de %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Hauteur de ligne"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Affichage des flèches de navigation par point."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Basculez pour afficher les légendes des éléments médias."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Paramètres des couleurs"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Taille"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Coins arrondis"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Couleur de la légende"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Appliquer"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Maçonnerie"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Écrire la description..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Affichez plusieurs images dans une galerie de maçonnerie organisée."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Affichez plusieurs images dans une magnifique galerie de carrousels."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Taille de colonne"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Paramètres de l’image"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Ajoutez des coins arrondis aux éléments de la galerie."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Ombre"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Légendes"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Style de légende"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Affichage des légendes pour chaque élément média."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Basculez pour afficher les légendes des éléments médias."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Maçonnerie"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Affichez plusieurs images dans une galerie de maçonnerie organisée."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Basculez pour activer les options de contrôles de la carte."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Paramètres de la carte"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Taille de colonne"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Ajoutez des coins arrondis aux éléments de la galerie."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Léger"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Empilé"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Affichez plusieurs images dans une seule galerie de colonnes empilées."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Images pleine largeur"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Image pleine largeur"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Ombre de zone"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Les images pleine largeur sont activées."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Basculez pour remplir la zone de galerie disponible d’images pleine largeur."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Basculez pour remplir la zone de galerie disponible d’images pleine largeur."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Paramètres de l’élément"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Images pleine largeur"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Image pleine largeur"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Supprimer le gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Ce gif a un attribut alt vide"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Recherchez le gif parfait sur Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Recherche de gifs"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Sélectionnez un gif, n’importe quel gif."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animé"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +851,11 @@ msgstr "Fichier GitHub"
 msgid "File"
 msgstr "Fichier"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Voir ce gist sur GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL du gist"
 
@@ -1024,12 +868,9 @@ msgid "Loading Gist"
 msgstr "Chargement du gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Intégrer les gists GitHub en ajoutant leur lien."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "code"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +893,159 @@ msgid "Gist Meta"
 msgstr "Méta du gist"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Modifier la mise en page"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Ajouter le fond à %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Partie d’introduction d’une page accompagnée d’un petit texte et d’un appel "
+"à l’action."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Partie d’introduction d’une page accompagnée d’un petit texte et d’un appel à l’action."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "bouton"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "appel à l’action"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Largeur du contenu en pixels"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Réglages Héro"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Espace à l’intérieur du conteneur."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Haut gauche"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Haut centre"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Haut droit"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Centre gauche"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Centre centre"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Centre droit"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Bas gauche"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Bas centre"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Bas droit"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Ajouter du texte en surbrillance..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Surbrillance"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Mettez le texte en surbrillance."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "texte"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "paragraphe"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Icône"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Ajoutez un symbole graphique stylisé pour communiquer un petit plus."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "icônes"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Très grand"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Ajoutez un symbole graphique stylisé pour communiquer un petit plus."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Paramètres des icônes"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Désactiver les paramètres %s avancés."
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Taille %s personnalisée"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Paramètres %s avancés"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Personnalisé"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Avancé"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Rayon"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Recherche d’icônes"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Aucun résultat trouvé."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Configuration des liens"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL du lien"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Rel du lien"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Ouverture dans un nouvel onglet"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Ouvrir dans un nouvel onglet"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Couleur de l’icône"
 
@@ -1261,30 +1054,21 @@ msgid "Edit logos"
 msgstr "Modifier les logos"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logos et badges"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Faites glisser des images, uploadez-en de nouvelles ou sélectionnez des fichiers dans votre bibliothèque."
+msgstr ""
+"Faites glisser des images, uploadez-en de nouvelles ou sélectionnez des "
+"fichiers dans votre bibliothèque."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Ajoutez des logos, des badges ou des certifications pour renforcer votre crédibilité."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "clients"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "preuve"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "témoignages"
+msgstr ""
+"Ajoutez des logos, des badges ou des certifications pour renforcer votre "
+"crédibilité."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1090,145 @@ msgstr "Modifier l’emplacement"
 msgid "Map style"
 msgstr "Style de la carte"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Clé API non valide, ou nombre excessif de demandes"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Map"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Entrez un lieu ou une adresse pour déposer une épingle sur une carte Google."
+msgstr ""
+"Entrez un lieu ou une adresse pour déposer une épingle sur une carte Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Rechercher un lieu ou une adresse…"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Appliquer"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Carte"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Ajoutez une adresse et déposez une épingle sur une carte Google."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "adresse"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "cartes"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Sélectionner un style de carte"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Paramètres de la carte"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Niveau de zoom"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Hauteur de la carte en pixels"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Niveau de zoom"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Taille du marqueur"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Les options de contrôle précis sont activées."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Basculez pour activer les options de contrôles de la carte."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Contrôles de la carte"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Type de carte"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "La commutation entre les vues cartographiques standard et satellite est activée."
+msgstr ""
+"La commutation entre les vues cartographiques standard et satellite est "
+"activée."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Basculez pour passer de la carte standard à la carte satellite, et inversement."
+msgstr ""
+"Basculez pour passer de la carte standard à la carte satellite, et "
+"inversement."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Contrôles de zoom"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Affichage des contrôles de zoom de la carte."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Basculez pour activer le zoom avant et arrière sur la carte à l’aide des contrôles de zoom."
+msgstr ""
+"Basculez pour activer le zoom avant et arrière sur la carte à l’aide des "
+"contrôles de zoom."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Vue de la rue"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Affichage du contrôle de la carte vue de la rue."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "Basculez pour afficher le contrôle vue de la rue en bas à droite."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Basculement plein écran"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Affichage du contrôle de la carte plein écran."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Basculez pour afficher le contrôle de la carte plein écran."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Clé API Google Maps"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Ajoutez votre clé API Google Maps. La mise à jour de cette clé API permettra à toutes vos cartes d’utiliser la nouvelle clé."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Ajoutez votre clé API Google Maps. La mise à jour de cette clé API permettra "
+"à toutes vos cartes d’utiliser la nouvelle clé."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Récupérez votre clé"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Besoin d’aide ?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Entrez la clé API Google…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Enregistré"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standard"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Gris argent"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Sombre"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Nuit"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Aubergine"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1238,9 @@ msgstr "Médias à droite"
 msgid "Media on left"
 msgstr "Médias à gauche"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Carte média"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Ajoutez une image ou une vidéo avec une carte décalée côte à côte."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "image"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "vidéo"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1254,18 @@ msgstr "Affichage de l’ombre de carte."
 msgid "Toggle to add a card shadow."
 msgstr "Basculez pour ajouter une ombre de carte."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Ombre %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Affichage de l’ombre %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Basculer pour ajouter une ombre %s"
 
@@ -1545,40 +1289,171 @@ msgstr "Déposer pour remplacer le média"
 msgid "Edit media"
 msgstr "Modifier le média"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Tableaux %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL du gist"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Plan %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Carrousel"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL du gist"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Paramètres des couleurs"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Affichage du prix de cet élément."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Basculez pour afficher les métadonnées du gist."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Affichage du bouton d’appel à l’action."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Basculez pour afficher les métadonnées du gist."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Réglages des fonctionnalités"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Médias à gauche"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Médias à droite"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Taille de colonne"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Paramètres du gist"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Tableau des prix"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Tableau des prix"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Tableau des prix"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Tableau des prix"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Ajoutez des tableaux de prix."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "accueil"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Plan %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "comparaison"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Paramètres du tableau de prix"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tableaux"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1471,171 @@ msgstr "Plan A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Élément du tableau de prix"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Une colonne placée dans le bloc tableau de prix."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Ajouter le fond à %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Colonne"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Un enfant immédiat d’une ligne."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Largeur"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Paramètres des colonnes"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Espace autour du conteneur."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Largeur"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Modifier la mise en page"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "one"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "deux"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "trois"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "quatre"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Ajouter le fond à %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Une colonne"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Deux colonnes"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Trois colonnes"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Quatre colonnes"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Structures de lignes"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Ligne"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Sélectionnez maintenant une structure pour cette ligne de colonne %s."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Sélectionnez le nombre de colonnes pour cette ligne."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Sélectionner les colonnes de ligne"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Sélectionner la structure des lignes"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Retour aux colonnes"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Ajoutez un wrapper structuré pour les blocs de colonnes, puis ajoutez les blocs de contenu souhaités dans les colonnes."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Ajoutez un wrapper structuré pour les blocs de colonnes, puis ajoutez les "
+"blocs de contenu souhaités dans les colonnes."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "lignes"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "colonnes"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "structures"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Structure"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Paramètres des lignes"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Aucun"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1645,9 @@ msgstr "Square"
 msgid "Circle"
 msgstr "Cercle"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Services"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Ajoutez jusqu’à quatre colonnes de services à afficher."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "fonctionnalités"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1669,7 @@ msgstr "Affichage des boutons d’appel à l’action."
 msgid "Toggle to show call to action buttons."
 msgstr "Basculez pour afficher les boutons d’appel à l’action."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Service"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Un seul élément de service au sein d’un bloc services."
 
@@ -1785,264 +1690,233 @@ msgid "Toggle to show a call to action button."
 msgstr "Basculez pour afficher un bouton d’appel à l’action."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Retourner horizontalement"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Retourner verticalement"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Diviseur de forme"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Ajoutez un diviseur de forme pour distinguer visuellement les sections de page."
+msgstr ""
+"Ajoutez un diviseur de forme pour distinguer visuellement les sections de "
+"page."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "séparateur"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Couleur de la forme"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Paramètres du diviseur"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Hauteur de la forme en pixels"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Hauteur du fond en pixels"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Orientation"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Couleur de la forme"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Partager sur Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Partager sur Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Partager sur Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Partager sur Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Partager sur LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Partager par email"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Partager sur Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Partager sur Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Partager sur Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Partager"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "réseaux sociaux"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Ajoutez des liens de partage sur les réseaux sociaux pour vous aider à obtenir des mentions « J’aime » et des partages."
+msgstr ""
+"Ajoutez des liens de partage sur les réseaux sociaux pour vous aider à "
+"obtenir des mentions « J’aime » et des partages."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Couleurs des médias sociaux"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Taille de l’icône"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Taille du cercle"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Taille des boutons"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Icônes"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Les couleurs des boutons de partage sont activées."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Basculez pour utiliser les couleurs officielles de chaque plateforme de médias sociaux."
+msgstr ""
+"Basculez pour utiliser les couleurs officielles de chaque plateforme de "
+"médias sociaux."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Couleurs des médias sociaux"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Ajouter un profil Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Ajouter un profil Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Ajouter un profil Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Ajouter un profil Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Ajouter un profil LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Ajouter un profil YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Ajouter un profil Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Ajouter un profil Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Profils sociaux"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "liens"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Affichez des liens vers les profils de médias sociaux."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Liens du profil"
 
@@ -2057,18 +1931,6 @@ msgstr "Supprimer le fond"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Arrière-plan"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Voiture"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Couverture"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Contiennent"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1988,6 @@ msgstr "Supprimer le fond"
 msgid "Remove "
 msgstr "Supprimer "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Ne pas répéter"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Répéter horizontalement"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Répéter verticalement"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Déplacer l’image vers l’arrière"
@@ -2150,17 +2000,14 @@ msgstr "Déplacer l’image vers l’avant"
 msgid "Link To"
 msgstr "Lien vers"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Galerie %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Uploader une image"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Léger"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2021,110 @@ msgstr "Page de pièce jointe"
 msgid "Custom URL"
 msgstr "URL personnalisée"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Orientation"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Pourcentage"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Réinitialiser"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Sélectionner les unités"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "Unités %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Désactiver les paramètres %s avancés."
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "Haut %s"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "Droite %s"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "Bas %s"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "Gauche %s"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Désynchroniser"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Synchroniser"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Synchroniser les unités"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Haut"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Droite"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Bas"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Gauche"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Paramètres %s avancés"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Avancé"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Défaut"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Structure"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2143,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Basculez pour activer le mode plein écran."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "En-tête %d"
@@ -2263,43 +2152,16 @@ msgstr "En-tête %d"
 msgid "Custom color picker"
 msgstr "Sélecteur de couleur personnalisé"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Original"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Échelle des gris"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sépia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Saturation"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Dim"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Appliquer le filtre"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Sélectionner l’orientation"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Hauteur"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Mobile %s"
@@ -2333,7 +2195,8 @@ msgid "Five Seconds"
 msgstr "Cinq secondes"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Six secondes"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2215,22 @@ msgstr "Neuf secondes"
 msgid "Ten Seconds"
 msgstr "Dix secondes"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Navigation par flèche"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Navigation par point"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "secondes"
@@ -2361,22 +2240,28 @@ msgid "second"
 msgstr "seconde"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Avancement après %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Passez automatiquement à la diapositive suivante."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Glisser-tapoter activé sur les appareils de bureau et mobiles."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Basculez pour activer la fonction glisser sur les appareils de bureau et mobiles."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Basculez pour activer la fonction glisser sur les appareils de bureau et "
+"mobiles."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2272,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Basculez pour afficher les flèches de navigation des diapositives."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Affichage des flèches de navigation par point."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Basculez pour afficher la navigation par point."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Espace à l’intérieur du conteneur."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Basculez pour couper le son de la vidéo."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Basculez pour lire la vidéo ne boucle."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Paramètres des curseurs"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Lecture automatique"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Vitesse de transition"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "déplaçable"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Navigation par flèche"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Navigation par point"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Mettre en majuscule"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2359,6 @@ msgstr "Pas d’espacement bas"
 msgid "Change typography"
 msgstr "Modifier la typographie"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Gras"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Majuscule"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Minuscule"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Empilement sur mobile"
@@ -2481,31 +2369,37 @@ msgstr "La réactivité est activée."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Basculez pour empiler les éléments les uns sur les autres sur des fenêtres d’affichage plus petites."
+msgstr ""
+"Basculez pour empiler les éléments les uns sur les autres sur des fenêtres "
+"d’affichage plus petites."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Supprimer l’espacement haut"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "La marge haute est supprimée sur ce bloc."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Basculez pour ajouter une ombre de carte."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Basculez pour supprimer toute marge appliquée sur le haut de ce bloc."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Basculez pour afficher la navigation par point."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Retirer l’espacement bas"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "La marge bas est supprimée sur ce bloc."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Basculez pour ajouter une ombre de carte."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Basculez pour supprimer toute marge appliquée sur le bas de ce bloc."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Basculez pour afficher la navigation par point."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2413,14 @@ msgstr "Affichage en pleine largeur."
 msgid "Toggle to display button as full width."
 msgstr "Basculez pour afficher le bouton en pleine largeur."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Circulaire"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Réglages Héro"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Ombre"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Case à cocher"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Majuscule"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2440,800 @@ msgstr "Rechercher un bloc"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Ce bloc est ajouté à la page et il ne peut pas être désactivé actuellement."
+msgstr ""
+"Ce bloc est ajouté à la page et il ne peut pas être désactivé actuellement."
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Désactiver tout"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Blocs « %s » introuvables."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Galeries %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Afficher l’accordéon ouvert"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Ajouter le titre de l’accordéon..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Élément d’accordéon"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "onglets"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "faq"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "avis"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "message"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biographie"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "lien"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "partager"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "espacement"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "services"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menu"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restaurant"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "email"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "messagerie"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Nom de famille"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Zone de texte"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Texte multiligne"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "email"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "à propos de"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "détails de contact"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galerie"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "photos"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Nuit"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animé"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "code"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "bouton"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "appel à l’action"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "texte"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "paragraphe"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "icônes"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "clients"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "preuve"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "témoignages"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "adresse"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "cartes"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "image"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "vidéo"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "adresse"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "accueil"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "comparaison"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "lignes"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "colonnes"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "structures"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "fonctionnalités"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "séparateur"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "réseaux sociaux"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "liens"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Affichage ouvert"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Ajouter un élément d’accordéon"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Accordéon"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Écrire le texte..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Écrire le titre..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Alerte"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Auteur"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Boutons"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Cliquez pour envoyer le tweet"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "RH dynamique"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Fonction"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Fonctionnalités"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Produit alimentaire"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Nourriture et boissons"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Nom"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Message"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Formulaire"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Carrousel"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Maçonnerie"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Empilé"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL du gist"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Surbrillance"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Icône"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logos et badges"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Carte"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Carte média"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Carrousel"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Tableau des prix"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Élément du tableau de prix"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Colonne"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Ligne"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Services"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Service"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Diviseur de forme"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Partager"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Profils sociaux"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Info"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Succès"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Attention"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Erreur"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Point"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Ligne"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Pleine largeur"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Réseau"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Liste"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Défaut"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Couches"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Esquissé"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Rempli"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Empilé"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Répéter horizontalement"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Ondulé"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Collines"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Vagues"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "À angle"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "En pente"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Arrondi"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Triangle"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Pointu"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Masque"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Icône"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Texte"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Icône et texte"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Circulaire"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Bas gauche"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Haut gauche"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Déposer pour ajouter en tant qu’avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Auteur"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3253,34 @@ msgstr "Ajouter un contenu de fonctionnalité"
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Il s’agit d’un bloc de fonctionnalités que vous pouvez utiliser pour mettre des fonctionnalités en surbrillance."
+msgstr ""
+"Il s’agit d’un bloc de fonctionnalités que vous pouvez utiliser pour mettre "
+"des fonctionnalités en surbrillance."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Ajouter le titre Hero..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Ajouter le titre Hero..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Ajoutez un contenu Hero, qui correspond normalement à une zone "
+"d’introduction d’une page accompagnée d’un ou deux appels à l’action."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Ajoutez un contenu Hero, qui correspond normalement à une zone d’introduction d’une page accompagnée d’un ou deux appels à l’action."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Ajouter une action principale..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Ajouter une action secondaire..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3299,126 @@ msgstr "Ajouter un contenu..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Remplacez ce texte par une copie descriptive pour accompagner l’image de la carte. Ajoutez ensuite d’autres blocs à cette carte, tels que des boutons, des listes ou des images."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Remplacez ce texte par une copie descriptive pour accompagner l’image de la "
+"carte. Ajoutez ensuite d’autres blocs à cette carte, tels que des boutons, "
+"des listes ou des images."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Écrire le titre..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Écrire la description..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Paramètres des boutons"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Personnalisé"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Empilement sur mobile"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Paramètres RH dynamiques"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Aucun"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Aucun"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Petit"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Moyen"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Grand"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Très large"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Aucun"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Petit"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Moyen"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Grand"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3160,7 +3838,9 @@ msgstr "monde public global mondial terre emplacement carte"
 #: src/blocks/icon/svgs.js:258
 msgctxt "tags"
 msgid "location map public business corporation building town skyscraper"
-msgstr "emplacement carte public business entreprise société immeuble bâtiment ville tour"
+msgstr ""
+"emplacement carte public business entreprise société immeuble bâtiment ville "
+"tour"
 
 #: src/blocks/icon/svgs.js:263
 msgctxt "tags"
@@ -3180,7 +3860,8 @@ msgstr "amusement fête joyeux célébration goût nourriture"
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "pétale parfum odeur agréable détente paysage jardinage plein air extérieur"
+msgstr ""
+"pétale parfum odeur agréable détente paysage jardinage plein air extérieur"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3259,8 +3940,12 @@ msgstr "musique microphone chanson artiste créatif média audio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "microphone podcast ordinateur appareil musique microphone chanson artiste créatif média audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"microphone podcast ordinateur appareil musique microphone chanson artiste "
+"créatif média audio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3270,7 +3955,8 @@ msgstr "photo photographe photographie appareil photo film créatif média"
 #: src/blocks/icon/svgs.js:55
 msgctxt "tags"
 msgid "photo photographer photography camera aperture film creative media"
-msgstr "photo photographe photographie appareil photo ouverture film créatif média"
+msgstr ""
+"photo photographe photographie appareil photo ouverture film créatif média"
 
 #: src/blocks/icon/svgs.js:61
 msgctxt "tags"
@@ -3284,8 +3970,12 @@ msgstr "film vidéographie réalisateur producteur média créatif"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "vidéo vidéographie réalisateur producteur média créatif appareil photo photographe photographie ouverture"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"vidéo vidéographie réalisateur producteur média créatif appareil photo "
+"photographe photographie ouverture"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3992,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "palette design couleurs artiste peintre créatif média peinture pinceau"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standard"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Gris argent"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Sombre"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Nuit"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Aubergine"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Circulaire"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Ombre"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Défaut"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Aucun"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Case à cocher"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Titre du menu..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Petit"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Moyen"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Grand"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Très large"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Voiture"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Couverture"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Contiennent"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Haut gauche"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Haut centre"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Haut droit"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Centre gauche"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Centre centre"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Centre droit"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Bas gauche"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Bas centre"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Bas droit"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Ne pas répéter"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Répéter"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Répéter horizontalement"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Répéter verticalement"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Rel du lien"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Sombre"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Léger"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Aucun"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Image"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Pixel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Pourcentage"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Original"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Échelle des gris"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Fichier média"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Saturation"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Fleur vintage"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Fleur vintage"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Mettre en majuscule"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Gras"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Défaut"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Majuscule"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Minuscule"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4340,16 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks est une suite professionnelle de <strong>blocs de contenu pour la création de pages</strong> destinée à l’éditeur de blocs WordPress Gutenberg. Nos blocs sont totalement centrés sur l’autonomisation des créateurs, pour les aider à construire de superbes pages magnifiquement illustrées dans WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks est une suite professionnelle de <strong>blocs de contenu pour la "
+"création de pages</strong> destinée à l’éditeur de blocs WordPress "
+"Gutenberg. Nos blocs sont totalement centrés sur l’autonomisation des "
+"créateurs, pour les aider à construire de superbes pages magnifiquement "
+"illustrées dans WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4359,173 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Vous trichez, non ?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Laissez un avis"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s ans"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "un an"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s semaines"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "une semaine"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s jours"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "un jour"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s heures"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "une heure"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minutes"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "une minute"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s secondes"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "une seconde"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Plug-in %s WordPress"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Vous appréciez %s ?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Vous utilisez %1$s depuis %2$s maintenant. Pouvez-vous nous laisser un avis pour nous faire connaître vos impression ? Nous vous en serions très reconnaissants !"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Laissez un avis"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Vous utilisez %1$s depuis %2$s maintenant. Pouvez-vous nous laisser un avis "
+"pour nous faire connaître vos impression ? Nous vous en serions très "
+"reconnaissants !"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Non merci / Je l’ai déjà fait"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Merci d’avoir choisi CoBlocks, le premier créateur de pages pour le nouvel éditeur de blocs WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Merci d’avoir choisi CoBlocks, le premier créateur de pages pour le nouvel "
+"éditeur de blocs WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Vous venez d’ajouter de nombreux blocs utiles et une nouvelle boîte à outils de création de pages dans l’éditeur WordPress. CoBlocks vous offre un ensemble de fonctionnalités qui changent la donne : %1$sdes dizaines de blocs%2$s, une %1$s expérience de la création de pages%2$s et des %1$s contrôles typographiques personnalisés%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Vous venez d’ajouter de nombreux blocs utiles et une nouvelle boîte à outils "
+"de création de pages dans l’éditeur WordPress. CoBlocks vous offre un "
+"ensemble de fonctionnalités qui changent la donne : %1$sdes dizaines de blocs"
+"%2$s, une %1$s expérience de la création de pages%2$s et des %1$s contrôles "
+"typographiques personnalisés%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Voici quelques vidéos pour vous aider à démarrer :"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Regardez comment créer votre première page avec %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Regardez comment créer votre première page"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Regardez comment utiliser les blocs Diviseur de ligne et de forme"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Découvrez comment utiliser le bloc Carte multimédia"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Vous aimez ce que vous voyez ? %1$sAbonnez-vous à notre chaîne YouTube%2$s et nous vous informerons dès que de nouveaux tutoriels vidéo seront disponibles."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Vous aimez ce que vous voyez ? %1$sAbonnez-vous à notre chaîne YouTube%2$s "
+"et nous vous informerons dès que de nouveaux tutoriels vidéo seront "
+"disponibles."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Si vous avez des questions ou des commentaires, faites-le nous savoir sur %1$sTwitter%4$s ou sur notre %2$sgroupe Facebook%4$s. Aussi, %3$sabonnez-vous à notre bulletin%4$s si vous voulez rester au courant de l’actualité CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Si vous avez des questions ou des commentaires, faites-le nous savoir sur "
+"%1$sTwitter%4$s ou sur notre %2$sgroupe Facebook%4$s. Aussi, %3$sabonnez-"
+"vous à notre bulletin%4$s si vous voulez rester au courant de l’actualité "
+"CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Profitez-en !"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Lancez-vous avec CoBlocks ici :"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4533,35 @@ msgstr "Activer ou désactiver les blocs"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "Clé de site reCAPTCHA pour la protection contre les spams de formulaire"
+msgstr ""
+"Clé de site reCAPTCHA pour la protection contre les spams de formulaire"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
-msgstr "Clé secrète reCAPTCHA pour la protection contre les spams de formulaire"
+msgstr ""
+"Clé secrète reCAPTCHA pour la protection contre les spams de formulaire"
+
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Nom"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Première"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Dernière"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Message"
 
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Envoyer"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Votre message a été envoyé :"
 
@@ -3490,3 +4576,87 @@ msgstr "Partager sur LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Type d’alerte"
+
+#~ msgid "Edit image"
+#~ msgstr "Modifier l’image"
+
+#~ msgid "Remove image"
+#~ msgstr "Supprimer l’image"
+
+#~ msgid "Heading..."
+#~ msgstr "En-tête..."
+
+#~ msgid "Author Name"
+#~ msgstr "Nom de l’auteur"
+
+#~ msgid "Write biography..."
+#~ msgstr "Écrire une biographie..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Ajoutez une biographie de l’auteur."
+
+#~ msgid "%s Settings"
+#~ msgstr "Paramètres de %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Couleur de la légende"
+
+#~ msgid "Highlight text."
+#~ msgstr "Mettez le texte en surbrillance."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Tableaux %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Paramètres du tableau de prix"
+
+#~ msgid "Tables"
+#~ msgstr "Tableaux"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Une colonne placée dans le bloc tableau de prix."
+
+#~ msgid "Sepia"
+#~ msgstr "Sépia"
+
+#~ msgid "Dim"
+#~ msgstr "Dim"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Sélectionner l’orientation"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "La marge haute est supprimée sur ce bloc."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Basculez pour supprimer toute marge appliquée sur le haut de ce bloc."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "La marge bas est supprimée sur ce bloc."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Basculez pour supprimer toute marge appliquée sur le bas de ce bloc."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Ajouter une action principale..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Ajouter une action secondaire..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Lancez-vous avec CoBlocks ici :"

--- a/languages/coblocks-hi_IN.po
+++ b/languages/coblocks-hi_IN.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "प्रदर्शन खुला"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "एकॉर्डियन शीर्षक जोड़ें..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "एकॉर्डियन आइटम"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "एकॉर्डियन में मिश्रित करने योग्य एकॉर्डियन आइटम जोड़ें"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "टैब्स"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "सामान्य प्रश्न"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "डिफ़ॉल्ट रूप से खुले रहने क�
 msgid "Accordion Item Settings"
 msgstr "एकॉर्डियन आइटम सेटिंग्स"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "प्रदर्शन खुला"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "रंग की सेटिंग्स"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "पृष्ठभूमि रंग"
@@ -103,14 +63,6 @@ msgstr "पृष्ठभूमि रंग"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "शीर्षक पाठ रंग"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "एकॉर्डियन आइटम जोड़ें"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "एकॉर्डियन"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -129,140 +81,77 @@ msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
 msgstr "JavaScript पॉलीफ़िल को लोड करके Internet Explorer के लिए समर्थन जोड़ें."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "इस पेज पर JavaScript पॉलीफ़िल को लोड करके Internet Explorer के लिए समर्थन करना."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"इस पेज पर JavaScript पॉलीफ़िल को लोड करके Internet Explorer के लिए समर्थन करना."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "चेतावनी"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "त्रुटि"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "अलर्ट प्रकार"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "डिफ़ॉल्ट"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "जानकारी"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "सफल"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "शीर्षक लिखें..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "पाठ लिखें..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "अलर्ट"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "प्रासंगिक प्रतिक्रिया संदेश दें."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "सूचना"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "संदेश"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "पाठ रंग"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "छवि संपादित करें"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "गैलरी संपादित करें"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "छवि निकालें"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "कैप्शन लिखें..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "अवतार के रूप में जोड़ने के लिए छोड़ें"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "शीर्षक..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "लेखक का नाम"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "बायोग्राफ़ी लिखें..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "फ़ॉर्म सेटिंग्स"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "लेखक"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "लेखक की बायोग्राफ़ी जोड़ें"
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "बायोग्राफ़ी"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "प्रोफ़ाइल"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "बटन"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "एक के पास मौजूद एक कई बटन के द्वारा आगंतुकों को कार्रवाई करने के लिए प्रेरित करें."
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "लिंक"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "बटन सेटिंग्स"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "मोबाइल पर स्टैक"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "बटन"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +169,25 @@ msgstr "Twitter उपयोगकर्ता का नाम"
 msgid "Username"
 msgstr "उपयोगकर्ता का नाम"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "बटन जोड़ें..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "ट्वीट करने के लिए कोट जोड़ें..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "ट्वीट करने के लिए क्लिक करें"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "पाठकों को Twitter के माध्यम से ट्वीट करने के लिए कोट जोड़ें."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "साझा करें"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +195,18 @@ msgid "Text Settings"
 msgstr "पाठ सेटिंग्स"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "बटन का रंग"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "डायनमिक HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "अन्य ब्लॉक के बीच आकार बदलने योग्य स्पेसर जोड़ें."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "स्पेसर"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "डायनमिक HR सेटिंग्स"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "पिक्सेल में ऊँचाई"
 
@@ -347,17 +218,12 @@ msgstr "पिक्सेल में डायनमिक विभाजक
 msgid "Color"
 msgstr "रंग"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "पृष्ठभूमि के रूप में जोड़ें"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "सुविधा"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "पेरेंट फ़ीचर ब्लॉक में एकल चाइल्ड कॉलम."
 
@@ -366,73 +232,54 @@ msgid "Feature Settings"
 msgstr "सुविधा सेटिंग्स"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "पैडिंग"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "सुविधाएं"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "अपने उत्पाद या सेवा के लिए संक्षिप्त टिप्पणी वाले तीन तक कॉलम जोड़ें."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "सेवाएँ"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "मार्जिन"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "गटर"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "प्रत्येक कॉलम के बीच जगह"
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "छोटा"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "मध्यम"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +289,8 @@ msgstr "बड़ा"
 msgid "Features Settings"
 msgstr "सुविधा सेटिंग्स"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "कॉलम"
 
@@ -455,76 +302,72 @@ msgstr "मेनू अनुभाग जोड़ें"
 msgid "Menu title..."
 msgstr "मेनू शीर्षक..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "ग्रिड"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "सूची"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "बदलने के लिए छवि छोड़ें"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "छवि निकालें"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "शीर्षक जोड़ें..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "तीखा"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "अत्यंत प्रचलित"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "शाकाहार"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "ग्लूटेन मुक्त"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "पेस्केटैरियन"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "वीगन"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "वर्णन जोड़ें..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0.00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "खाद्य पदार्थ"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "खाद्य और पेय ब्लॉक के भीतर खाद्य और पेय पदार्थ."
 
@@ -560,62 +403,46 @@ msgstr "इस आइटम के लिए कीमत दिखाने क
 msgid "Item Attributes"
 msgstr "आइटम की विशेषताएं"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "मसालेदार"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "छवि की सेटिंग्स"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "सभी पाठ (वैकल्पिक पाठ)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "छवि का उद्देश्य बताएँ"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "यदि छवि पूरी तरह से सजावटी है, तो खाली छोड़ दें."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "फोकल प्वाइंट"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "भोजन और पेय"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "मेनू या मूल्य सूची प्रदर्शित करें."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "रेस्तरां"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "मेनू"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "शैलियां"
@@ -648,134 +475,84 @@ msgstr "प्रत्येक आइटम के लिए मूल्य �
 msgid "Toggle to show the price of each item."
 msgstr "इस आइटम के लिए मूल्य दिखाने के लिए टॉगल करें."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "ईमेल"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "ई-मेल"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "मेल"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "ईमेल पता फ़ील्ड."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "संदेश"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "टेक्स्ट क्षेत्र"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "मल्टीलाइन पाठ"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "लंबी प्रतिक्रियाओं के लिए पाठ बॉक्स."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s कोई मान्य ईमेल पता नहीं है."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s और %s कोई मान्य ईमेल पते नहीं हैं."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s कोई मान्य ईमेल पता नहीं है."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "ईमेल पता"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "विषय"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "फ़ॉर्म सेटिंग्स"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
 msgstr "अपनी reCAPTCHA साइट जोड़ें और स्पैम से आपके फ़ॉर्म को सुरक्षित करने के लिए गुप्त कुंजी."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "कुंजियाँ जनरेट करें"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "मेरी कुंजी"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "सहायता प्राप्त करें"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "साइट कुंजी"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "गुप्त कुंजी"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "सहेज रहे हैं"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "सहेजें"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "निकालें"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "पहले"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "अंतिम"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "नाम"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "नाम के लिए पाठ फ़ील्ड"
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "ईमेल पता फ़ील्ड."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "लेबल जोड़ें..."
 
@@ -783,41 +560,38 @@ msgstr "लेबल जोड़ें..."
 msgid "Required"
 msgstr "आवश्यक"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "नाम फ़ील्ड सेटिंग्स"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "अंतिम नाम"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "पहले और अंतिम नाम फ़ील्ड दोनों दिखाना."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "अंतिम नाम फ़ील्ड जोड़ने के लिए टॉगल करें."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "फ़ॉर्म"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "नाम के लिए पाठ फ़ील्ड"
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "लंबी प्रतिक्रियाओं के लिए पाठ बॉक्स."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "अपने पेज में सामान्य फ़ॉर्म जोड़ें."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "ईमेल"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "इसके बारे में"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "संपर्क"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "विषय"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +601,217 @@ msgstr "पाठ जोड़ें…"
 msgid "Button Text Color"
 msgstr "बटन पाठ रंग"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "गैलरी संपादित करें"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "कैरोसल"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "गैलरी में %2$d की %1$dछवि"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "कैप्शन लिखें..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "कैरोसल"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "सुंदर कैरोसल गैलरी में कई छवियाँ दिखाएं"
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "गैलरी"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "फ़ोटो"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s सेटिंग्स"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "लाइन उँचाई"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "डॉट नेविगेशन तीर दिखाना."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "मी़डिया कैप्शन दिखाने के लिए टॉगल करें."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "रंग की सेटिंग्स"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "आकार"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "घुमावदार कोने"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "कैप्शन का रंग"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "लागू करें"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "मिस्त्री"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "वर्णन लिखें..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "किसी संगठित मिस्त्री गैलरी में कई छवि प्रदर्शित होती हैं."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "सुंदर कैरोसल गैलरी में कई छवियाँ दिखाएं"
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "कॉलम का आकार"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "छवि की सेटिंग्स"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "गैलरी आइटम मे ंघुमावदार कोने जोड़ें."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "शैडो"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "कैप्शन"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "कैप्शन स्टाइल"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "प्रत्येक मीडिया आइटम के लिए कैप्शन दिखाना."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "मी़डिया कैप्शन दिखाने के लिए टॉगल करें."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "मिस्त्री"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "किसी संगठित मिस्त्री गैलरी में कई छवि प्रदर्शित होती हैं."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "मैप नियंत्रण विकल्पों को सक्षम करने के लिए टॉगल करें."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "मैप सेटिंग्स"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "कॉलम का आकार"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "गैलरी आइटम मे ंघुमावदार कोने जोड़ें."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "प्रकाश"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "स्टैक किया गया"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "एकल कॉलम स्टैक की गई गैलरी में कई छवियां दिखाएं."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "पूर्ण-चौड़ाई छवियां"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "पूर्ण-चौड़ाई छवि"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "बॉक्स शैडो"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "पूर्ण-चौड़ाई छवियां सक्षम हैं"
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
 msgstr "उपलब्ध गैलरी क्षेत्र को पूरी चौड़ाई की छवियों के साथ भरने के लिए टॉगल करें."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "‌आइटम सेटिंग्स"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "पूर्ण-चौड़ाई छवियां"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "पूर्ण-चौड़ाई छवि"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "gif निकालें"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "इस gif में खाली alt विशेषता है"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Giphy पर उस सही gif के लिए खोजें"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "gif खोजें"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "कोई gif चुनें, कोई भी gif."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "एनीमेटेड"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +837,11 @@ msgstr "GitHub फ़ाइल"
 msgid "File"
 msgstr "फ़ाइल"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "GitHub पर इस gist को देखें"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist URL"
 
@@ -1024,12 +854,9 @@ msgid "Loading Gist"
 msgstr "Gist लोड हो रहा है"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "gist लिंक जोड़कर एम्बेड की गई GitHub gist"
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "कोड"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +879,159 @@ msgid "Gist Meta"
 msgstr "Gist मेटा"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "लेआउट बदलें"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "%s में पृष्ठभूमि जोड़ें"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "हीरो"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"पेज का परिचय देने वाला क्षेत्र पाठ जिसमें थोड़ा-सा पाठ रहेगा और कार्रवाई के लिए कॉल करें "
+"होगा."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "पेज का परिचय देने वाला क्षेत्र पाठ जिसमें थोड़ा-सा पाठ रहेगा और कार्रवाई के लिए कॉल करें होगा."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "बटन"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "कार्रवाई के लिए कॉल करें"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "पिक्सेल में सामग्री की चौड़ाई"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "हीरो सेटिंग्स"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "कंटेनर के अंदर जगह."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "शीर्ष बायां"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "शीर्ष केंद्र"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "शीर्ष दायां"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "केंद्र बायां"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "केंद्र केंद्र"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "केंद्र दायां"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "नीचे बायां"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "नीचे केंद्र"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "नीचे दायां"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "हाइलाइट किया गया पाठ जोड़ें..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "हाइलाइट"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "हाइलाइट"
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "पाठ"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "पैराग्राफ़"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "आइकन"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "कुछ और संचार करने के लिए स्टाइल वाला ग्राफ़िक प्रतीक जोड़ें."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "आइकन"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "बड़ा"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "कुछ और संचार करने के लिए स्टाइल वाला ग्राफ़िक प्रतीक जोड़ें."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "आइकन सेटिंग्स"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "उन्नत %s सेटिंग्स बंद करें"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "रीसेट करें"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "कस्टम %s आकार"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "उन्नत %s सेटिंग"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "सीमा-शुल्क"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "उन्नत"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "त्रिज्या"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "आइकन खोज"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "कोई परिणाम नहीं मिला."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "लिंक सेटिंग्स"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "लिंक URL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "लिंक Rel"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "नई टैब में खोलना"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "नई टैब में खोलें"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "आइकन का रंग"
 
@@ -1261,30 +1040,17 @@ msgid "Edit logos"
 msgstr "लोगो संपादित करें"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "लोगो और बैज"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr "छवियां खींचें, नए अपलोड करें या अपनी लाइब्रेरी से फ़ाइलों का चयन करें."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "विश्वसनीयता बनाने के लिए लोगो, बैजेस या प्रमाणपत्र जोड़ें."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "क्लायंट्स"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "प्रमाण"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "विवरण"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1072,138 @@ msgstr "स्थान संपादित करें"
 msgid "Map style"
 msgstr "मैप स्टाइल"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "अमान्य API कुंजी या कई सारे अनुरोध"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Map"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "Google मैप पर पिन छोड़ने के लिए कोई स्थान या पता दर्ज करें."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "स्थान या पते के लिए खोजें..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "लागू करें"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "मैप"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "कोई पता जोड़ें और Google मैप पर पिन छोड़ें."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "पता"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "मैप"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "मैप स्टाइल चुनें"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "मैप सेटिंग्स"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "ज़ूम स्तर"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "पिक्सेल में मैप के लिए उँचाई"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "ज़ूम स्तर"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "मार्कर का आकार"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "बेहतर नियंत्रण विकल्प सक्षम हैं."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "मैप नियंत्रण विकल्पों को सक्षम करने के लिए टॉगल करें."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "मैप नियंत्रण"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "मैप प्रकार"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "मानक और सैटलाइट मैप दृश्यों के बीच स्विच करना सक्षम है."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "मानक और सैटलाइट मैप के बीच स्विच सक्षम करने लिए टॉगल करें."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "ज़ूम नियंत्रण"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "मैप ज़ूम नियंत्रण दिखाना."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "ज़ूम नियंत्रण के साथ मैप पर ज़ूम इन और आउट सक्षम करने के लिए टॉगल करें."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "स्ट्रीट दृश्य"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "स्ट्रीट दृश्य मैप नियंत्रण दिखाना."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "नीचे दाईं ओर स्ट्रीट दृश्य नियंत्रण दिखाने के लिए टॉगल करें."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "पूर्ण स्क्रीन टॉगल करना"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "पूर्ण स्क्रीन मैप नियंत्रण दिखाना."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "पूर्ण स्क्रीन मैप नियंत्रण दिखाने के लिए टॉगल करें."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google Maps API कुंजी"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "अपने Google Maps API कुंजी में जोड़ें. इस API कुंजी को अपडेट करने से नई कुंजी का उपयोग करने के लिए अपने सभी मैप सेट हो जाएंगे."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"अपने Google Maps API कुंजी में जोड़ें. इस API कुंजी को अपडेट करने से नई कुंजी का उपयोग करने "
+"के लिए अपने सभी मैप सेट हो जाएंगे."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "अपनी कुंजी पुनः प्राप्त करें"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "मदद चाहिए?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Google API कुंजी दर्ज करें…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "सहेजा गया"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "मानक"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "सिल्वर"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "रेट्रो"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "अंधेरा"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "रात"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "बैंगनी"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1213,9 @@ msgstr "दाईं ओर स्थित मीडिया"
 msgid "Media on left"
 msgstr "बाईं ओर स्थित मीडिया"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "मीडिया कार्ड"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "ऑफ़सेट कार्ड के साथ कोई छवि या वीडियो जोड़ें."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "छवि"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "वीडियो"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1229,18 @@ msgstr "कार्ड शैडो दिखाना."
 msgid "Toggle to add a card shadow."
 msgstr "कार्ड शैडो जोड़ने के लिए टॉगल करें."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s शैडो"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "%s शैडो दिखाना."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "%s शैडो जोड़ने के लिए टॉगल करें"
 
@@ -1545,40 +1264,171 @@ msgstr "मीडिया बदलने के लिए छोड़ें"
 msgid "Edit media"
 msgstr "मीडिया संपादित करें"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s तालिकाएं"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "%s प्लान"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "कैरोसल"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "रंग की सेटिंग्स"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "इस आइटम के लिए कीमत दिखाना."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "gist मेटा डेटा दिखाने के लिए टॉगल करें."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "कार्रवाई के लिए कॉल करें बटन दिखाना."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "gist मेटा डेटा दिखाने के लिए टॉगल करें."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "सुविधा सेटिंग्स"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "बाईं ओर स्थित मीडिया"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "दाईं ओर स्थित मीडिया"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "कॉलम का आकार"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gist सेटिंग्स"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "मूल्य निर्धारण तालिका"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "मूल्य निर्धारण तालिका"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "मूल्य निर्धारण तालिका"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "मूल्य निर्धारण तालिका"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "मूल्य निर्धारण तालिका जोड़ें."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "लैंडिंग"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "%s प्लान"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "तुलना करें"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "मूल्य निर्धारण तालिका सेटिंग्स"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "तालिकाएं"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1446,170 @@ msgstr "A प्लान"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "मूल्य निर्धारण तालिका आइटम"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "मूल्य निर्धारण तालिका ब्लॉक के भीतर रखा गया कॉलम."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "%s में पृष्ठभूमि जोड़ें"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "कॉलम"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "पंक्ति का इमिडिएट चाइल्ड."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "चौड़ाई"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "कॉलम सेटिंग्स"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "कंटेनर के आसपास की जगह."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "चौड़ाई"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "लेआउट बदलें"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "एक"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "दो"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "तीन"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "चार"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "%s में पृष्ठभूमि जोड़ें"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "एक कॉलम"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "दो कॉलम"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "तीन कॉलम"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "चार कॉलम"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "पंक्ति का लेआउट"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "पंक्ति"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "अब इस %s स्तंभ पंक्ति के लिए लेआउट चुनें."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "इस पंक्ति के लिए स्तंभ की संख्या चुनें."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "स्तंभ पंक्तियां चुनें"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "पंक्ति का लेआउट चुनें"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "स्तंभ पर वापस जाएं"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "स्तंभ ब्लॉक के लिए संरचित रैपर जोड़ें, फिर स्तंभ को पसंद करने के लिए सामग्री ब्लॉक जोड़ें."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"स्तंभ ब्लॉक के लिए संरचित रैपर जोड़ें, फिर स्तंभ को पसंद करने के लिए सामग्री ब्लॉक जोड़ें."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "पंक्तियां"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "स्तंभ"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "लेआउट"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "लेआउट"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "पंक्ति की सेटिंग्स"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "कोई नहीं"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1619,9 @@ msgstr "वर्गाकार"
 msgid "Circle"
 msgstr "सर्कल"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "सेवाएं"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "प्रदर्शित करने के लिए सेवाओं के चार स्तंभ जोड़ें."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "सुविधाएं"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1643,7 @@ msgstr "कार्रवाई के लिए कॉल करें बट�
 msgid "Toggle to show call to action buttons."
 msgstr "कार्रवाई के लिए कॉल करें बटन दिखाने हेतु टॉगल करें."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "सेवा"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "सेवा ब्लॉक के भीतर एकल सेवा आइटम."
 
@@ -1785,264 +1664,228 @@ msgid "Toggle to show a call to action button."
 msgstr "कार्रवाई के लिए कॉल करें बटन दिखाने हेतु टॉगल करें."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "क्षैतिज रूप से फ़्लिप करें"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "लंबवत  रूप से फ़्लिप करें"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "शेप डिवाइडर"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "विज़ुअल रूप से अलग पेज अनुभागों के लिए शेप डिवाइडर जोड़ें."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "सेपरेटर"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "शेप रंग"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "डिवाइडर सेटिंग्स"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "पिक्सेल में शेप ऊँचाई"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "पिक्सेल में पृष्ठभूमि ऊँचाई"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "अभिविन्यास"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "शेप रंग"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Twitter पर साझा करें"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Facebook पर साझा करें"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Twitter पर साझा करें"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Pinterest पर साझा करें"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Linkedin पर साझा करें"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "ईमेल के माध्यम से साझा करें"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Tumblr पर साझा करें"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Google पर साझा करें"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Reddit पर साझा करें"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "साझा करें"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "सामाजिक"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
 msgstr "पसंद और साझा पाने में अपनी मदद करने के लिए सामाजिक साझाकरण लिंक जोड़ें."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "सामाजिक रंग"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "आइकन का आकार"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "सर्कल आकार"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "बटन आकार"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "आइकन"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "ईमेल"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "साझा करें बटन के रंग सक्षम कर दिया गया है."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "प्रत्येक सामाजिक मीडिया प्लेटफ़ॉर्म से आधिकारिक रंगों का उपयोग करने के लिए टॉगल करें."
+msgstr ""
+"प्रत्येक सामाजिक मीडिया प्लेटफ़ॉर्म से आधिकारिक रंगों का उपयोग करने के लिए टॉगल करें."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "सामाजिक रंग"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Facebook प्रोफ़ाइल जोड़ें"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Twitter प्रोफ़ाइल जोड़ें"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Instagram प्रोफ़ाइल जोड़ें"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Pinterest प्रोफ़ाइल जोड़ें"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "LinkedIn प्रोफ़ाइल जोड़ें"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "YouTube प्रोफ़ाइल जोड़ें"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Yelp प्रोफ़ाइल जोड़ें"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Houzz प्रोफ़ाइल जोड़ें"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "सामाजिक प्रोफ़ाइल"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "लिंक"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "सामाजिक मीडिया प्रोफ़ाइल के लिंक प्रदर्शित करें."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "प्रोफ़ाइल लिंक"
 
@@ -2057,18 +1900,6 @@ msgstr "पृष्ठभूमि निकालें"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "पृष्ठभूमि"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "ऑटो"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "कवर"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "शामिल"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1957,6 @@ msgstr "पृष्ठभूमि निकालें"
 msgid "Remove "
 msgstr "निकालें "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "कोई दोहराव नहीं"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "क्षैतिज रूप से दोहराएं"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "लंबवत रूप से दोहराएं"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "छवि को पीछे ले जाएं"
@@ -2150,17 +1969,14 @@ msgstr "छवि को आगे ले जाएं"
 msgid "Link To"
 msgstr "इससे लिंक करें"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s गैलरी"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "कोई छवि अपलोड करें"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "प्रकाश"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +1990,110 @@ msgstr "अटैचमेंट पेज"
 msgid "Custom URL"
 msgstr "कस्टम URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "पिक्सेल"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "अभिविन्यास"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "प्रतिशत"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "रीसेट करें"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "यूनिट चुनें"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s यूनिट"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "उन्नत %s सेटिंग्स बंद करें"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s शीर्ष"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s दाएं"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s नीचे"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s बाएं"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "सिंक न करें"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "सिंक करें"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "यूनिट सिंक करें"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "शीर्ष"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "दाएं"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "नीचे"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "बाएं"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "उन्नत %s सेटिंग"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "उन्नत"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "डिफ़ॉल्ट"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "लेआउट"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2112,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "पूर्णस्क्रीन मोड सक्षम करने के लिए टॉगल करें."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "%d शीर्षक"
@@ -2263,43 +2121,16 @@ msgstr "%d शीर्षक"
 msgid "Custom color picker"
 msgstr "कस्टम रंग पिकर"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "मूल"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "ग्रेस्केल"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "गहरा काला रंग"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "सैचुरेशन"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "धूंधला"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "विंटेज"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "फ़िल्टर लागू करें"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "अभिविन्यास चुनें"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "उँचाई"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "%s मोबाइल"
@@ -2333,7 +2164,8 @@ msgid "Five Seconds"
 msgstr "पाँच सेकंड"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "छह सेकंड"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2184,22 @@ msgstr "नौ सेकंड"
 msgid "Ten Seconds"
 msgstr "दस सेकंड"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "तीर नेविगेशन"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "डॉट नेविगेशन"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "सेकंड"
@@ -2361,22 +2209,28 @@ msgid "second"
 msgstr "सेकंड"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "%1$d %2$s के बाद.आगे बढ़ना."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "स्वचालित रूप से अगली स्लाइड पर जाएं."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "डेस्कटॉप और मोबाइल डिवाइस पर खींचना और फ़्लिक सक्षम करना."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "डेस्कटॉप और मोबाइल डिवाइस पर किसी चीज़ को खींच कर ले जाने की कार्यक्षमता को सक्षम करने के लिए टॉगल करें."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"डेस्कटॉप और मोबाइल डिवाइस पर किसी चीज़ को खींच कर ले जाने की कार्यक्षमता को सक्षम करने "
+"के लिए टॉगल करें."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2241,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "स्लाइड नेविगेशन तीर दिखाने के लिए टॉगल करें."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "डॉट नेविगेशन तीर दिखाना."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "डॉट नेविगेशन दिखाने के लिए टॉगल करें."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "कंटेनर के अंदर जगह."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "वीडियो म्यूट करने के लिए टॉगल करें."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "वीडियो लूप करने के लिए टॉगल करें."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "स्लाइडर सेटिंग्स"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "ऑटोप्ले"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "लेनदेन गति"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "खींचने योग्य"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "तीर नेविगेशन"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "डॉट नेविगेशन"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "बड़े अक्षरों में करना"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "सामान्य"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2328,6 @@ msgstr "कोई बॉटम स्पेसिंग नहीं"
 msgid "Change typography"
 msgstr "टाइपोग्राफ़ी बदलें"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "बोल्ड"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "बड़ा अक्षर"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "छोटा अक्षर"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "मोबाइल पर स्टैक"
@@ -2487,25 +2344,29 @@ msgstr "छोटे व्यूपोर्ट पर एक दूसरे �
 msgid "Remove Top Spacing"
 msgstr "शीर्ष स्पेसिंग निकालें"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "इस ब्लॉक पर शीर्ष मार्जिन हटा दिया जाता है."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "कार्ड शैडो जोड़ने के लिए टॉगल करें."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "इस ब्लॉक के शीर्ष पर लागू किसी भी मार्जिन को निकालने के लिए टॉगल करें."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "डॉट नेविगेशन दिखाने के लिए टॉगल करें."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "नीचे स्पेसिंग निकालें"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "इस ब्लॉक पर निचली मार्जिन हटा दी जाती है."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "कार्ड शैडो जोड़ने के लिए टॉगल करें."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "इस ब्लॉक के नीचे लागू किसी भी मार्जिन को निकालने के लिए टॉगल करें."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "डॉट नेविगेशन दिखाने के लिए टॉगल करें."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2380,14 @@ msgstr "पूर्ण चौड़ाई के रूप में प्र�
 msgid "Toggle to display button as full width."
 msgstr "पूर्ण चौड़ाई के रूप में बटन प्रदर्शित करने के लिए टॉगल करें."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "सर्कुलर"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "हीरो सेटिंग्स"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "शैडो"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "चेकबॉक्स"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "बड़ा अक्षर"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2413,793 @@ msgstr "यह ब्लॉक पेज पर जोड़ा जाता ह
 msgid "Disable all"
 msgstr "सभी अक्षम करें‌‌"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "कोई \"%s\" ब्लॉक मिले."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s गैलरीज़"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "प्रदर्शन खुला"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "एकॉर्डियन शीर्षक जोड़ें..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "एकॉर्डियन आइटम"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "टैब्स"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "सामान्य प्रश्न"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "सूचना"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "संदेश"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "बायोग्राफ़ी"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "प्रोफ़ाइल"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "लिंक"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "साझा करें"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "स्पेसर"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "सेवाएँ"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "मेनू"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "रेस्तरां"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "ई-मेल"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "मेल"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "अंतिम नाम"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "टेक्स्ट क्षेत्र"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "मल्टीलाइन पाठ"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "ईमेल"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "इसके बारे में"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "संपर्क"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "गैलरी"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "फ़ोटो"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "रात"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "एनीमेटेड"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "कोड"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "बटन"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "कार्रवाई के लिए कॉल करें"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "पाठ"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "पैराग्राफ़"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "आइकन"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "क्लायंट्स"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "प्रमाण"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "विवरण"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "पता"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "मैप"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "छवि"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "वीडियो"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "पता"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "लैंडिंग"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "तुलना करें"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "पंक्तियां"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "स्तंभ"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "लेआउट"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "सुविधाएं"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "सेपरेटर"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "सामाजिक"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "लिंक"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "प्रदर्शन खुला"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "एकॉर्डियन आइटम जोड़ें"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "एकॉर्डियन"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "पाठ लिखें..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "शीर्षक लिखें..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "अलर्ट"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "लेखक"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "बटन"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "ट्वीट करने के लिए क्लिक करें"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "डायनमिक HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "सुविधा"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "सुविधाएं"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "खाद्य पदार्थ"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "भोजन और पेय"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "ईमेल"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "नाम"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "संदेश"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "फ़ॉर्म"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "कैरोसल"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "मिस्त्री"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "स्टैक किया गया"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "हीरो"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "हाइलाइट"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "आइकन"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "लोगो और बैज"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "मैप"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "मीडिया कार्ड"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "कैरोसल"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "मूल्य निर्धारण तालिका"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "मूल्य निर्धारण तालिका आइटम"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "कॉलम"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "पंक्ति"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "सेवाएं"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "सेवा"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "शेप डिवाइडर"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "साझा करें"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "सामाजिक प्रोफ़ाइल"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "जानकारी"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "सफल"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "चेतावनी"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "त्रुटि"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "डॉट"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "लाइन"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "पूर्ण-चौड़ाई"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "ग्रिड"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "सूची"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "डिफ़ॉल्ट"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "लेयर्स"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "आउटलाइन किया गया"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "फ़िल्ड"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "स्टैक किया गया"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "क्षैतिज रूप से दोहराएं"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "वेवी"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "हिल्स"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "वेव्स"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "एंगल्ड"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "स्लोप्ड"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "राउंडेड"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "ट्राएंगल"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "पॉइंटेड"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "मास्क"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "आइकन"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "पाठ"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "आइकन और पाठ"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "सर्कुलर"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "नीचे बायां"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "शीर्ष बायां"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "अवतार के रूप में जोड़ने के लिए छोड़ें"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "लेखक"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3219,33 @@ msgstr "फ़ीचर कंटेंट जोड़ें..."
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "यह ऐसी फ़ीचर ब्लॉक है जिसका उपयोग आप सुविधाओं को हाइलाइट करने के लिए कर सकते हैं."
+msgstr ""
+"यह ऐसी फ़ीचर ब्लॉक है जिसका उपयोग आप सुविधाओं को हाइलाइट करने के लिए कर सकते हैं."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "हीरो शीर्षक जोड़ें..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "हीरो शीर्षक जोड़ें..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"ऐसी हीरो सामग्री जोड़ें, जो आमतौर पर कार्रवाई के लिए कॉल करें या दो के साथ पेज का "
+"परिचयात्मक क्षेत्र है."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "ऐसी हीरो सामग्री जोड़ें, जो आमतौर पर कार्रवाई के लिए कॉल करें या दो के साथ पेज का परिचयात्मक क्षेत्र है."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "प्राथमिक कार्रवाई जोड़ें..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "द्धितीयक कार्रवाई जोड़ें..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3264,125 @@ msgstr "सामग्री जोड़ें..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "कार्ड छवि के साथ साथ जाने के लिए वर्णनात्मक प्रतिलिपि के साथ इस पाठ को बदलें. फिर इस कार्ड में और ब्लॉक जोड़ें, जैसे बटन, सूची या छवियां."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"कार्ड छवि के साथ साथ जाने के लिए वर्णनात्मक प्रतिलिपि के साथ इस पाठ को बदलें. फिर इस "
+"कार्ड में और ब्लॉक जोड़ें, जैसे बटन, सूची या छवियां."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "शीर्षक लिखें..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "वर्णन लिखें..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "सामान्य"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "बटन सेटिंग्स"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "सीमा-शुल्क"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "मोबाइल पर स्टैक"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "डायनमिक HR सेटिंग्स"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "कोई नहीं"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "कोई नहीं"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "छोटा"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "बड़ा"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "अधिक बड़ा"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "कोई नहीं"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "छोटा"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "बड़ा"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,8 +3901,11 @@ msgstr "संगीत माइक्रोफ़ोन गाने कला
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "माइक्रोफ़ोन पॉडकास्ट कंप्यूटर डिवाइस संगीत माइक्रोफ़ोन गीत कलाकार रचनात्मक मीडिया ऑडियो"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"माइक्रोफ़ोन पॉडकास्ट कंप्यूटर डिवाइस संगीत माइक्रोफ़ोन गीत कलाकार रचनात्मक मीडिया ऑडियो"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3929,12 @@ msgstr "फ़िल्म वीडियोग्राफी निर्द�
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "वीडियो वीडियोग्राफी निर्देशक रचनात्मक मीडिया रचनात्मक कैमरा फ़ोटोग्राफर फ़ोटोग्राफी अपर्चर"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"वीडियो वीडियोग्राफी निर्देशक रचनात्मक मीडिया रचनात्मक कैमरा फ़ोटोग्राफर फ़ोटोग्राफी "
+"अपर्चर"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3951,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "पैलेट डिज़ाइन रंग कलाकार रचनात्मक मीडिया पेंट पेंटब्रश"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "मानक"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "सिल्वर"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "रेट्रो"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "अंधेरा"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "रात"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "बैंगनी"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "सर्कुलर"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "शैडो"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "डिफ़ॉल्ट"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "कोई नहीं"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "चेकबॉक्स"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "मेनू शीर्षक..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "छोटा"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "बड़ा"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "अधिक बड़ा"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "ऑटो"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "कवर"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "शामिल"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "शीर्ष बायां"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "शीर्ष केंद्र"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "शीर्ष दायां"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "केंद्र बायां"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "केंद्र केंद्र"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "केंद्र दायां"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "नीचे बायां"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "नीचे केंद्र"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "नीचे दायां"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "कोई दोहराव नहीं"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "दोहराएं"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "क्षैतिज रूप से दोहराएं"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "लंबवत रूप से दोहराएं"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "लिंक Rel"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "अंधेरा"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "प्रकाश"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "कोई नहीं"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "छवि"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "पिक्सेल"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "प्रतिशत"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "मूल"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "ग्रेस्केल"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "मीडिया फ़ाइल"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "सैचुरेशन"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "विंटेज फ़िल्टर"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "विंटेज फ़िल्टर"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "बड़े अक्षरों में करना"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "सामान्य"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "बोल्ड"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "डिफ़ॉल्ट"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "बड़ा अक्षर"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "छोटा अक्षर"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4299,14 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlock, WordPress गुटेनबर्ग ब्लॉक संपादक के लिए व्यावसायिक <strong>पेज निर्माण सामग्री ब्लॉक</strong> का सूइट है. हमारे ब्लॉक का पूरा उद्देश्य पेज मेकर्स को ऐसी सुविधाएं देना है, जिससे वे WordPress में बहुत ही शानदार पेज बना सकें."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlock, WordPress गुटेनबर्ग ब्लॉक संपादक के लिए व्यावसायिक <strong>पेज निर्माण "
+"सामग्री ब्लॉक</strong> का सूइट है. हमारे ब्लॉक का पूरा उद्देश्य पेज मेकर्स को ऐसी सुविधाएं "
+"देना है, जिससे वे WordPress में बहुत ही शानदार पेज बना सकें."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4316,167 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "धोखाधड़ी, हां??"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "एक समीक्षा लिखें"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s वर्ष"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "वर्ष"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s सप्ताह"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "सप्ताह में"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s दिन"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "दिन में"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s घंटें"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "एक घंटे"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s मिनट"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "मिनट"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s सेकंड्स"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "सेकंड में"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPress प्लगइन"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "क्या आप %s मज़े कर रहे हैं?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "आप अभी %2$s के लिए %1$s का उपयोग कर रहे हैं. क्या आप समीक्षा लिखकर हमें यह बताना नहीं चाहेंगे कि आपका क्या विचार हैं? हम वास्तव में इसकी सराहना करेंगे!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "एक समीक्षा लिखें"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"आप अभी %2$s के लिए %1$s का उपयोग कर रहे हैं. क्या आप समीक्षा लिखकर हमें यह बताना नहीं "
+"चाहेंगे कि आपका क्या विचार हैं? हम वास्तव में इसकी सराहना करेंगे!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "नहीं धन्यवाद / मेरे पास पहले से है"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "CoBlocks चुनने के लिए धन्यवाद, नए WordPress ब्लॉक एडिटर के लिए प्रमुख पेज बिल्डर."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"CoBlocks चुनने के लिए धन्यवाद, नए WordPress ब्लॉक एडिटर के लिए प्रमुख पेज बिल्डर."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "आपन अभीे WordPress संपादक में बहुत सारे उपयोगी ब्लॉक और नया पेज बिल्डर टूलकिट जोड़ा है. CoBlock आपको खेल परिवर्तन वाली सुविधाओं का सेट देता है: %1$s दस ब्लॉक%2$s, %1$s पेज बिल्डर अनुभव %2$s और%1$sकस्टम टाइपोग्राफी नियंत्रण%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"आपन अभीे WordPress संपादक में बहुत सारे उपयोगी ब्लॉक और नया पेज बिल्डर टूलकिट जोड़ा है. "
+"CoBlock आपको खेल परिवर्तन वाली सुविधाओं का सेट देता है: %1$s दस ब्लॉक%2$s, %1$s पेज "
+"बिल्डर अनुभव %2$s और%1$sकस्टम टाइपोग्राफी नियंत्रण%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "शुरू करने में आपकी सहायता के लिए यहां कुछ वीडियो दिए गए हैं:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "देखें कि %s के साथ अपना पहला पेज कैसे बना सकते हैं"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "देखें कि अपना पहला पेज कैसे बना सकते हैं"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "देखें कि पंक्ति और शेप डिवाइडर ब्लॉक का उपयोग कैसे करें"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "मीडिया कार्ड ब्लॉक का उपयोग करने का तरीका देखें"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "आपने जो देखा वह आपको पसंद है? %1$sहमारे YouTube चैनल पर सब्सक्राइब करें%2$s और नए वीडियो ट्यूटोरियल जारी होने पर हम आपको बताएंगे."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"आपने जो देखा वह आपको पसंद है? %1$sहमारे YouTube चैनल पर सब्सक्राइब करें%2$s और नए "
+"वीडियो ट्यूटोरियल जारी होने पर हम आपको बताएंगे."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "यदि आपके कोई प्रश्न या प्रतिक्रिया है, तो हमें %1$sTwitter%4$s या हमारे %2$sFacebook समूह %4$s पर बताएं. इसके अलावा, अगर आप CoBlock में नए और आगामी समय के साथ रहना चाहते हैं, तो %3$sहमारे न्यूज़लेटर को सब्सक्राइब करें%4$s."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"यदि आपके कोई प्रश्न या प्रतिक्रिया है, तो हमें %1$sTwitter%4$s या हमारे %2$sFacebook "
+"समूह %4$s पर बताएं. इसके अलावा, अगर आप CoBlock में नए और आगामी समय के साथ रहना "
+"चाहते हैं, तो %3$sहमारे न्यूज़लेटर को सब्सक्राइब करें%4$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "आनंद लें!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "यहाँ CoBlocks के साथ शुरू करें:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4490,27 @@ msgstr "फ़ॉर्म स्पैम सुरक्षा के लिए G
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "फ़ॉर्म स्पैम सुरक्षा के लिए Google reCaptcha गुप्त कुंजी"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "नाम"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "पहले"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "अंतिम"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "संदेश"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "सबमिट करें"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "आपका संदेश भेज दिया गया था:"
 
@@ -3490,3 +4525,85 @@ msgstr "Linkedin पर साझा करें"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "अलर्ट प्रकार"
+
+#~ msgid "Edit image"
+#~ msgstr "छवि संपादित करें"
+
+#~ msgid "Remove image"
+#~ msgstr "छवि निकालें"
+
+#~ msgid "Heading..."
+#~ msgstr "शीर्षक..."
+
+#~ msgid "Author Name"
+#~ msgstr "लेखक का नाम"
+
+#~ msgid "Write biography..."
+#~ msgstr "बायोग्राफ़ी लिखें..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "लेखक की बायोग्राफ़ी जोड़ें"
+
+#~ msgid "%s Settings"
+#~ msgstr "%s सेटिंग्स"
+
+#~ msgid "Caption Color"
+#~ msgstr "कैप्शन का रंग"
+
+#~ msgid "Highlight text."
+#~ msgstr "हाइलाइट"
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s तालिकाएं"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "मूल्य निर्धारण तालिका सेटिंग्स"
+
+#~ msgid "Tables"
+#~ msgstr "तालिकाएं"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "मूल्य निर्धारण तालिका ब्लॉक के भीतर रखा गया कॉलम."
+
+#~ msgid "Sepia"
+#~ msgstr "गहरा काला रंग"
+
+#~ msgid "Dim"
+#~ msgstr "धूंधला"
+
+#~ msgid "Vintage"
+#~ msgstr "विंटेज"
+
+#~ msgid "Select Orientation"
+#~ msgstr "अभिविन्यास चुनें"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "इस ब्लॉक पर शीर्ष मार्जिन हटा दिया जाता है."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "इस ब्लॉक के शीर्ष पर लागू किसी भी मार्जिन को निकालने के लिए टॉगल करें."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "इस ब्लॉक पर निचली मार्जिन हटा दी जाती है."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "इस ब्लॉक के नीचे लागू किसी भी मार्जिन को निकालने के लिए टॉगल करें."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "प्राथमिक कार्रवाई जोड़ें..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "द्धितीयक कार्रवाई जोड़ें..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "सामान्य"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "यहाँ CoBlocks के साथ शुरू करें:"

--- a/languages/coblocks-id_ID.po
+++ b/languages/coblocks-id_ID.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Tampilkan dalam keadaan terbuka"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Tambahkan judul accordion..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Item Accordion"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Tambahkan item accordion yang bisa diciutkan ke accordion."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "tab"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "FAQ"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "Alihkan untuk mengatur item accordion ini agar dibuka secara default."
 msgid "Accordion Item Settings"
 msgstr "Pengaturan Item Accordion"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Tampilkan dalam Keadaan Terbuka"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Pengaturan Warna"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Warna Latar Belakang"
@@ -103,14 +63,6 @@ msgstr "Warna Latar Belakang"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Warna Teks Judul"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Tambahkan Item Accordion"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Accordion"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +78,82 @@ msgstr "Dukungan Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Tambahkan dukungan untuk Internet Explorer dengan memuat polyfill JavaScript."
+msgstr ""
+"Tambahkan dukungan untuk Internet Explorer dengan memuat polyfill JavaScript."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Mendukung Internet Explorer dengan memuat polyfill JavaScript di halaman ini."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Mendukung Internet Explorer dengan memuat polyfill JavaScript di halaman ini."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Peringatan"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Kesalahan"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Jenis Peringatan"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Default"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Info"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Berhasil"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Tulis judul..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Tulis teks..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Peringatan"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Berikan pesan umpan balik kontekstual."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "pemberitahuan"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "pesan"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Warna Teks"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Edit gambar"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Edit galeri"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Hapus gambar"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Tulis keterangan..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Letakkan untuk ditambahkan sebagai avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Judul..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Nama Penulis"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Tulis biografi..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Pengaturan Formulir"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Penulis"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Minta pengunjung untuk bertindak dengan beberapa tombol, secara berdampingan."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Tambahkan biografi penulis."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografi"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profil"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Tombol"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Minta pengunjung untuk bertindak dengan beberapa tombol, secara berdampingan."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "tautan"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Pengaturan Tombol"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Tumpuk di perangkat seluler"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +171,25 @@ msgstr "Nama Pengguna Twitter"
 msgid "Username"
 msgstr "Nama pengguna"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Tambahkan tombol..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Tambahkan harga untuk di-tweet..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Klik untuk Mentweet"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Tambahkan harga untuk di-tweet pembaca melalui Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "bagikan"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +197,18 @@ msgid "Text Settings"
 msgstr "Pengaturan Teks"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Warna Tombol"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "HR Dinamis"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Menambahkan pengatur jarak yang bisa disesuaikan antar blok lain."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "pengatur jarak"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Pengaturan HR Dinamis"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Tinggi dalam piksel"
 
@@ -347,17 +220,12 @@ msgstr "Ketinggian untuk elemen pemisah dinamis dalam piksel."
 msgid "Color"
 msgstr "Warna"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Tambahkan sebagai latar belakang"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Fitur"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "Satu kolom anak dalam blok fitur orang tua."
 
@@ -366,73 +234,55 @@ msgid "Feature Settings"
 msgstr "Pengaturan Fitur"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Padding"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Fitur"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Tambahkan hingga tiga kolom catatan kecil untuk produk atau layanan Anda."
+msgstr ""
+"Tambahkan hingga tiga kolom catatan kecil untuk produk atau layanan Anda."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "layanan"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Margin"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Tepian"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Jarak antar masing-masing kolom."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Kecil"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Medium"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +292,8 @@ msgstr "Besar"
 msgid "Features Settings"
 msgstr "Pengaturan Fitur"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Kolom"
 
@@ -455,76 +305,72 @@ msgstr "Tambah Bagian Menu"
 msgid "Menu title..."
 msgstr "Judul menu..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Grid"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Daftar"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Letakkan gambar untuk menggantikan"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Hapus Gambar"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Tambah judul..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Pedas"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Pedas"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetarian"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Bebas Gluten"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescatarian"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Vegan"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Tambahkan deskripsi..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0,00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Item Makanan"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Item makanan dan minuman dalam blok Makanan & Minuman."
 
@@ -560,62 +406,46 @@ msgstr "Alihkan untuk menampilkan harga untuk item ini."
 msgid "Item Attributes"
 msgstr "Atribut Item"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Lebih Pedas"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Pengaturan Gambar"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Teks Alt (Teks Alternatif)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Deskripsikan tujuan gambar"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Biarkan kosong jika gambar hanyalah pemanis."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Titik Fokus"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Makanan & Minuman"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Tampilkan daftar menu atau harga."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restoran"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menu"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Gaya"
@@ -648,134 +478,86 @@ msgstr "Menampilkan harga masing-masing item"
 msgid "Toggle to show the price of each item."
 msgstr "Alihkan untuk menampilkan harga masing-masing item."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Email"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "email"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "email"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Bidang alamat email."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Pesan"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Area teks"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Teks multibaris"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Kotak teks untuk tanggapan yang panjang."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "‌‌%s bukan alamat email yang valid."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "‌‌%s dan %s bukan alamat email yang valid."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "‌‌%s bukan alamat email yang valid."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Alamat email"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Perihal"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Pengaturan Formulir"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "reCAPTCHA Google"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Tambahkan situs reCAPTCHA dan kunci rahasia untuk melindungi formulir Anda dari spam."
+msgstr ""
+"Tambahkan situs reCAPTCHA dan kunci rahasia untuk melindungi formulir Anda "
+"dari spam."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Buat kunci"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Kunci saya"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Dapatkan bantuan"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Kunci Situs"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Kunci Rahasia"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Menyimpan"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Simpan"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Hapus"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Pertama"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Terakhir"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Nama"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Bidang teks untuk nama."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Bidang alamat email."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Tambahkan label…"
 
@@ -783,41 +565,38 @@ msgstr "Tambahkan label…"
 msgid "Required"
 msgstr "Wajib Diisi"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Pengaturan Bidang Nama"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Nama Belakang"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Menampilkan bidang nama depan dan belakang."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Alihkan untuk menambahkan bidang nama belakang."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Formulir"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Bidang teks untuk nama."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Kotak teks untuk tanggapan yang panjang."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Tambahkan formulir sederhana ke halaman Anda."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "email"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "tentang"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "kontak"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Perihal"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +606,218 @@ msgstr "Tambahkan teks…"
 msgid "Button Text Color"
 msgstr "Warna Teks Tombol"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Edit galeri"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Carousel"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "gambar %1$d dari %2$d di galeri"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Tulis keterangan..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Carousel"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Tampilkan beberapa gambar dalam galeri carousel yang menarik."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galeri"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "foto"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Pengaturan %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Tinggi Baris"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Menampilkan panah navigasi titik."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Alihkan untuk menampilkan keterangan media."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Pengaturan Warna"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Ukuran"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Pojok Bulat"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Warna Keterangan"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Terapkan"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Masonry"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Tulis deskripsi..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Tampilkan beberapa gambar di galeri masonry yang tertata."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Tampilkan beberapa gambar dalam galeri carousel yang menarik."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Ukuran Kolom"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Pengaturan Gambar"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Tambahkan pojok bulat ke item galeri."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Bayangan"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Keterangan"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Gaya Keterangan"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Menampilkan keterangan untuk setiap item media."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Alihkan untuk menampilkan keterangan media."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Masonry"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Tampilkan beberapa gambar di galeri masonry yang tertata."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Alihkan untuk mengaktifkan opsi kontrol peta."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Pengaturan Peta"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Ukuran Kolom"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Tambahkan pojok bulat ke item galeri."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Terang"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Bertumpuk"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Tampilkan beberapa gambar dalam galeri bertumpuk kolom tunggal."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Gambar dengan Lebar Penuh"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Gambar dengan Lebar Penuh"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Bayangan Kotak"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Gambar dengan lebar penuh diaktifkan."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Alihkan untuk mengisi area galeri yang tersedia dengan gambar lebar penuh."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Alihkan untuk mengisi area galeri yang tersedia dengan gambar lebar penuh."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Pengaturan Item"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Gambar dengan Lebar Penuh"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Gambar dengan Lebar Penuh"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Hapus GIF"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "GIF ini memiliki atribut alt kosong"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Cari GIF sempurna di Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Cari GIF"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Pilih GIF, apa saja."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animasi"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +843,11 @@ msgstr "File GitHub"
 msgid "File"
 msgstr "File"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Lihat Gist ini di GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL Gist"
 
@@ -1024,12 +860,9 @@ msgid "Loading Gist"
 msgstr "Memuat Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Sematkan Gist GitHub dengan menambahkan tautan Gist."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "kode"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +885,158 @@ msgid "Gist Meta"
 msgstr "Meta Gist"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Ubah tata letak"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Tambahkan latar belakang ke %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Area pendahuluan halaman yang disertai sedikit teks dan seruan bertindak."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Area pendahuluan halaman yang disertai sedikit teks dan seruan bertindak."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "tombol"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "seruan bertindak"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Lebar konten dalam piksel"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Pengaturan Hero"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Ruang di dalam kontainer."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Kiri Atas"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Tengah Atas"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Kanan Atas"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Kiri Tengah"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Tengah Tengah"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Kanan Tengah"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Kiri Bawah"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Tengah Bawah"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Kanan Bawah"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Tambahkan teks yang disorot..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Sorot"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Teks sorotan."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "teks"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "paragraf"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Ikon"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Tambahkan simbol grafik bergaya untuk mengomunikasikan banyak hal."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "ikon"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Besar"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Tambahkan simbol grafik bergaya untuk mengomunikasikan banyak hal."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Pengaturan Ikon"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Nonaktifkan pengaturan %s lanjutan"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Reset"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Ukuran %s kustom"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Pengaturan %s lanjutan"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Kustom"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Lanjutan"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Radius"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Pencarian Ikon"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Tidak ditemukan hasil."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "‌‌Pengaturan Tautan"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL Tautan"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Hubungan Tautan"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Membuka di Tab Baru"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Buka di Tab Baru"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Warna Ikon"
 
@@ -1261,30 +1045,18 @@ msgid "Edit logos"
 msgstr "Edit logo"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logo & Lencana"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr "Seret gambar, unggah gambar baru atau pilih file dari pustaka Anda."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Tambahkan logo, lencana, atau sertifikasi untuk membangun kredibilitas."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "klien"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "bukti"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "testimoni"
+msgstr ""
+"Tambahkan logo, lencana, atau sertifikasi untuk membangun kredibilitas."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1078,140 @@ msgstr "Edit Lokasi"
 msgid "Map style"
 msgstr "Gaya peta"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Kunci API tidak valid, atau terlalu banyak permintaan"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Peta Google"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "Masukkan lokasi atau alamat untuk meletakkan pin di peta Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Cari tempat atau alamat…"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Terapkan"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Peta"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Tambahkan alamat dan letakkan pin di peta Google."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "alamat"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "peta"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Pilih Gaya Peta"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Pengaturan Peta"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Tingkat Zoom"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Tinggi peta dalam piksel"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Tingkat Zoom"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Ukuran Penanda"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Opsi kontrol halus diaktifkan."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Alihkan untuk mengaktifkan opsi kontrol peta."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Kontrol Peta"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Jenis Peta"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "Beralih antara tampilan peta Standar dan satelit diaktifkan."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "Alihkan untuk mengaktifkan peralihan antara peta standar dan satelit."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Kontrol Zoom"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Menampilkan kontrol zoom peta."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Alihkan untuk mengaktifkan zoom perbesar dan perkecil pada peta dengan kontrol zoom."
+msgstr ""
+"Alihkan untuk mengaktifkan zoom perbesar dan perkecil pada peta dengan "
+"kontrol zoom."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Tampilan Jalan"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Menampilkan kontrol peta tampilan jalan."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "Alihkan untuk menampilkan kontrol tampilan jalan di kanan bawah."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Pengalihan Layar Penuh"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Menampilkan kontrol peta layar penuh."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Alihkan untuk menampilkan kontrol peta layar penuh."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Kunci Api Peta Google"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Tambahkan kunci API Peta Google Anda. Memperbarui kunci API ini akan mengatur semua peta Anda untuk menggunakan kunci baru."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Tambahkan kunci API Peta Google Anda. Memperbarui kunci API ini akan "
+"mengatur semua peta Anda untuk menggunakan kunci baru."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Ambil kunci Anda"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Perlu bantuan?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Masukkan Kunci API Google..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Disimpan"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standar"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Silver"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Gelap"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Malam"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Aubergine"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1221,9 @@ msgstr "Media di kanan"
 msgid "Media on left"
 msgstr "Media di kiri"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Kartu Media"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Tambahkan gambar atau video dengan kartu offset secara berdampingan."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "gambar"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1237,18 @@ msgstr "Menampilkan bayangan kartu."
 msgid "Toggle to add a card shadow."
 msgstr "Alihkan untuk menambahkan bayangan kartu."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s Bayangan"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Menampilkan bayangan %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Alihkan untuk menambahkan bayangan %s"
 
@@ -1545,40 +1272,171 @@ msgstr "Letakkan untuk mengganti media"
 msgid "Edit media"
 msgstr "Edit media"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Tabel %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL Gist"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Paket %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Carousel"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL Gist"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Pengaturan Warna"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Menampilkan harga untuk item ini."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Alihkan untuk menampilkan meta data Gist."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Menampilkan tombol seruan bertindak."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Alihkan untuk menampilkan meta data Gist."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Pengaturan Fitur"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Media di kiri"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Media di kanan"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Ukuran Kolom"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Pengaturan Gist"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Tabel Harga"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Tabel Harga"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Tabel Harga"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Tabel Harga"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Tambahkan tabel harga."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "tujuan"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Paket %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "perbandingan"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Pengaturan Tabel Harga"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabel"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1454,171 @@ msgstr "Paket A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Item Tabel Harga"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Kolom yang ditempatkan di dalam blok tabel harga."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Tambahkan latar belakang ke %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Kolom"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Baris anak."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Lebar"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Pengaturan Kolom"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Ruang di sekitar kontainer."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Lebar"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Ubah tata letak"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "satu"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "dua"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "tiga"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "empat"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Tambahkan latar belakang ke %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Satu Kolom"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Dua Kolom"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Tiga Kolom"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Empat Kolom"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Tata Letak Baris"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Baris"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Sekarang pilih tata letak untuk baris %s kolom ini."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Pilih jumlah kolom untuk baris ini."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Pilih Kolom Baris"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Pilih Tata Letak Baris"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Kembali ke Kolom"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Tambahkan wrapper terstruktur untuk blok kolom, lalu tambahkan blok konten yang Anda inginkan ke kolom."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Tambahkan wrapper terstruktur untuk blok kolom, lalu tambahkan blok konten "
+"yang Anda inginkan ke kolom."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "baris"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "kolom"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "tata letak"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Tata letak"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Pengaturan Baris"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Tidak Ada"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1628,9 @@ msgstr "Persegi"
 msgid "Circle"
 msgstr "Lingkaran"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Layanan"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Tambahkan hingga empat kolom layanan untuk ditampilkan."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "fitur"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1652,7 @@ msgstr "Menampilkan tombol seruan bertindak."
 msgid "Toggle to show call to action buttons."
 msgstr "Alihkan untuk menampilkan tombol seruan bertindak."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Layanan"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Item layanan tunggal dalam blok layanan."
 
@@ -1785,264 +1673,232 @@ msgid "Toggle to show a call to action button."
 msgstr "Alihkan untuk menampilkan tombol seruan bertindak."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Balik secara horizontal"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Balik secara vertikal"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Pemisah Bentuk"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Tambahkan pemisah bentuk untuk membedakan bagian halaman secara visual."
+msgstr ""
+"Tambahkan pemisah bentuk untuk membedakan bagian halaman secara visual."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "pemisah"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Warna Bentuk"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Pengaturan Pemisah"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Tinggi Bentuk dalam piksel"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Tinggi Latar Belakang dalam piksel"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Orientasi"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Warna Bentuk"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Bagikan di Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Bagikan di Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Bagikan di Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Bagikan di Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Bagikan di LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Bagikan melalui Email"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Bagikan di Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Bagikan di Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Bagikan di Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Bagikan"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "sosial"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Tambahkan tautan berbagi ke media sosial untuk membantu Anda mendapatkan suka dan konten Anda bisa dibagikan."
+msgstr ""
+"Tambahkan tautan berbagi ke media sosial untuk membantu Anda mendapatkan "
+"suka dan konten Anda bisa dibagikan."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Warna Media Sosial"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Ukuran Ikon"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Ukuran Lingkaran"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Ukuran Tombol"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Ikon"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Warna tombol bagikan diaktifkan."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Alihkan untuk menggunakan warna resmi dari masing-masing platform media sosial."
+msgstr ""
+"Alihkan untuk menggunakan warna resmi dari masing-masing platform media "
+"sosial."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Warna Media Sosial"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Tambahkan Profil Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Tambahkan Profil Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Tambahkan Profil Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Tambahkan Profil Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Tambahkan Profil LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Tambahkan Profil YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Tambahkan Profil Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Tambahkan Profil Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Profil Media Sosial"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "tautan"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Tampilkan tautan ke profil media sosial."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Tautan Profil"
 
@@ -2057,18 +1913,6 @@ msgstr "Hapus Latar Belakang"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Latar belakang"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Oto"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Sampul"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Berisi"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1970,6 @@ msgstr "Hapus latar belakang"
 msgid "Remove "
 msgstr "Hapus "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Tanpa Pengulangan"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Ulangi Secara Horizontal"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Ulangi Secara Vertikal"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Pindah Gambar ke Belakang"
@@ -2150,17 +1982,14 @@ msgstr "Pindah Gambar ke Depan"
 msgid "Link To"
 msgstr "Tautkan ke"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Galeri %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Unggah gambar"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Terang"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2003,110 @@ msgstr "Halaman Lampiran"
 msgid "Custom URL"
 msgstr "URL Kustom"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Piksel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Orientasi"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Persentase"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Reset"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Pilih Unit"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s Unit"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Nonaktifkan pengaturan %s lanjutan"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s Atas"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s Kanan"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s Bawah"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s Kiri"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Batalkan Sinkronisasi"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Sinkronisasi"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Sinkronisasi Unit"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Atas"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Kanan"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Bawah"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Kiri"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Pengaturan %s lanjutan"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Lanjutan"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Default"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Tata letak"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2125,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Alihkan untuk mengaktifkan mode layar penuh."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Judul %d"
@@ -2263,43 +2134,16 @@ msgstr "Judul %d"
 msgid "Custom color picker"
 msgstr "Pemilih warna kustom"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Asli"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Hitam Putih"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sepia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Saturasi"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Redup"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Terapkan Filter"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Pilih Orientasi"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Tinggi"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Ponsel %s"
@@ -2333,7 +2177,8 @@ msgid "Five Seconds"
 msgstr "Lima Detik"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Enam Detik"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2197,22 @@ msgstr "Sembilan Detik"
 msgid "Ten Seconds"
 msgstr "Sepuluh Detik"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Navigasi Panah"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Navigasi Titik"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "detik"
@@ -2361,22 +2222,27 @@ msgid "second"
 msgstr "detik"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Maju setelah %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Otomatis maju ke slide berikutnya."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Menyeret dan menggeser diaktifkan di perangkat desktop dan seluler."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Alihkan untuk mengaktifkan fungsi seret di perangkat desktop dan seluler."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Alihkan untuk mengaktifkan fungsi seret di perangkat desktop dan seluler."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2253,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Alihkan untuk menampilkan panah navigasi slide."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Menampilkan panah navigasi titik."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Alihkan untuk menampilkan navigasi titik."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Ruang di dalam kontainer."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Alihkan untuk mensenyapkan video."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Alihkan untuk mengulang video."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Pengaturan Slider"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Putar otomatis"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Kecepatan Transisi"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Bisa Diseret"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Navigasi Panah"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Navigasi Titik"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Kapitalisasi"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2340,6 @@ msgstr "Tanpa Spasi Bawah"
 msgid "Change typography"
 msgstr "Ubah tipografi"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Tebal"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Huruf Besar"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Huruf Kecil"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Tumpuk di Perangkat Seluler"
@@ -2481,31 +2350,37 @@ msgstr "Kecepatan respons diaktifkan."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Alihkan untuk saling menumpuk elemen di atasnya pada viewport yang lebih kecil."
+msgstr ""
+"Alihkan untuk saling menumpuk elemen di atasnya pada viewport yang lebih "
+"kecil."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Hapus Spasi Atas"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Margin atas dihapus di blok ini."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Alihkan untuk menambahkan bayangan kartu."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Alihkan untuk menghapus margin yang diterapkan ke bagian atas blok ini."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Alihkan untuk menampilkan navigasi titik."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Hapus Spasi Bawah"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Margin bawah dihapus di blok ini."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Alihkan untuk menambahkan bayangan kartu."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Alihkan untuk menghapus margin yang diterapkan ke bagian bawah blok ini."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Alihkan untuk menampilkan navigasi titik."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2394,14 @@ msgstr "Menampilkan sebagai lebar penuh."
 msgid "Toggle to display button as full width."
 msgstr "Alihkan untuk menampilkan tombol sebagai lebar penuh."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Melingkar"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Pengaturan Hero"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Bayangan"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Kotak Centang"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Huruf Besar"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2427,793 @@ msgstr "Blok ini ditambahkan ke halaman dan saat ini tidak bisa dinonaktifkan"
 msgid "Disable all"
 msgstr "Nonaktifkan semua"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Tidak ditemukan blok \"%s\"."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Galeri %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Tampilkan dalam keadaan terbuka"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Tambahkan judul accordion..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Item Accordion"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "tab"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "FAQ"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "pemberitahuan"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "pesan"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografi"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "tautan"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "bagikan"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "pengatur jarak"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "layanan"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menu"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restoran"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "email"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "email"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Nama Belakang"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Area teks"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Teks multibaris"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "email"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "tentang"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "kontak"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galeri"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "foto"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Malam"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animasi"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "kode"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "tombol"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "seruan bertindak"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "teks"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "paragraf"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "ikon"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "klien"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "bukti"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "testimoni"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "alamat"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "peta"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "gambar"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "alamat"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "tujuan"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "perbandingan"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "baris"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "kolom"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "tata letak"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "fitur"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "pemisah"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "sosial"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "tautan"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Tampilkan dalam Keadaan Terbuka"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Tambahkan Item Accordion"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Accordion"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Tulis teks..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Tulis judul..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Peringatan"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Penulis"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Tombol"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Klik untuk Mentweet"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "HR Dinamis"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Fitur"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Fitur"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Item Makanan"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Makanan & Minuman"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Nama"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Pesan"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Formulir"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Carousel"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Masonry"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Bertumpuk"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL Gist"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Sorot"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Ikon"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logo & Lencana"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Peta"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Kartu Media"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Carousel"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Tabel Harga"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Item Tabel Harga"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Kolom"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Baris"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Layanan"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Layanan"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Pemisah Bentuk"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Bagikan"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Profil Media Sosial"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Info"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Berhasil"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Peringatan"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Kesalahan"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Titik"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Baris"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Lebar Penuh"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Grid"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Daftar"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Default"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Lapisan"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Berkerangka"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Berisi"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Bertumpuk"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Ulangi Secara Horizontal"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Bergelombang"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Perbukitan"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Gelombang"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Bersudut"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Miring"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Bulat"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Segi tiga"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Lancip"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Topeng"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Ikon"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Teks"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Ikon & Teks"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Melingkar"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Kiri Bawah"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Kiri Atas"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Letakkan untuk ditambahkan sebagai avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Penulis"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3235,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "Ini adalah blok fitur yang bisa Anda gunakan untuk menyorot fitur."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "Tambahkan judul hero..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Tambahkan konten hero, yang umumnya adalah area pendahuluan halaman yang disertai satu atau beberapa seruan bertindak."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Tambahkan konten hero, yang umumnya adalah area pendahuluan halaman yang "
+"disertai satu atau beberapa seruan bertindak."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Tambahkan seruan bertindak utama..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Tambahkan seruan bertindak sekunder..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3277,126 @@ msgstr "Tambah konten..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Ganti teks ini dengan salinan deskripsi untuk disertakan dengan gambar kartu. Lalu tambahkan lebih banyak blok ke kartu ini, seperti tombol, daftar, atau gambar."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Ganti teks ini dengan salinan deskripsi untuk disertakan dengan gambar "
+"kartu. Lalu tambahkan lebih banyak blok ke kartu ini, seperti tombol, "
+"daftar, atau gambar."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Tulis judul..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Tulis deskripsi..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Pengaturan Tombol"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Kustom"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Tumpuk di perangkat seluler"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Pengaturan HR Dinamis"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Tidak Ada"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Tidak Ada"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Kecil"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Besar"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Sangat Besar"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Tidak Ada"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Kecil"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Besar"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,8 +3915,12 @@ msgstr "musik mikrofon lagu artis kreatif media audio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "mikrofon podcast komputer perangkat musik mikrofon lagu artis kreatif media audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"mikrofon podcast komputer perangkat musik mikrofon lagu artis kreatif media "
+"audio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3944,12 @@ msgstr "film videografi direktur produser media kreatif"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "video videografi direktur produser media kreatif kamera fotografer fotografi apertur"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"video videografi direktur produser media kreatif kamera fotografer fotografi "
+"apertur"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3966,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "palet desain warna seniman kreatif media cat kuas cat"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standar"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Silver"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Gelap"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Malam"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Aubergine"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Melingkar"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Bayangan"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Default"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Tidak Ada"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Kotak Centang"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Judul menu..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Kecil"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Besar"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Sangat Besar"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Oto"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Sampul"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Berisi"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Kiri Atas"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Tengah Atas"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Kanan Atas"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Kiri Tengah"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Tengah Tengah"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Kanan Tengah"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Kiri Bawah"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Tengah Bawah"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Kanan Bawah"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Tanpa Pengulangan"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Ulangi"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Ulangi Secara Horizontal"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Ulangi Secara Vertikal"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Hubungan Tautan"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Gelap"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Terang"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Tidak Ada"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Gambar"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Piksel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Persentase"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Asli"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Hitam Putih"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "File Media"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Saturasi"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Filter Vintage"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Filter Vintage"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Kapitalisasi"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Tebal"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Default"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Huruf Besar"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Huruf Kecil"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4314,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks adalah rangkaian <strong>blok konten untuk membangun halaman</strong> yang profesional untuk editor blok Gutenberg WordPress. Blok kami fokus untuk memberdayakan penanda dalam membangun halaman yang kaya akan konten menarik di WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks adalah rangkaian <strong>blok konten untuk membangun halaman</"
+"strong> yang profesional untuk editor blok Gutenberg WordPress. Blok kami "
+"fokus untuk memberdayakan penanda dalam membangun halaman yang kaya akan "
+"konten menarik di WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4332,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Selingkuh?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Tulis Ulasan"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s tahun"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "tahun"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s minggu"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "satu minggu"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s hari"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "hari"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s jam"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "satu jam"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s menit"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "satu menit"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s detik"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "satu detik"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Plugin %s WordPress"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Anda suka %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Anda sudah menggunakan %1$s selama %2$s sekarang. Mau memberikan ulasan untuk memberi tahu kami kesan Anda? Kami sangat menghargainya!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Tulis Ulasan"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Anda sudah menggunakan %1$s selama %2$s sekarang. Mau memberikan ulasan "
+"untuk memberi tahu kami kesan Anda? Kami sangat menghargainya!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Tidak, terima kasih/sudah memberikan ulasan"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Terima kasih telah memilih CoBlocks, pembuat halaman premier untuk editor blok WordPress yang baru."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Terima kasih telah memilih CoBlocks, pembuat halaman premier untuk editor "
+"blok WordPress yang baru."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Anda baru saja menambahkan banyak blok berguna dan toolkit pembuat halaman baru ke editor WordPress. CoBlocks menyediakan rangkaian fitur berpengaruh: %1$s puluhan blok%2$s, %1$s pengalaman pembuat halaman %2$s dan %1$s kontrol tipografi kustom%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Anda baru saja menambahkan banyak blok berguna dan toolkit pembuat halaman "
+"baru ke editor WordPress. CoBlocks menyediakan rangkaian fitur berpengaruh: "
+"%1$s puluhan blok%2$s, %1$s pengalaman pembuat halaman %2$s dan %1$s kontrol "
+"tipografi kustom%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Berikut ini beberapa video untuk membantu Anda mulai menggunakannya:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Lihat cara membuat halaman pertama Anda dengan %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Lihat cara membuat halaman pertama Anda"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Lihat cara menggunakan blok Baris dan Pemisah Bentuk"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Lihat cara menggunakan blok Kartu Media"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Suka yang Anda lihat? %1$sBerlangganan saluran YouTube kami%2$s dan kami akan memberi tahu Anda jika ada tutorial video baru yang dirilis."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Suka yang Anda lihat? %1$sBerlangganan saluran YouTube kami%2$s dan kami "
+"akan memberi tahu Anda jika ada tutorial video baru yang dirilis."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Jika ada pertanyaan atau masukan, beri tahu kami di %1$sTwitter%4$s atau %2$sgrup Facebook%4$s kami. Selain itu, %3$sberlangganan buletin kami%4$s jika Anda ingin terus mendapatkan info terkini tentang apa yang baru dan akan hadir di CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Jika ada pertanyaan atau masukan, beri tahu kami di %1$sTwitter%4$s atau "
+"%2$sgrup Facebook%4$s kami. Selain itu, %3$sberlangganan buletin kami%4$s "
+"jika Anda ingin terus mendapatkan info terkini tentang apa yang baru dan "
+"akan hadir di CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Nikmati!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Mulai gunakan CoBlocks di sini:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4509,27 @@ msgstr "Kunci situs reCaptcha Google untuk perlindungan spam formulir"
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "Kunci rahasia reCaptcha Google untuk perlindungan spam formulir"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Nama"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Pertama"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Terakhir"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Pesan"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Kirim"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Pesan Anda terkirim:"
 
@@ -3490,3 +4544,87 @@ msgstr "Bagikan di LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Jenis Peringatan"
+
+#~ msgid "Edit image"
+#~ msgstr "Edit gambar"
+
+#~ msgid "Remove image"
+#~ msgstr "Hapus gambar"
+
+#~ msgid "Heading..."
+#~ msgstr "Judul..."
+
+#~ msgid "Author Name"
+#~ msgstr "Nama Penulis"
+
+#~ msgid "Write biography..."
+#~ msgstr "Tulis biografi..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Tambahkan biografi penulis."
+
+#~ msgid "%s Settings"
+#~ msgstr "Pengaturan %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Warna Keterangan"
+
+#~ msgid "Highlight text."
+#~ msgstr "Teks sorotan."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Tabel %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Pengaturan Tabel Harga"
+
+#~ msgid "Tables"
+#~ msgstr "Tabel"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Kolom yang ditempatkan di dalam blok tabel harga."
+
+#~ msgid "Sepia"
+#~ msgstr "Sepia"
+
+#~ msgid "Dim"
+#~ msgstr "Redup"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Pilih Orientasi"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Margin atas dihapus di blok ini."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Alihkan untuk menghapus margin yang diterapkan ke bagian atas blok ini."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Margin bawah dihapus di blok ini."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Alihkan untuk menghapus margin yang diterapkan ke bagian bawah blok ini."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Tambahkan seruan bertindak utama..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Tambahkan seruan bertindak sekunder..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Mulai gunakan CoBlocks di sini:"

--- a/languages/coblocks-it_IT.po
+++ b/languages/coblocks-it_IT.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Visualizza aperto"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Aggiungi titolo menu a fisarmonica..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Elemento menu a fisarmonica"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Aggiungi elementi comprimibili ai menu a fisarmonica."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "schede"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "domande frequenti"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,40 @@ msgstr "L’elemento menu a fisarmonica è aperto per impostazione predefinita."
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Alterna l’impostazione predefinita di questo elemento menu a fisarmonica aperto."
+msgstr ""
+"Alterna l’impostazione predefinita di questo elemento menu a fisarmonica "
+"aperto."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Impostazioni elemento menu a fisarmonica"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Visualizza aperto"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Impostazioni colore"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Colore dello sfondo"
@@ -104,17 +66,11 @@ msgstr "Colore dello sfondo"
 msgid "Title Text Color"
 msgstr "Colore testo titolo"
 
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Aggiungi elemento menu a fisarmonica"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Menu a fisarmonica"
-
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
-msgstr "Organizza il contenuto all’interno degli elementi menu a fisarmonica comprimibili."
+msgstr ""
+"Organizza il contenuto all’interno degli elementi menu a fisarmonica "
+"comprimibili."
 
 #: src/blocks/accordion/inspector.js:27
 msgid "Accordion Settings"
@@ -126,143 +82,84 @@ msgstr "Supporto Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Aggiungi il supporto di Internet Explorer tramite il caricamento di un polyfill JavaScript."
+msgstr ""
+"Aggiungi il supporto di Internet Explorer tramite il caricamento di un "
+"polyfill JavaScript."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Supporto di Internet Explorer tramite il caricamento di un polyfill JavaScript in questa pagina."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Supporto di Internet Explorer tramite il caricamento di un polyfill "
+"JavaScript in questa pagina."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Avvertenza"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Errore"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Tipo di avviso"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Predefinito"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Info"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Operazione riuscita"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Scrivi titolo..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Scrivi testo..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Avviso"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Fornisci messaggi di feedback contestuali."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "avviso"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "messaggio"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Colore testo"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Modifica immagine"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Modifica galleria"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Rimuovi immagine"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Scrivi didascalia..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Rilascia per aggiungere come avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Intestazione..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Nome autore"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Scrivi biografia..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Impostazioni modulo"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Autore"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Richiedi ai visitatori di intervenire con più pulsanti, fianco a fianco."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Aggiungi una biografica dell’autore."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografia"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profilo"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Pulsanti"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Richiedi ai visitatori di intervenire con più pulsanti, fianco a fianco."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "link"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Impostazioni pulsanti"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Impila su dispositivo mobile"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +177,25 @@ msgstr "Nome utente Twitter"
 msgid "Username"
 msgstr "Nome utente"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Aggiungi pulsante..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Aggiungi un commento da tweettare..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Fai clic per tweettare"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Aggiungi un commento per i lettori da tweettare via Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "condividi"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "Twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +203,18 @@ msgid "Text Settings"
 msgstr "Impostazioni testo"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Colore pulsante"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "HR dinamico"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Aggiungi uno spaziatore ridimensionabile tra gli altri blocchi."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "spaziatore"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Impostazioni HR dinamiche"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Altezza in pixel"
 
@@ -347,92 +226,70 @@ msgstr "Altezza dell’elemento separatore dinamico in pixel."
 msgid "Color"
 msgstr "Colore"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Aggiungi come sfondo"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Caratteristica"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
-msgstr "Una singola colonna figlia all’interno di un blocco caratteristiche padre."
+msgstr ""
+"Una singola colonna figlia all’interno di un blocco caratteristiche padre."
 
 #: src/blocks/features/feature/inspector.js:68
 msgid "Feature Settings"
 msgstr "Impostazioni caratteristica"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Spaziatura interna"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Caratteristiche"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Aggiungi fino a tre colonne di piccole note per il tuo prodotto o servizio."
+msgstr ""
+"Aggiungi fino a tre colonne di piccole note per il tuo prodotto o servizio."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "servizi"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Margine"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Rilegatura"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Spazio tra ogni colonna."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Piccolo"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Medio"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +299,8 @@ msgstr "Grande"
 msgid "Features Settings"
 msgstr "Impostazioni caratteristiche"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Colonne"
 
@@ -455,78 +312,75 @@ msgstr "Aggiungi sezione menu"
 msgid "Menu title..."
 msgstr "Titolo menu..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Griglia"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Elenco"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Rilascia immagine da sostituire"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Rimuovi immagine"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Aggiungi titolo..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Speziato"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Piccante"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetariano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Senza glutine"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescetariano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Vegano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Aggiungi descrizione..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$ 0,00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Elemento cibo"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
-msgstr "Aggiungi un elemento cibo/bevanda all’interno del blocco Cibo e bevande."
+msgstr ""
+"Aggiungi un elemento cibo/bevanda all’interno del blocco Cibo e bevande."
 
 #: src/blocks/food-and-drinks/food-item/inspector.js:19
 msgid "Item Settings"
@@ -560,62 +414,46 @@ msgstr "Alterna la visualizzazione del prezzo per questo elemento."
 msgid "Item Attributes"
 msgstr "Attributi elemento"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Più speziato"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Impostazioni immagine"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Testo alternativo"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Descrivi lo scopo dell’immagine"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Lascia vuoto se l’immagine è puramente decorativa."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Punto focale"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Cibo e bevande"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Aggiungi un menu o listino prezzi."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "ristorante"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menu"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Stili"
@@ -648,134 +486,86 @@ msgstr "Visualizzazione del prezzo di ciascun elemento."
 msgid "Toggle to show the price of each item."
 msgstr "Alterna la visualizzazione del prezzo di ciascun elemento."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Email"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "email"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "posta"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Un campo di indirizzo email."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Messaggio"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Area testo"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Testo multiriga"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Una casella di testo per risposte più lunghe."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "‌‌%s non è un indirizzo email valido."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "‌‌%s e %s non sono indirizzi email validi."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "‌‌%s non sono un indirizzo email valido."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Indirizzo email"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "nome@esempio.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Oggetto"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Impostazioni modulo"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "reCAPTCHA Google"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Aggiungi il tuo sito reCAPTCHA e i tuoi codici segreti per proteggere il tuo modulo dalla posta indesiderata."
+msgstr ""
+"Aggiungi il tuo sito reCAPTCHA e i tuoi codici segreti per proteggere il tuo "
+"modulo dalla posta indesiderata."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Genera codici"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "I miei codici"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Richiedi assistenza"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Codice sito"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Codice segreto"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Salvataggio"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Salva"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Nome"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Cognome"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Nome"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Un campo di testo per i nomi."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Un campo di indirizzo email."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Aggiungi etichetta..."
 
@@ -783,41 +573,38 @@ msgstr "Aggiungi etichetta..."
 msgid "Required"
 msgstr "Obbligatorio"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Impostazioni campo nome"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Cognome"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Visualizzazione di entrambi i campi nome e cognome."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Alterna l’aggiunta di un campo cognome."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Modulo"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Un campo di testo per i nomi."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Una casella di testo per risposte più lunghe."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Aggiungi un semplice modulo alla tua pagina."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "email"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "informazioni su"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "contatto"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Oggetto"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +614,221 @@ msgstr "Aggiungi testo..."
 msgid "Button Text Color"
 msgstr "Colore testo pulsante"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Modifica galleria"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Carosello"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "immagine %1$d di %2$d in galleria"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Scrivi didascalia..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Carosello"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Visualizza più immagini in una meravigliosa galleria a carosello."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galleria"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "foto"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Impostazioni %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Altezza linea"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Visualizzazione delle frecce di navigazione a punti."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Alterna la visualizzazione delle didascalie media."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Impostazioni colore"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Dimensione"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Angoli arrotondati"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Colore didascalia"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Applica"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Muratura"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Scrivi descrizione..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Visualizza più immagini in una galleria organizzata come un’opera muraria."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Visualizza più immagini in una meravigliosa galleria a carosello."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Dimensione colonna"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Impostazioni immagine"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Aggiungi angoli arrotondati agli elementi della galleria."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Ombreggiatura"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Didascalie"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Stile didascalia"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Visualizzazione di didascalie per ciascun elemento media."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Alterna la visualizzazione delle didascalie media."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Muratura"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr ""
+"Visualizza più immagini in una galleria organizzata come un’opera muraria."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Alterna l’abilitazione delle opzioni di controllo delle mappe."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Impostazioni mappa"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Dimensione colonna"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Aggiungi angoli arrotondati agli elementi della galleria."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Chiaro"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Impilata"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
-msgstr "Visualizza più immagini in una galleria impilata in una singola colonna."
+msgstr ""
+"Visualizza più immagini in una galleria impilata in una singola colonna."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Immagini a tutta larghezza"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Immagine a tutta larghezza"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Ombreggiatura casella"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Sono abilitate le immagini a tutta larghezza."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Alterna lo riempimento della galleria disponibile con immagini a tutta larghezza."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Alterna lo riempimento della galleria disponibile con immagini a tutta "
+"larghezza."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Impostazioni elemento"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Immagini a tutta larghezza"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Immagine a tutta larghezza"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Rimuovi gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Questa gif presenta un attributo alternativo vuoto"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Cerca la gif perfetta su Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Cerca gif"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Scegli una gif, una qualsiasi."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animata"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +854,11 @@ msgstr "File GitHub"
 msgid "File"
 msgstr "File"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Visualizza questo Gist su GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL Gist"
 
@@ -1024,12 +871,9 @@ msgid "Loading Gist"
 msgstr "Caricamento Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Incorpora Gist GitHub tramite l’aggiunta del link Gist."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "codice"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +896,159 @@ msgid "Gist Meta"
 msgstr "Metadati Gist"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Cambia layout"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Aggiungi sfondo a %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Un’area introduttiva della pagina accompagnata da una piccola parte di testo "
+"e da un invito all’azione."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Un’area introduttiva della pagina accompagnata da una piccola parte di testo e da un invito all’azione."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "pulsante"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "invito all’azione"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Larghezza contenuto in pixel"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Impostazioni hero"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Spazio all’interno del contenitore."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "In alto a sinistra"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "In alto al centro"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "In alto a destra"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Centrale a sinistra"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Centrale al centro"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Centrale a destra"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "In basso a sinistra"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "In basso al centro"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "In basso a destra"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Aggiungi testo evidenziato..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Evidenzia"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Evidenzia testo."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "testo"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "paragrafo"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Icona"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Aggiungi un simbolo grafico stilizzato per comunicare qualcosa in più."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "icone"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Enorme"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Aggiungi un simbolo grafico stilizzato per comunicare qualcosa in più."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Impostazioni icona"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Disattiva impostazioni %s avanzate"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Reimposta"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Dimensione %s personalizzata"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Impostazioni %s avanzate"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Personalizzata"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Avanzate"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Raggio"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Icona Cerca"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Nessun risultato trovato."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Impostazioni link"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL link"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Link relazionale"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Apertura in una nuova scheda"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Apri in nuova scheda"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Colore icona"
 
@@ -1261,30 +1057,18 @@ msgid "Edit logos"
 msgstr "Modifica loghi"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Loghi e badge"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Trascina immagini, carica nuove immagini o seleziona file dalla libreria."
+msgstr ""
+"Trascina immagini, carica nuove immagini o seleziona file dalla libreria."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "Aggiungi loghi, badge o certificati per creare credibilità."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "clienti"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "prova"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "testimonianze"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1090,146 @@ msgstr "Modifica località"
 msgid "Map style"
 msgstr "Stile mappa"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Chiave API non valida, o troppe richieste"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Mappe di Google"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Immetti una posizione o un indirizzo per inserire un segnaposto in una mappa di Google."
+msgstr ""
+"Immetti una posizione o un indirizzo per inserire un segnaposto in una mappa "
+"di Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Cerca un luogo o un indirizzo…"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Applica"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Mappa"
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
+msgstr ""
+"Aggiungi un indirizzo e inserisci un segnaposto in una mappa di Google."
 
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
-msgstr "Aggiungi un indirizzo e inserisci un segnaposto in una mappa di Google."
-
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "indirizzo"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "mappe"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "Google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Seleziona stile mappa"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Impostazioni mappa"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Livello zoom"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Altezza mappa in pixel"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Livello zoom"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Dimensione evidenziatore"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Le opzioni di controllo fine sono abilitate."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Alterna l’abilitazione delle opzioni di controllo delle mappe."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Controlli mappe"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Tipo di mappa"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "Il passaggio tra la visualizzazione della mappa standard e satellitare è abilitato."
+msgstr ""
+"Il passaggio tra la visualizzazione della mappa standard e satellitare è "
+"abilitato."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "Alterna l’abilitazione del passaggio tra mappa standard e satellitare."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Controlli zoom"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Visualizzazione dei controlli zoom della mappa."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Alterna l’abilitazione dei controlli zoom per ingrandire e ridurre la mappa."
+msgstr ""
+"Alterna l’abilitazione dei controlli zoom per ingrandire e ridurre la mappa."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Street View"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Visualizzazione del controllo mappa Street View."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Alterna la visualizzazione del controllo Street View in fondo a destra nella mappa."
+msgstr ""
+"Alterna la visualizzazione del controllo Street View in fondo a destra nella "
+"mappa."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Alterna la visualizzazione a schermo intero"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Visualizzazione del controllo mappa a schermo intero."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Alterna la visualizzazione del controllo mappa a schermo intero."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Chiave API Google Maps"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Aggiungi la tua chiave API Google Maps. Aggiornando questa chiave API, tutte le mappe verranno impostate per l’impiego della nuova chiave."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Aggiungi la tua chiave API Google Maps. Aggiornando questa chiave API, tutte "
+"le mappe verranno impostate per l’impiego della nuova chiave."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Recupera la chiave"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Hai bisogno di aiuto?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Immetti la chiave API Google…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Salvato"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standard"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Argento"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Scuro"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Notte"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Melanzana"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1239,10 @@ msgstr "Media a destra"
 msgid "Media on left"
 msgstr "Media a sinistra"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Scheda media"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
-msgstr "Aggiungi un'immagine o un video con una scheda sfalsata, fianco a fianco."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "immagine"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
+msgstr ""
+"Aggiungi un'immagine o un video con una scheda sfalsata, fianco a fianco."
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1256,18 @@ msgstr "Visualizzazione dell’ombreggiatura scheda."
 msgid "Toggle to add a card shadow."
 msgstr "Alterna l’aggiunta di un’ombreggiatura scheda."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Ombreggiatura %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Visualizzazione ombreggiatura %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Alterna l’aggiunta di un’ombreggiatura %s."
 
@@ -1545,40 +1291,171 @@ msgstr "Rilascia per sostituire media"
 msgid "Edit media"
 msgstr "Modifica media"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Tabelle %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL Gist"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Piano %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Carosello"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL Gist"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Impostazioni colore"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Visualizzazione del prezzo per questo elemento."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Alterna la visualizzazione dei metadati Gist."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Visualizzazione del pulsante di invito all’azione."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Alterna la visualizzazione dei metadati Gist."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Impostazioni caratteristica"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Media a sinistra"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Media a destra"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Dimensione colonna"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Impostazioni Gist"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Tabella prezzi"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Tabella prezzi"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Tabella prezzi"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Tabella prezzi"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Aggiungi tabelle prezzi."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "destinazione"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Piano %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "confronto"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Impostazioni tabella prezzi"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabelle"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1473,171 @@ msgstr "Piano A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Elemento tabella prezzi"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Una colonna posizionata all’interno del blocco della tabella prezzi."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Aggiungi sfondo a %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Colonna"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Il figlio diretto di una riga."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Larghezza"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Impostazioni colonna"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Spazio attorno al contenitore."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Larghezza"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Cambia layout"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "uno"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "due"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "tre"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "quattro"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Aggiungi sfondo a %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Una colonna"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Due colonne"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Tre colonne"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Quattro colonne"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Layout riga"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Riga"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Ora seleziona un layout per questa riga di colonna %s."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Seleziona il numero di colonne per questa riga."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Seleziona colonne riga"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Seleziona layout riga"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Torna a colonne"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Aggiungi un involucro strutturato per i blocchi di colonne, quindi aggiungi i blocchi di contenuti che desideri alle colonne."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Aggiungi un involucro strutturato per i blocchi di colonne, quindi aggiungi "
+"i blocchi di contenuti che desideri alle colonne."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "righe"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "colonne"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "layout"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Layout"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Impostazioni riga"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Nessuno"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1647,9 @@ msgstr "Quadrato"
 msgid "Circle"
 msgstr "Cerchio"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Servizi"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Aggiungi fino a quattro colonne di servizi da visualizzare."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "caratteristiche"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1671,7 @@ msgstr "Visualizzazione dei pulsanti di invito all’azione."
 msgid "Toggle to show call to action buttons."
 msgstr "Alterna la visualizzazione dei pulsanti di invito all’azione."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Servizio"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Un unico elemento servizio all’interno di un blocco di servizi."
 
@@ -1785,264 +1692,232 @@ msgid "Toggle to show a call to action button."
 msgstr "Alterna la visualizzazione del pulsante di invito all’azione."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Ruota orizzontalmente"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Ruota verticalmente"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Separatore forma"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Aggiungi un separatore forma per distinguere visivamente le sezioni della pagina."
+msgstr ""
+"Aggiungi un separatore forma per distinguere visivamente le sezioni della "
+"pagina."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "separatore"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Colore forma"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Impostazioni separatore"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Altezza separatore in pixel"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Altezza sfondo in pixel"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Orientamento"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Colore forma"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Condividi su Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Condividi su Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Condividi su Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Condivisi su Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Condividi su LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Condividi via email"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Condividi su Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Condividi su Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Condividi su Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Condividi"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "social"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Aggiungi dei link di condivisione sui social network per ottenere like e favorire la condivisione."
+msgstr ""
+"Aggiungi dei link di condivisione sui social network per ottenere like e "
+"favorire la condivisione."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Colori social media"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Dimensione icona"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Dimensione cerchio"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Dimensione pulsante"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Icone"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "Linkedin"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "I colori del pulsante di condivisone sono abilitati."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Alterna l’uso dei colori ufficiali di ciascuna piattaforma di social media."
+msgstr ""
+"Alterna l’uso dei colori ufficiali di ciascuna piattaforma di social media."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Colori social media"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Aggiungi profilo Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Aggiungi profilo Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Aggiungi profilo Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Aggiungi profilo Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Aggiungi profilo LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Aggiungi profilo YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Aggiungi profilo Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Aggiungi profilo Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Profili social"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "link"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Visualizza i link ai profili social."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Link al profilo"
 
@@ -2057,18 +1932,6 @@ msgstr "Rimuovi sfondo"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Sfondo"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Auto"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Copertina"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Contiene"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1989,6 @@ msgstr "Rimuovi sfondo"
 msgid "Remove "
 msgstr "Rimuovi "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Nessuna ripetizione"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Ripeti orizzontalmente"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Ripeti verticalmente"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Sposta immagine indietro"
@@ -2150,17 +2001,14 @@ msgstr "Sposta immagine avanti"
 msgid "Link To"
 msgstr "Collega a"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Galleria %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Carica un'immagine"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Chiaro"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2022,110 @@ msgstr "Pagina allegato"
 msgid "Custom URL"
 msgstr "URL personalizzato"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Orientamento"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Percentuale"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Reimposta"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Seleziona unità"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "‌Unità: %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Disattiva impostazioni %s avanzate"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s in alto"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s a destra"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s in basso"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s a sinistra"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Annulla sincronizzazione"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Sincronizza"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Sincronizza unità"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "In alto"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Destra"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "In basso"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Sinistra"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Impostazioni %s avanzate"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Avanzate"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Predefinito"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Layout"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2144,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Alterna l’abilitazione della modalità a schermo intero."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Intestazione %d"
@@ -2263,43 +2153,16 @@ msgstr "Intestazione %d"
 msgid "Custom color picker"
 msgstr "Selettore colore personalizzato"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Originale"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Scala di grigi"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Seppia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Saturazione"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Tenue"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Applica filtro"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Seleziona orientamento"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Altezza"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Dispositivo mobile %s"
@@ -2333,7 +2196,8 @@ msgid "Five Seconds"
 msgstr "Cinque secondi"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Sei secondi"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2216,22 @@ msgstr "Nove secondi"
 msgid "Ten Seconds"
 msgstr "Dieci secondi"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Navigazione tramite frecce"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Navigazione tramite punti"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "secondi"
@@ -2361,22 +2241,28 @@ msgid "second"
 msgstr "secondo"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Avanzamento dopo %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Avanza automaticamente alla slide successiva."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Trascinamento e scorrimento abilitati su desktop e dispositivi mobili."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Alterna l’abilitazione della funzionalità di trascinamento su desktop e dispositivi mobili."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Alterna l’abilitazione della funzionalità di trascinamento su desktop e "
+"dispositivi mobili."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2273,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Alterna la visualizzazione delle frecce di navigazione a scorrimento."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Visualizzazione delle frecce di navigazione a punti."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Alterna la visualizzazione delle frecce di navigazione a punti."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Spazio all’interno del contenitore."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Alterna la disattivazione audio del video."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Alterna la riproduzione del video di sfondo a ciclo continuo."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Impostazioni scorrimento"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Riproduzione automatica"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Velocità transizione"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Trascinabile"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Navigazione tramite frecce"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Navigazione tramite punti"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Iniziale maiuscola"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normale"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2360,6 @@ msgstr "Nessuna spaziatura inferiore"
 msgid "Change typography"
 msgstr "Cambia tipografia"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Grassetto"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Tutto maiuscolo"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Tutto minuscolo"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Impila su dispositivo mobile"
@@ -2481,31 +2370,37 @@ msgstr "Velocità di risposta abilitata."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Alterna l’impilamento degli elementi uno sull’altro in riquadri di piccole dimensioni."
+msgstr ""
+"Alterna l’impilamento degli elementi uno sull’altro in riquadri di piccole "
+"dimensioni."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Rimuovi spaziatura superiore"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Margine superiore rimosso da questo blocco."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Alterna l’aggiunta di un’ombreggiatura scheda."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Alterna la rimozione di margini superiori applicati a questo blocco."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Alterna la visualizzazione delle frecce di navigazione a punti."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Rimuovi spaziatura inferiore"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Margine inferiore rimosso da questo blocco."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Alterna l’aggiunta di un’ombreggiatura scheda."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Alterna la rimozione di margini inferiori applicati a questo blocco."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Alterna la visualizzazione delle frecce di navigazione a punti."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2414,14 @@ msgstr "Visualizzazione a tutta larghezza."
 msgid "Toggle to display button as full width."
 msgstr "Alterna la visualizzazione del pulsante a tutta larghezza."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Circolare"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Impostazioni hero"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Ombreggiatura"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Casella di controllo"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Tutto maiuscolo"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2441,801 @@ msgstr "Cerca un blocco"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Questo blocco è stato aggiunto alla pagina e al momento non può essere disabilitato"
+msgstr ""
+"Questo blocco è stato aggiunto alla pagina e al momento non può essere "
+"disabilitato"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Disabilita tutto"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Nessun blocco \"%s\" trovato."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Gallerie %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Visualizza aperto"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Aggiungi titolo menu a fisarmonica..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Elemento menu a fisarmonica"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "schede"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "domande frequenti"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "avviso"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "messaggio"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografia"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profilo"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "link"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "condividi"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "Twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "spaziatore"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "servizi"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menu"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "ristorante"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "email"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "posta"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Cognome"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Area testo"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Testo multiriga"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "email"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "informazioni su"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "contatto"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galleria"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "foto"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Notte"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animata"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "codice"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "pulsante"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "invito all’azione"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "testo"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "paragrafo"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "icone"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "clienti"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "prova"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "testimonianze"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "indirizzo"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "mappe"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "Google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "immagine"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "indirizzo"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "destinazione"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "confronto"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "righe"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "colonne"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "layout"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "caratteristiche"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "separatore"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "social"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "link"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Visualizza aperto"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Aggiungi elemento menu a fisarmonica"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Menu a fisarmonica"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Scrivi testo..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Scrivi titolo..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Avviso"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Autore"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Pulsanti"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Fai clic per tweettare"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "HR dinamico"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Caratteristica"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Caratteristiche"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Elemento cibo"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Cibo e bevande"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Nome"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Messaggio"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Modulo"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Carosello"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Muratura"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Impilata"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL Gist"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Evidenzia"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Icona"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Loghi e badge"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Mappa"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Scheda media"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Carosello"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Tabella prezzi"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Elemento tabella prezzi"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Colonna"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Riga"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Servizi"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Servizio"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Separatore forma"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Condividi"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Profili social"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Info"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Operazione riuscita"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Avvertenza"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Errore"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Punto"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Linea"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Tutta larghezza"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Griglia"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Elenco"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Predefinito"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Strati"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Tracciato"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Pieno"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Impilata"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Ripeti orizzontalmente"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Ondulato"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Colline"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Onde"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Angolato"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Inclinato"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Arrotondato"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Triangolare"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Appuntito"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Maschera"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Icona"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Testo"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Icona e testo"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Circolare"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "In basso a sinistra"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "In alto a sinistra"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Rilascia per aggiungere come avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Autore"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3255,34 @@ msgstr "Aggiungi contenuto caratteristica"
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Questo blocco caratteristiche può essere utilizzato per evidenziare delle caratteristiche."
+msgstr ""
+"Questo blocco caratteristiche può essere utilizzato per evidenziare delle "
+"caratteristiche."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Aggiungi intestazione hero..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Aggiungi intestazione hero..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Aggiungi il contenuto hero, che in genere corrisponde a un’area introduttiva "
+"della pagina accompagnata da uno o due inviti all’azione."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Aggiungi il contenuto hero, che in genere corrisponde a un’area introduttiva della pagina accompagnata da uno o due inviti all’azione."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Aggiungi azione principale..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Aggiungi azione secondaria..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3301,126 @@ msgstr "Aggiungi contenuto..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Sostituisci questo testo con il testo descrittivo che deve accompagnare l’immagine della scheda. Quindi aggiungi altri blocchi alla scheda, come pulsanti, elenchi o immagini."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Sostituisci questo testo con il testo descrittivo che deve accompagnare "
+"l’immagine della scheda. Quindi aggiungi altri blocchi alla scheda, come "
+"pulsanti, elenchi o immagini."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Scrivi titolo..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Scrivi descrizione..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normale"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Impostazioni pulsanti"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Personalizzata"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Impila su dispositivo mobile"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Impostazioni HR dinamiche"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Nessuno"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Nessuno"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Piccolo"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Medio"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Grande"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Molto grande"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Nessuno"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Piccolo"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Medio"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Grande"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3080,7 +3760,8 @@ msgstr "codice greco matematica"
 #: src/blocks/icon/svgs.js:143
 msgctxt "tags"
 msgid "drawing doodle art creative type font pencil marker"
-msgstr "disegnare scarabocchio arte creatività carattere font matita evidenziatore"
+msgstr ""
+"disegnare scarabocchio arte creatività carattere font matita evidenziatore"
 
 #: src/blocks/icon/svgs.js:15
 msgctxt "tags"
@@ -3180,7 +3861,9 @@ msgstr "divertimento party felicità celebrazione gusto cibo"
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "petalo profumo annusare bello relax paesaggio giardinaggio aria aperta esterno"
+msgstr ""
+"petalo profumo annusare bello relax paesaggio giardinaggio aria aperta "
+"esterno"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3259,8 +3942,12 @@ msgstr "musica microfono brano artista creatività media audio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "microfono podcast computer dispositivo musica brano artista creatività media audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"microfono podcast computer dispositivo musica brano artista creatività media "
+"audio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3971,12 @@ msgstr "film videografia regista produttore media creatività"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "film videografia regista produttore media creatività fotocamera fotografo fotografia apertura"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"film videografia regista produttore media creatività fotocamera fotografo "
+"fotografia apertura"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3993,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "tavolozza progetto colori artista creatività media dipingere pennello"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standard"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Argento"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Scuro"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Notte"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Melanzana"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Circolare"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Ombreggiatura"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Predefinito"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Nessuno"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Casella di controllo"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Titolo menu..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Piccolo"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Medio"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Grande"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Molto grande"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Auto"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Copertina"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Contiene"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "In alto a sinistra"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "In alto al centro"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "In alto a destra"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Centrale a sinistra"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Centrale al centro"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Centrale a destra"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "In basso a sinistra"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "In basso al centro"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "In basso a destra"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Nessuna ripetizione"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Ripeti"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Ripeti orizzontalmente"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Ripeti verticalmente"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Link relazionale"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Scuro"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Chiaro"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Nessuno"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Immagine"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Pixel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Percentuale"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Originale"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Scala di grigi"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "File multimediale"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Saturazione"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Filtro vintage"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Filtro vintage"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Iniziale maiuscola"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normale"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Grassetto"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Predefinito"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Tutto maiuscolo"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Tutto minuscolo"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4341,16 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks è una suite professionale di <strong>blocchi di contenuto per la creazione di pagine web</strong> con l’editor di blocchi Gutenberg di WordPress. I nostri blocchi sono appositamente studiati per consentire agli sviluppatori di creare pagine web accattivanti e ricche di contenuti in WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks è una suite professionale di <strong>blocchi di contenuto per la "
+"creazione di pagine web</strong> con l’editor di blocchi Gutenberg di "
+"WordPress. I nostri blocchi sono appositamente studiati per consentire agli "
+"sviluppatori di creare pagine web accattivanti e ricche di contenuti in "
+"WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4360,169 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Scherzi?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Scrivi una recensione"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s anni"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "un anno"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s settimane"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "una settimana"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s giorni"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "un giorno"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s ore"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "un'ora"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minuti"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "un minuto"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s secondi"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "un secondo"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Plugin %s WordPress"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Ti piace %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Stai usando %1$s ormai da %2$s. Ti spiacerebbe scrivere una recensione per farci sapere cosa ne pensi? Te ne saremmo davvero grati!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Scrivi una recensione"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Stai usando %1$s ormai da %2$s. Ti spiacerebbe scrivere una recensione per "
+"farci sapere cosa ne pensi? Te ne saremmo davvero grati!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "No grazie / L’ho già fatto"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Grazie per aver scelto CoBlocks, la più completa suite per la creazione di pagine per il nuovo editor di blocchi WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Grazie per aver scelto CoBlocks, la più completa suite per la creazione di "
+"pagine per il nuovo editor di blocchi WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Hai appena aggiunto tanti utili blocchi e un nuovo toolkit per la creazione di pagine nell’editor WordPress. CoBlocks offre una serie di rivoluzionarie funzioni: %1$s decine di blocchi%2$s, un’%1$sesperienza di creazione pagine senza confronti%2$s e %1$scontrolli tipografici personalizzati%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Hai appena aggiunto tanti utili blocchi e un nuovo toolkit per la creazione "
+"di pagine nell’editor WordPress. CoBlocks offre una serie di rivoluzionarie "
+"funzioni: %1$s decine di blocchi%2$s, un’%1$sesperienza di creazione pagine "
+"senza confronti%2$s e %1$scontrolli tipografici personalizzati%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Ecco alcuni video per aiutarti a iniziare:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Guarda come creare la tua prima pagina con %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Guarda come creare la tua prima pagina"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Guarda come usare i blocchi Riga e Separatore forma"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Scopri come usare il blocco Scheda media"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Ti piace ciò che vedi? %1$sAbbonati al nostro canale YouTube%2$s per sapere quando vengono pubblicati nuovi tutorial video."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Ti piace ciò che vedi? %1$sAbbonati al nostro canale YouTube%2$s per sapere "
+"quando vengono pubblicati nuovi tutorial video."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Se hai domande o feedback, contattaci su %1$sTwitter%4$s o tramite il nostro %2$sgruppo Facebook %4$s. Inoltre, %3$sabbonati alla nostra newsletter%4$s per ricevere aggiornamenti su tutte le novità di CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Se hai domande o feedback, contattaci su %1$sTwitter%4$s o tramite il nostro "
+"%2$sgruppo Facebook %4$s. Inoltre, %3$sabbonati alla nostra newsletter%4$s "
+"per ricevere aggiornamenti su tutte le novità di CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Approfittane."
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Inizia a usare CoBlocks da qui:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4530,37 @@ msgstr "Abilita o disabilita blocchi"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "Codice sito reCAPTCHA di Google per la protezione dalla posta indesiderata nei moduli"
+msgstr ""
+"Codice sito reCAPTCHA di Google per la protezione dalla posta indesiderata "
+"nei moduli"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
-msgstr "Codice segreto reCAPTCHA di Google per la protezione dalla posta indesiderata nei moduli"
+msgstr ""
+"Codice segreto reCAPTCHA di Google per la protezione dalla posta "
+"indesiderata nei moduli"
+
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Nome"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Nome"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Cognome"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Messaggio"
 
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Invia"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Il tuo messaggio è stato inviato:"
 
@@ -3490,3 +4575,88 @@ msgstr "Condividi su LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "Tipo di avviso"
+
+#~ msgid "Edit image"
+#~ msgstr "Modifica immagine"
+
+#~ msgid "Remove image"
+#~ msgstr "Rimuovi immagine"
+
+#~ msgid "Heading..."
+#~ msgstr "Intestazione..."
+
+#~ msgid "Author Name"
+#~ msgstr "Nome autore"
+
+#~ msgid "Write biography..."
+#~ msgstr "Scrivi biografia..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Aggiungi una biografica dell’autore."
+
+#~ msgid "%s Settings"
+#~ msgstr "Impostazioni %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Colore didascalia"
+
+#~ msgid "Highlight text."
+#~ msgstr "Evidenzia testo."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Tabelle %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Impostazioni tabella prezzi"
+
+#~ msgid "Tables"
+#~ msgstr "Tabelle"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr ""
+#~ "Una colonna posizionata all’interno del blocco della tabella prezzi."
+
+#~ msgid "Sepia"
+#~ msgstr "Seppia"
+
+#~ msgid "Dim"
+#~ msgstr "Tenue"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Seleziona orientamento"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Margine superiore rimosso da questo blocco."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Alterna la rimozione di margini superiori applicati a questo blocco."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Margine inferiore rimosso da questo blocco."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Alterna la rimozione di margini inferiori applicati a questo blocco."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Aggiungi azione principale..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Aggiungi azione secondaria..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normale"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Inizia a usare CoBlocks da qui:"

--- a/languages/coblocks-ja.po
+++ b/languages/coblocks-ja.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "開いて表示"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "アコーディオンタイトルを追加..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "アコーディオンアイテム"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "折りたためるアコーディオンアイテムをアコーディオンに追加します。"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "タブ"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "よくある質問"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,39 @@ msgstr "アコーディオンアイテムはデフォルトで開いています
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "切り替えると、このアコーディオンアイテムをデフォルトで開くように設定します。"
+msgstr ""
+"切り替えると、このアコーディオンアイテムをデフォルトで開くように設定します。"
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "アコーディオンアイテム設定"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "ディスプレイを開く"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "色設定"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "背景色"
@@ -103,14 +64,6 @@ msgstr "背景色"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "タイトルテキスト色"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "アコーディオンアイテムを追加"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "アコーディオン"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +79,83 @@ msgstr "Internet Explorerサポート"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "JavaScriptのポリフィルを読み込んで、Internet Explorerへのサポートを追加します。"
+msgstr ""
+"JavaScriptのポリフィルを読み込んで、Internet Explorerへのサポートを追加しま"
+"す。"
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "このページにJavaScriptのポリフィルを読み込んで、Internet Explorerをサポートします。"
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"このページにJavaScriptのポリフィルを読み込んで、Internet Explorerをサポートし"
+"ます。"
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "警告"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "エラー"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "アラートタイプ"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "デフォルト"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "情報"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "成功"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "タイトルを入力..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "テキストを入力..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "アラート"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "文脈にそったフィードバックのメッセージを表示します。"
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "お知らせ"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "メッセージ"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "テキスト色"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "画像を編集"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "ギャラリーを編集"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "画像を削除"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "キャプションを入力..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "ドロップしてアバターとして追加する"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "見出し..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "作成者名"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "経歴を入力..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "フォーム設定"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "作成者"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "作成者の経歴を追加します。"
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "経歴"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "プロフィール"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "ボタン"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "複数のボタンを横に並べて、訪問者にアクションを選ぶよう促します。"
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "リンク"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "CTA"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "ボタン設定"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "モバイルで積み重ねる"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "ボタン"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +173,25 @@ msgstr "Twitterユーザー名"
 msgid "Username"
 msgstr "ユーザー名"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "ボタンを追加..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "ツイートに引用を追加..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "クリックしてツイート"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Twitterのツイートに引用を追加します。"
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "シェア"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "Twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +199,18 @@ msgid "Text Settings"
 msgstr "テキスト設定"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "ボタン色"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "動的水平線"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "サイズ調整のできるスペーサーをブロック間に追加します。"
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "スペーサー"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "動的水平線設定"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "高さ（ピクセル）"
 
@@ -347,17 +222,12 @@ msgstr "ピクセルで表した動的区切り要素の高さです。"
 msgid "Color"
 msgstr "色"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "背景として追加"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "特集"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "特集ブロック内にある単一のカラムです。"
 
@@ -366,73 +236,54 @@ msgid "Feature Settings"
 msgstr "特集設定"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "パディング"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "特集"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "商品やサービスの短いメモを最大3カラムまで追加できます。"
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "サービス"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "マージン"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "ガター"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "カラム間の余白です。"
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "小"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "中"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +293,8 @@ msgstr "大"
 msgid "Features Settings"
 msgstr "特集設定"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "カラム"
 
@@ -455,76 +306,72 @@ msgstr "メニューセクションを追加"
 msgid "Menu title..."
 msgstr "メニュータイトル..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "グリッド"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "リスト"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "画像をドロップして置き換える"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "画像を削除"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "タイトルを追加..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "スパイシー"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "ホット"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "ベジタリアン"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "グルテンフリー"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "ペスクタリアン"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "ビーガン"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "説明を追加..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0.00ドル"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "食品アイテム"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "食品＆飲料ブロックの飲食物アイテムです。"
 
@@ -560,62 +407,46 @@ msgstr "切り替えると、このアイテムの価格を表示します。"
 msgid "Item Attributes"
 msgstr "アイテムの属性"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "スパイシー"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "画像設定"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "altテキスト（代替テキスト）"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "画像の目的を説明"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "画像の目的が装飾のみの場合は空にします。"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "フォーカルポイント"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "食品＆飲料"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "メニューや価格表を表示します。"
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "飲食店"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "メニュー"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "スタイル"
@@ -648,134 +479,84 @@ msgstr "各アイテムの価格を表示しています。"
 msgid "Toggle to show the price of each item."
 msgstr "切り替えると、各アイテムの価格を表示します。"
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "メールアドレス"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "メールアドレス"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "メールアドレス"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "メールアドレスのフィールドです。"
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "メッセージ"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "テキストエリア"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "複数行テキスト"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "長い応答のためのテキストボックスです。"
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%sは有効なメールアドレスではありません。"
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%sと%sは有効なメールアドレスではありません。"
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%sは有効なメールアドレスではありません。"
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "メールアドレス"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "件名"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "フォーム設定"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
 msgstr "reCAPTCHAサイトと秘密キーを追加してスパムからフォームを守ります。"
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "キーを生成"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "キー"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "サポート"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "サイトキー"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "秘密キー"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "保存中"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "保存"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "削除"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "名"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "姓"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "名前"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "名前のテキストフィールドです。"
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "メールアドレスのフィールドです。"
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "ラベルを追加..."
 
@@ -783,41 +564,38 @@ msgstr "ラベルを追加..."
 msgid "Required"
 msgstr "必須"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "名前フィールド設定"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "姓"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "姓と名のフィールドを両方表示しています。"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "切り替えると、姓のフィールドを追加します。"
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "フォーム"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "名前のテキストフィールドです。"
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "長い応答のためのテキストボックスです。"
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "ページに簡易フォームを追加します。"
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "メールアドレス"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "概要"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "連絡先"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "件名"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +605,217 @@ msgstr "テキストを追加..."
 msgid "Button Text Color"
 msgstr "ボタンテキスト色"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "ギャラリーを編集"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "カルーセル"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "ギャラリーの画像%1$d/%2$d"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "キャプションを入力..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "カルーセル"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "複数の画像を美しいカルーセルギャラリーで表示します。"
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "ギャラリー"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "写真"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s設定"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "行の高さ"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "ドットナビゲーションの矢印を表示しています。"
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "切り替えると、メディアにキャプションを表示します。"
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "色設定"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "サイズ"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "角丸"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "キャプション色"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "適用"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Masonry"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "説明を入力..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "複数の画像を整頓されたMasonryギャラリーで表示します。"
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "複数の画像を美しいカルーセルギャラリーで表示します。"
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "カラムサイズ"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "画像設定"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "ギャラリーアイテムに角丸を追加します。"
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "影"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "キャプション"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "キャプションのスタイル"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "メディアアイテムにキャプションを表示しています。"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "切り替えると、メディアにキャプションを表示します。"
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Masonry"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "複数の画像を整頓されたMasonryギャラリーで表示します。"
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "切り替えると、マップの調整オプションを有効にします。"
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "マップ設定"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "カラムサイズ"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "ギャラリーアイテムに角丸を追加します。"
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "ライト"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "スタック"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "1カラムのギャラリーに複数の画像を積み重ねて表示します。"
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "全幅画像"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "全幅画像"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "ボックスの影"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "全幅画像が有効です。"
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
 msgstr "切り替えると、ギャラリーエリアを全幅画像で埋めます。"
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "アイテム設定"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "全幅画像"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "全幅画像"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "GIFを削除"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "このGIFには空のalt属性があります"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Giphyで適切なGIFを検索"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "GIFを検索"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "どのGIFでも良いので選択します。"
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "アニメーション"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +841,11 @@ msgstr "GitHubファイル"
 msgid "File"
 msgstr "ファイル"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "GitHubでこのGistを表示"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist URL"
 
@@ -1024,12 +858,9 @@ msgid "Loading Gist"
 msgstr "Gistを読み込んでいます"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Gistのリンクを追加してGitHub Gistを埋め込みます。"
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "コード"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +883,157 @@ msgid "Gist Meta"
 msgstr "Gistメタ"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "レイアウトを変更"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "%sに背景を追加"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "ヒーロー"
-
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
 msgstr "短いテキストとCTAを含む、ページの導入エリアです。"
 
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "ボタン"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "Call to Action"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "コンテンツの幅（ピクセル）"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "ヒーロー設定"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "コンテナ内のスペースです。"
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "左上"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "中央上"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "右上"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "左中央"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "中央"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "右中央"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "左下"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "中央下"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "右下"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "ハイライト表示のテキストを追加..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "ハイライト"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "テキストを強調表示します。"
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "テキスト"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "段落"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "アイコン"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "図案化したグラフィックシンボルを追加して分かりやすくします。"
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "アイコン"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "特大"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "図案化したグラフィックシンボルを追加して分かりやすくします。"
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "アイコン設定"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "%sの高度な設定をオフにする"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "リセット"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "%sのカスタムサイズ"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "%sの高度な設定"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "カスタム"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "高度"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "半径"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "アイコン検索"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "結果は見つかりませんでした。"
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "リンク設定"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "リンクURL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "リンクの関係"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "新しいタブで開いています"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "新しいタブで開く"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "アイコン色"
 
@@ -1261,30 +1042,18 @@ msgid "Edit logos"
 msgstr "ロゴを編集"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "ロゴ＆バッジ"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "画像をドラッグ、新規アップロード、またはライブラリからファイルを選択します。"
+msgstr ""
+"画像をドラッグ、新規アップロード、またはライブラリからファイルを選択します。"
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "ロゴやバッジ、認証を追加して信頼を築きます。"
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "クライアント"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "証明"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "証明書"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1075,138 @@ msgstr "場所を編集"
 msgid "Map style"
 msgstr "マップのスタイル"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "APIキーが無効、またはリクエストが多すぎます"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Googleマップ"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "Googleマップにピンをたてるには、位置または住所を入力します。"
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "場所または住所を検索..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "適用"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "マップ"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "住所を追加してGoogleマップにピンを立てます。"
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "住所"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "マップ"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "Google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "マップのスタイルを選択"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "マップ設定"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "ズームレベル"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "マップの高さ（ピクセル）"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "ズームレベル"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "マーカーサイズ"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "微調整オプションが有効です。"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "切り替えると、マップの調整オプションを有効にします。"
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "マップの調整"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "マップの種類"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "マップの標準地図と航空写真の切り替えが有効です。"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "切り替えると、マップの標準地図と航空写真の変更を有効にします。"
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "ズームコントロール"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "マップのズームコントロールを表示しています。"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "切り替えると、マップのズームコントロールを表示します。"
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "ストリートビュー"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "ストリートビューのマップコントロールを表示しています。"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "切り替えると、右下にストリートビューのコントロールを表示します。"
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "全画面切り替え"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "全画面表示のマップコントロールを表示しています。"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "切り替えると、全画面表示のマップコントロールを表示します。"
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "GoogleマップのAPIキー"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "GoogleマップのAPIキーを追加します。このAPIキーを更新すると、すべてのマップで新しいキーが使われます。"
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"GoogleマップのAPIキーを追加します。このAPIキーを更新すると、すべてのマップで"
+"新しいキーが使われます。"
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "キーを取得"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "お困りですか？"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Google APIキーを入力..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "保存されました"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "スタンダード"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "シルバー"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "レトロ"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "ダーク"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "夜"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "オーベルジーヌ"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1216,9 @@ msgstr "右にメディア"
 msgid "Media on left"
 msgstr "左にメディア"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "メディアカード"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "画像や動画をオフセットカードで並べて追加します。"
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "画像"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "動画"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1232,18 @@ msgstr "カードの影を表示しています。"
 msgid "Toggle to add a card shadow."
 msgstr "切り替えると、カードの影を追加します。"
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %sの影"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "%sの影を表示しています。"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "切り替えると、%sの影を追加します。"
 
@@ -1545,40 +1267,171 @@ msgstr "ドロップしてメディアを置き換える"
 msgid "Edit media"
 msgstr "メディアを編集"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%sテーブル"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "プラン%s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "カルーセル"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "色設定"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "このアイテムの価格を表示しています。"
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "切り替えると、Gistのメタデータを表示します。"
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Call to Actionボタンを表示しています。"
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "切り替えると、Gistのメタデータを表示します。"
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "特集設定"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "左にメディア"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "右にメディア"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "カラムサイズ"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gist設定"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "価格表"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "価格表"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "価格表"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "価格表"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "価格表を追加します。"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "ランディング"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "プラン%s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "比較"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "価格表設定"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "テーブル"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1449,171 @@ msgstr "プランA"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "価格表のアイテム"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "価格表ブロック内のカラムです。"
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "%sに背景を追加"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "カラム"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "行のすぐ下に表示されます。"
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "幅"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "カラム設定"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "コンテナの周囲の余白です。"
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "幅"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "レイアウトを変更"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "1"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "2"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "3"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "4"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "%sに背景を追加"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "1カラム"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "2カラム"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "3カラム"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "4カラム"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "行のレイアウト"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "行"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "この%sカラムの行のレイアウトを選びます。"
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "この行のカラム数を選びます。"
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "行のカラム数を選ぶ"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "行のレイアウトを選ぶ"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "カラムに戻る"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "カラムブロックに構造ラッパーを追加してから、カラムにコンテンツブロックを追加します。"
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"カラムブロックに構造ラッパーを追加してから、カラムにコンテンツブロックを追加"
+"します。"
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "行"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "カラム"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "レイアウト"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "レイアウト"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "行設定"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "なし"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1623,9 @@ msgstr "正方形"
 msgid "Circle"
 msgstr "円形"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "サービス"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "表示するサービスを4カラム以内で追加します。"
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "特集"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1647,7 @@ msgstr "Call to Actionボタンを表示しています。"
 msgid "Toggle to show call to action buttons."
 msgstr "切り替えると、Call to Actionボタンを表示します。"
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "サービス"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "サービスブロック内のサービスアイテム1点です。"
 
@@ -1785,264 +1668,228 @@ msgid "Toggle to show a call to action button."
 msgstr "切り替えると、Call to Actionボタンを表示します。"
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "水平方向にめくる"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "垂直方向にめくる"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "シェイプ区切り"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "ページのセクションが視覚的に明確になるようシェイプ区切りを追加します。"
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "区切り"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "シェイプ色"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "区切り設定"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "シェイプの高さ（ピクセル）"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "背景の高さ（ピクセル）"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "向き"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "シェイプ色"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "‌‌Twitterでシェア"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Facebookでシェア"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "‌‌Twitterでシェア"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Pinterestでシェア"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "LinkedInでシェア"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "メールでシェア"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Tumblrでシェア"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Googleでシェア"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Redditでシェア"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "シェア"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "ソーシャル"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
 msgstr "「いいね」やシェアを広げるソーシャル共有リンクを追加します。"
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "ソーシャルメディアの色"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "アイコンサイズ"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "円形サイズ"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "ボタンサイズ"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "アイコン"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "メールアドレス"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "シェアボタンの色は有効です。"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "切り替えると、ソーシャル メディア プラットフォームの公式カラーを使います。"
+msgstr ""
+"切り替えると、ソーシャル メディア プラットフォームの公式カラーを使います。"
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "ソーシャルメディアの色"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Facebookのプロフィールを追加"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Twitterのプロフィールを追加"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Instagramのプロフィールを追加"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Pinterestのプロフィールを追加"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "LinkedInのプロフィールを追加"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "YouTubeのプロフィールを追加"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Yelpのプロフィールを追加"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Houzzのプロフィールを追加"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "ソーシャルメディアのプロフィール"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "リンク"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "ソーシャルメディアのプロフィールへのリンクを表示します。"
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "プロフィールのリンク"
 
@@ -2057,18 +1904,6 @@ msgstr "背景を削除"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "背景"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "自動"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "カバー"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "含む"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1961,6 @@ msgstr "背景を削除"
 msgid "Remove "
 msgstr "削除 "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "繰り返さない"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "水平方向に繰り返す"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "垂直方向に繰り返す"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "画像を後方に移動"
@@ -2150,17 +1973,14 @@ msgstr "画像を前方に移動"
 msgid "Link To"
 msgstr "リンク先："
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%sギャラリー"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "画像をアップロード"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "ライト"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +1994,110 @@ msgstr "添付ファイルページ"
 msgid "Custom URL"
 msgstr "カスタムURL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "ピクセル"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "向き"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "割合"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "リセット"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "単位を選択"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s単位"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "%sの高度な設定をオフにする"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s上"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s右"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s下"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s左"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "同期しない"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "同期"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "単位を同期"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "上"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "右"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "下"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "左"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "%sの高度な設定"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "高度"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "デフォルト"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "レイアウト"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2116,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "切り替えると、全画面モードを有効にします。"
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "見出し%d"
@@ -2263,43 +2125,16 @@ msgstr "見出し%d"
 msgid "Custom color picker"
 msgstr "カスタムカラーピッカー"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "オリジナル"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "モノクロ"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "セピア"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "彩度"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "淡色"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "ビンテージ"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "フィルターを適用"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "向きを選択"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "高さ"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "モバイル%s"
@@ -2333,7 +2168,8 @@ msgid "Five Seconds"
 msgstr "5秒"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "6秒"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2188,22 @@ msgstr "9秒"
 msgid "Ten Seconds"
 msgstr "10秒"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "矢印ナビゲーション"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "ドットナビゲーション"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "秒"
@@ -2361,21 +2213,25 @@ msgid "second"
 msgstr "秒"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "%1$d%2$s後に進みます。"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "自動的に次のスライドに進めます。"
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "デスクトップとモバイル端末でドラッグとフリックが有効です。"
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
 msgstr "切り替えると、デスクトップとモバイル端末でドラッグ機能を有効にします。"
 
 #: src/components/slider-panel/index.js:35
@@ -2387,44 +2243,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "切り替えると、スライドナビゲーションの矢印を表示します。"
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "ドットナビゲーションの矢印を表示しています。"
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "切り替えると、ドットナビゲーションを表示します。"
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "コンテナ内のスペースです。"
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "切り替えると、動画をミュート再生します。"
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "切り替えると、動画をループ再生します。"
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "スライダー設定"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "オートプレイ"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "遷移速度"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "ドラッグ可能"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "矢印ナビゲーション"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "ドットナビゲーション"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "頭文字を大文字にする"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "標準"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2330,6 @@ msgstr "下部の余白なし"
 msgid "Change typography"
 msgstr "タイポグラフィを変更"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "太字"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "大文字"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "小文字"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "モバイルで積み重ねる"
@@ -2487,25 +2346,29 @@ msgstr "切り替えると、表示域が小さい場合に要素同士を積み
 msgid "Remove Top Spacing"
 msgstr "上部の余白を削除"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "このブロックでは上部のマージンが削除されます。"
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "切り替えると、カードの影を追加します。"
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "切り替えると、このブロックの上部にできるマージンをすべて削除します。"
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "切り替えると、ドットナビゲーションを表示します。"
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "下部の余白を削除"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "このブロックでは下部のマージンが削除されます。"
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "切り替えると、カードの影を追加します。"
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "切り替えると、このブロックの下部にできるマージンをすべて削除します。"
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "切り替えると、ドットナビゲーションを表示します。"
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2382,14 @@ msgstr "全幅で表示します。"
 msgid "Toggle to display button as full width."
 msgstr "切り替えると、ボタンを全幅で表示します。"
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "円形"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "ヒーロー設定"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "影"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "チェックボックス"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "大文字"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2415,793 @@ msgstr "このブロックはページに追加されており、無効にする
 msgid "Disable all"
 msgstr "すべてを無効にする"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "「%s」ブロックは見つかりません。"
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%sギャラリー"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "開いて表示"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "アコーディオンタイトルを追加..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "アコーディオンアイテム"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "タブ"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "よくある質問"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "お知らせ"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "メッセージ"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "経歴"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "プロフィール"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "リンク"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "CTA"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "シェア"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "Twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "スペーサー"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "サービス"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "メニュー"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "飲食店"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "メールアドレス"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "メールアドレス"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "姓"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "テキストエリア"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "複数行テキスト"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "メールアドレス"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "概要"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "連絡先"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "ギャラリー"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "写真"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "夜"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "アニメーション"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "コード"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "ボタン"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "Call to Action"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "テキスト"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "段落"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "アイコン"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "クライアント"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "証明"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "証明書"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "住所"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "マップ"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "Google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "画像"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "動画"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "住所"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "ランディング"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "比較"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "行"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "カラム"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "レイアウト"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "特集"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "区切り"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "ソーシャル"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "リンク"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "ディスプレイを開く"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "アコーディオンアイテムを追加"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "アコーディオン"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "テキストを入力..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "タイトルを入力..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "アラート"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "作成者"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "ボタン"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "クリックしてツイート"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "動的水平線"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "特集"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "特集"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "食品アイテム"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "食品＆飲料"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "メールアドレス"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "名前"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "メッセージ"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "フォーム"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "カルーセル"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Masonry"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "スタック"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "ヒーロー"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "ハイライト"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "アイコン"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "ロゴ＆バッジ"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "マップ"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "メディアカード"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "カルーセル"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "価格表"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "価格表のアイテム"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "カラム"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "行"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "サービス"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "サービス"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "シェイプ区切り"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "シェア"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "ソーシャルメディアのプロフィール"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "情報"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "成功"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "警告"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "エラー"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "ドット"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "ライン"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "全幅"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "グリッド"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "リスト"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "デフォルト"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "レイヤー"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "アウトライン"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "フィルド"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "スタック"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "水平方向に繰り返す"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "ウェイビー"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "ヒルズ"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "ウェーブ"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "アングル"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "スロープ"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "ラウンド"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "トライアングル"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "ポインテッド"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "マスク"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "アイコン"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "テキスト"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "アイコン＆テキスト"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "円形"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "左下"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "左上"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "ドロップしてアバターとして追加する"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "作成者"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3223,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "特集を強調するために使用する特集ブロックです。"
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "ヒーローの見出しを追加..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "通常、CTAなどをともなうページの導入エリアとして使用されるヒーローのコンテンツを追加します。"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"通常、CTAなどをともなうページの導入エリアとして使用されるヒーローのコンテンツ"
+"を追加します。"
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "プライマリアクションを追加..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "セカンダリアクションを追加..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3265,125 @@ msgstr "コンテンツを追加..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "このテキストを説明的なコピーに置き換えてカード画像に合わせます。それから、ボタンやリスト、画像などのブロックをこのカードに追加します。"
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"このテキストを説明的なコピーに置き換えてカード画像に合わせます。それから、ボ"
+"タンやリスト、画像などのブロックをこのカードに追加します。"
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "タイトルを入力..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "説明を入力..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "標準"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "ボタン設定"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "カスタム"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "モバイルで積み重ねる"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "動的水平線設定"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "なし"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "なし"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "小"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "中"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "大"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "特大"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "なし"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "小"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "中"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "大"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3125,7 +3768,9 @@ msgstr "usb 接続 ハブ 端末 ソーシャル"
 #: src/blocks/icon/svgs.js:20
 msgctxt "tags"
 msgid "music microphone podcast song artist creative media audio"
-msgstr "音楽 マイク ポッドキャスト 曲 アーティスト クリエイティブ メディア オーディオ 音声"
+msgstr ""
+"音楽 マイク ポッドキャスト 曲 アーティスト クリエイティブ メディア オーディ"
+"オ 音声"
 
 #: src/blocks/icon/svgs.js:209
 msgctxt "tags"
@@ -3210,7 +3855,8 @@ msgstr "言語 グローバル 世界 音声"
 #: src/blocks/icon/svgs.js:319
 msgctxt "tags"
 msgid "music microphone song artist creative media audio badge"
-msgstr "音楽 マイク 曲 アーティスト クリエイティブ メディア オーディオ 音声 バッジ"
+msgstr ""
+"音楽 マイク 曲 アーティスト クリエイティブ メディア オーディオ 音声 バッジ"
 
 #: src/blocks/icon/svgs.js:32
 msgctxt "tags"
@@ -3259,8 +3905,12 @@ msgstr "音楽 マイク 曲 アーティスト クリエイティブ メディ�
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "マイク ポッドキャスト コンピューター 端末 音楽 曲 アーティスト クリエイティブ メディア オーディオ"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"マイク ポッドキャスト コンピューター 端末 音楽 曲 アーティスト クリエイティ"
+"ブ メディア オーディオ"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3280,12 +3930,17 @@ msgstr "写真 画像 メディア カメラ 絞り値 コレクション"
 #: src/blocks/icon/svgs.js:67
 msgctxt "tags"
 msgid "film videography director producer media creative"
-msgstr "フィルム ビデオ撮影 ディレクター プロデューサー メディア クリエイティブ"
+msgstr ""
+"フィルム ビデオ撮影 ディレクター プロデューサー メディア クリエイティブ"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "動画 ビデオ撮影 ディレクター プロデューサー メディア クリエイティブ カメラ 写真家 写真撮影 絞り値"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"動画 ビデオ撮影 ディレクター プロデューサー メディア クリエイティブ カメラ 写"
+"真家 写真撮影 絞り値"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3300,14 +3955,350 @@ msgstr "パレット デザイン 色 アーティスト クリエイティブ �
 #: src/blocks/icon/svgs.js:97
 msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
-msgstr "パレット デザイン 色 アーティスト クリエイティブ メディア ペイント ペイントブラシ"
+msgstr ""
+"パレット デザイン 色 アーティスト クリエイティブ メディア ペイント ペイントブ"
+"ラシ"
+
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "スタンダード"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "シルバー"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "レトロ"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "ダーク"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "夜"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "オーベルジーヌ"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "円形"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "影"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "デフォルト"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "なし"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "チェックボックス"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "メニュータイトル..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "小"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "中"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "大"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "特大"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "自動"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "カバー"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "含む"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "左上"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "中央上"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "右上"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "左中央"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "中央"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "右中央"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "左下"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "中央下"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "右下"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "繰り返さない"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "繰り返し"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "水平方向に繰り返す"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "垂直方向に繰り返す"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "リンクの関係"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "ダーク"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "ライト"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "なし"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "画像"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "ピクセル"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "割合"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "オリジナル"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "モノクロ"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "メディアファイル"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "彩度"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "ビンテージフィルター"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "ビンテージフィルター"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "頭文字を大文字にする"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "標準"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "太字"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "デフォルト"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "大文字"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "小文字"
 
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4307,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocksは、ブロックエディタのWordPress Gutenberg向けに、プロフェッショナルな<strong>ページ作成用コンテンツブロック</strong>を豊富にそろえたツールです。WordPressで美しくてリッチなページを作成する方のニーズにフォーカスしたブロックをご用意しています。"
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocksは、ブロックエディタのWordPress Gutenberg向けに、プロフェッショナルな"
+"<strong>ページ作成用コンテンツブロック</strong>を豊富にそろえたツールです。"
+"WordPressで美しくてリッチなページを作成する方のニーズにフォーカスしたブロック"
+"をご用意しています。"
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4325,169 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "冗談でしょう？"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "レビューを書く"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s年"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "1年"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s週間"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "1週間"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s日"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "1日"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s時間"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "1時間"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s分"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "1分"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s秒"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "1秒"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPressプラグイン"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "%sをお楽しみいただいていますか？"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "%1$sを%2$sお使いいただいています。ぜひご感想をお寄せください。ご協力よろしくお願いいたします。"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "レビューを書く"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"%1$sを%2$sお使いいただいています。ぜひご感想をお寄せください。ご協力よろしく"
+"お願いいたします。"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "今はしない／すでに書いた"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "WordPressブロックエディタ用の優れたページビルダー、CoBlocksをご利用いただき誠にありがとうございます。"
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"WordPressブロックエディタ用の優れたページビルダー、CoBlocksをご利用いただき誠"
+"にありがとうございます。"
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "WordPressエディタに、多彩で便利なブロックと新しいページビルダーツールキットを追加しました。CoBlocksは%1$s多彩なブロック%2$s、%1$sページ作成体験%2$s、そして%1$sカスタムのタイポグラフィコントロール%2$sを含む、数々の革新的な機能を提供します。"
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"WordPressエディタに、多彩で便利なブロックと新しいページビルダーツールキットを"
+"追加しました。CoBlocksは%1$s多彩なブロック%2$s、%1$sページ作成体験%2$s、そし"
+"て%1$sカスタムのタイポグラフィコントロール%2$sを含む、数々の革新的な機能を提"
+"供します。"
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "開始に役立つ動画をご用意しました。"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "%sで最初のページを作成する方法を見る"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "最初のページを作成する方法を見る"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "行とシェイプ区切りブロックの使い方を見る"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "メディアカードブロックの使い方を見る"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "気に入っていただけましたか？%1$s弊社のYouTubeチャンネルを登録%2$sすると、新しいチュートリアル動画の配信時にお知らせします。"
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"気に入っていただけましたか？%1$s弊社のYouTubeチャンネルを登録%2$sすると、新し"
+"いチュートリアル動画の配信時にお知らせします。"
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "ご質問やご意見がありましたら、%1$sTwitter%4$sまたは%2$sFacebookグループ%4$sに投稿してください。また、%3$s弊社のニュースレターにご登録%4$sいただくと、CoBlocksの最新情報や今後の予定をチェックできます。"
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"ご質問やご意見がありましたら、%1$sTwitter%4$sまたは%2$sFacebookグループ%4$sに"
+"投稿してください。また、%3$s弊社のニュースレターにご登録%4$sいただくと、"
+"CoBlocksの最新情報や今後の予定をチェックできます。"
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "どうぞお楽しみください！"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "ここからCoBlocksを始めましょう："
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4501,27 @@ msgstr "スパムからフォームを守るGoogle reCAPTCHAのサイトキー"
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "スパムからフォームを守るGoogle reCAPTCHAの秘密キー"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "名前"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "名"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "姓"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "メッセージ"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "送信"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "メッセージを送信しました："
 
@@ -3490,3 +4536,87 @@ msgstr "LinkedInでシェア"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "アラートタイプ"
+
+#~ msgid "Edit image"
+#~ msgstr "画像を編集"
+
+#~ msgid "Remove image"
+#~ msgstr "画像を削除"
+
+#~ msgid "Heading..."
+#~ msgstr "見出し..."
+
+#~ msgid "Author Name"
+#~ msgstr "作成者名"
+
+#~ msgid "Write biography..."
+#~ msgstr "経歴を入力..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "作成者の経歴を追加します。"
+
+#~ msgid "%s Settings"
+#~ msgstr "%s設定"
+
+#~ msgid "Caption Color"
+#~ msgstr "キャプション色"
+
+#~ msgid "Highlight text."
+#~ msgstr "テキストを強調表示します。"
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%sテーブル"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "価格表設定"
+
+#~ msgid "Tables"
+#~ msgstr "テーブル"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "価格表ブロック内のカラムです。"
+
+#~ msgid "Sepia"
+#~ msgstr "セピア"
+
+#~ msgid "Dim"
+#~ msgstr "淡色"
+
+#~ msgid "Vintage"
+#~ msgstr "ビンテージ"
+
+#~ msgid "Select Orientation"
+#~ msgstr "向きを選択"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "このブロックでは上部のマージンが削除されます。"
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "切り替えると、このブロックの上部にできるマージンをすべて削除します。"
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "このブロックでは下部のマージンが削除されます。"
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "切り替えると、このブロックの下部にできるマージンをすべて削除します。"
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "プライマリアクションを追加..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "セカンダリアクションを追加..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "標準"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "ここからCoBlocksを始めましょう："

--- a/languages/coblocks-ko_KR.po
+++ b/languages/coblocks-ko_KR.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "열기 표시"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "아코디언 제목 추가..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "아코디언 항목"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "아코디언에 접을 수 있는 아코디언 항목을 추가합니다."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "탭"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "자주 묻는 질문(FAQ)"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "이 아코디언 항목을 기본값으로 열려 있도록 설정하려
 msgid "Accordion Item Settings"
 msgstr "아코디언 항목 설정"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "열기 표시"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "색 설정"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "배경색"
@@ -103,14 +63,6 @@ msgstr "배경색"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "제목 텍스트 색"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "아코디언 항목 추가"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "아코디언"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -129,140 +81,79 @@ msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
 msgstr "JavaScript 보충 기능을 로드하여 Internet Explorer 지원을 추가합니다."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "이 페이지에서 JavaScript 보충 기능을 로드하여 Internet Explorer를 지원합니다."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"이 페이지에서 JavaScript 보충 기능을 로드하여 Internet Explorer를 지원합니다."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "경고"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "오류"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "알림 유형"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "기본"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "정보"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "성공"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "제목 쓰기..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "텍스트 쓰기..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "알림"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "상황별 피드백 메시지를 제공합니다."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "공지"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "메시지"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "텍스트 색"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "이미지 편집"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "갤러리 편집"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "이미지 제거"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "캡션 쓰기..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "아바타로 추가하려면 마우스 놓기"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "머리글..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "작성자 이름"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "소개 쓰기..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "양식 설정"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "작성자"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"함께 사용하는 여러 버튼을 통해 작업을 수행하도록 방문자에게 메시지를 표시합니"
+"다."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "작성자 소개를 추가합니다."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "소개"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "프로필"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "버튼"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "함께 사용하는 여러 버튼을 통해 작업을 수행하도록 방문자에게 메시지를 표시합니다."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "링크"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "버튼 설정"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "모바일에서 스택"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +171,25 @@ msgstr "Twitter 사용자 이름"
 msgid "Username"
 msgstr "사용자 이름"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "버튼 추가..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "트윗할 인용 추가..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "트윗하려면 클릭"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Twitter를 통해 독자들에게 트윗할 인용을 추가합니다."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "공유"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "Twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +197,18 @@ msgid "Text Settings"
 msgstr "텍스트 설정"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "버튼 색"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynamic HR(구분선)"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "다른 블록 사이에 크기 조정이 가능한 공백을 추가합니다."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "공백"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "동적 HR 설정"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "높이(픽셀)"
 
@@ -347,17 +220,12 @@ msgstr "동적 구분 요소의 높이(픽셀 단위)입니다."
 msgid "Color"
 msgstr "색상"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "배경으로 추가"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "기능"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "상위 기능 블록 내의 단일 하위 열."
 
@@ -366,73 +234,54 @@ msgid "Feature Settings"
 msgstr "기능 설정"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "안쪽 여백"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "기능"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "귀하의 제품 또는 서비스에 대한 간단한 노트를 최대 3열까지 추가합니다."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "서비스"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "여백"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "제본용 여백"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "각 열 사이의 공간입니다."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "작게"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "보통"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +291,8 @@ msgstr "크게"
 msgid "Features Settings"
 msgstr "기능 설정"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "열"
 
@@ -455,76 +304,72 @@ msgstr "메뉴 섹션 추가"
 msgid "Menu title..."
 msgstr "메뉴 제목..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "그리드"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "목록"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "대치할 이미지 놓기"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "이미지 제거"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "제목 추가..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "매콤한 음식"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "매운 음식"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "채식"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "글루텐 프리"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "해산물 채식"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "완전 채식"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "설명 추가..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0.00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "식품"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "식품 및 음료 블록의 식품 및 음료 항목."
 
@@ -560,62 +405,46 @@ msgstr "이 항목의 가격을 표시하려면 토글합니다."
 msgid "Item Attributes"
 msgstr "항목 속성"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "더 매콤한 음식"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "이미지 설정"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "대체 텍스트"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "이미지의 목적 설명"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "장식용 이미지일 뿐인 경우 빈 곳으로 남겨 둡니다."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "초점"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "식품 및 음료"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "메뉴 또는 가격 목록을 표시합니다."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "음식점"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "메뉴"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "스타일"
@@ -648,134 +477,86 @@ msgstr "각 항목의 가격을 표시합니다."
 msgid "Toggle to show the price of each item."
 msgstr "각 항목의 가격을 표시하려면 토글합니다."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "이메일"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "전자메일"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "메일"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "이메일 주소 필드."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "메시지"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "텍스트 영역"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "여러 줄 텍스트"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "더 긴 응답을 위한 텍스트 상자."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "‌‌%s은(는) 올바른 이메일 주소가 아닙니다."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "‌‌%s 및 %s은(는) 올바른 이메일 주소가 아닙니다."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "‌‌%s은(는) 올바른 이메일 주소가 아닙니다."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "이메일 주소"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "제목"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "양식 설정"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "스팸으로부터 귀하의 양식을 보호하도록 reCAPTCHA 사이트 및 비밀 키를 추가합니다."
+msgstr ""
+"스팸으로부터 귀하의 양식을 보호하도록 reCAPTCHA 사이트 및 비밀 키를 추가합니"
+"다."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "키 생성"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "나의 키"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "지원 받기"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "사이트 키"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "비밀 키"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "저장하기"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "저장"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "제거"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "이름"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "성"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "이름"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "이름 텍스트 필드."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "이메일 주소 필드."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "레이블 추가..."
 
@@ -783,41 +564,38 @@ msgstr "레이블 추가..."
 msgid "Required"
 msgstr "요청됨"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "이름 필드 설정"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "성"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "이름 및 성 필드 모두 표시합니다."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "성 필드를 추가하려면 토글합니다."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "양식"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "이름 텍스트 필드."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "더 긴 응답을 위한 텍스트 상자."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "페이지에 간단한 양식을 추가합니다."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "이메일"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "정보"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "연락처"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "제목"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +605,218 @@ msgstr "텍스트 추가..."
 msgid "Button Text Color"
 msgstr "버튼 텍스트 색"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "갤러리 편집"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "회전식"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "갤러리 이미지 %2$d개 중 %1$d개"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "캡션 쓰기..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "회전식"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "아름다운 회전식 갤러리에서 여러 개의 이미지를 표시합니다."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "갤러리"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "사진"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s 설정"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "줄 높이"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "점선 탐색 화살표를 표시합니다."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "미디어 캡션을 표시하려면 토글합니다."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "색 설정"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "크기"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "둥근 모서리"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "캡션 색"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "적용"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "석조"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "설명 쓰기..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "잘 정리된 석조 갤러리에 여러 이미지를 표시합니다."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "아름다운 회전식 갤러리에서 여러 개의 이미지를 표시합니다."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "열 크기"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "이미지 설정"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "갤러리 항목에 둥근 모서리를 추가합니다."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "그림자"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "캡션"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "캡션 스타일"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "각 미디어 항목마다 캡션을 표시합니다."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "미디어 캡션을 표시하려면 토글합니다."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "석조"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "잘 정리된 석조 갤러리에 여러 이미지를 표시합니다."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "지도 제어 옵션을 설정하려면 토글합니다."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "지도 설정"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "열 크기"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "갤러리 항목에 둥근 모서리를 추가합니다."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "라이트"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "쌓기"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "열이 한 개만 쌓여 있는 갤러리에 여러 이미지를 표시합니다."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "전체 너비 이미지"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "전체 너비 이미지"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "상자 그림자"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "전체 너비 이미지가 설정되었습니다."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "사용할 수 있는 갤러리 영역을 전체 너비 이미지로 완전히 채우려면 토글합니다."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"사용할 수 있는 갤러리 영역을 전체 너비 이미지로 완전히 채우려면 토글합니다."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "항목 설정"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "전체 너비 이미지"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "전체 너비 이미지"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "GIF 제거"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "이 GIF에는 비어 있는 alt 특성이 있습니다."
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Giphy에서 딱 맞는 GIF 검색"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "GIF 검색"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "GIF를 마음껏 선택하세요."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "애니메이션"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +842,11 @@ msgstr "GitHub 파일"
 msgid "File"
 msgstr "파일"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "GitHub에서 이 gist 보기"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "gist URL"
 
@@ -1024,12 +859,9 @@ msgid "Loading Gist"
 msgstr "gist 로드 중"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "gist 링크를 추가하여 GitHub gist를 포함합니다."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "코드"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +884,157 @@ msgid "Gist Meta"
 msgstr "gist 메타"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "레이아웃 변경"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "%s에 배경 추가"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
-
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
 msgstr "적은 양의 텍스트 및 콜투액션이 있는 페이지의 소개 영역입니다."
 
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "버튼"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "콜투액션"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "콘텐츠 너비(픽셀)"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "‌‌Hero 설정"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "컨테이너 내부 공간입니다."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "왼쪽 상단"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "가운데 상단"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "오른쪽 상단"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "왼쪽 중앙"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "가운데 중앙"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "오른쪽 중앙"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "왼쪽 하단"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "가운데 하단"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "오른쪽 하단"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "하이라이트 텍스트"
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "하이라이트"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "텍스트를 강조 표시합니다."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "텍스트"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "단락"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "아이콘"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "좀 더 폭넓은 소통을 하려면 양식화된 그래픽 기호를 추가합니다."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "아이콘"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "매우 크게"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "좀 더 폭넓은 소통을 하려면 양식화된 그래픽 기호를 추가합니다."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "아이콘 설정"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "고급 %s 설정 끄기"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "재설정"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "사용자 지정 %s 크기"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "고급 %s 설정"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "사용자 정의"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "고급"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "반지름"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "아이콘 검색"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "결과가 없습니다."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "링크 설정"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "링크 URL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "링크 관계"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "새 탭에서 여는 중"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "새 탭에서 열기"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "아이콘 색"
 
@@ -1261,30 +1043,19 @@ msgid "Edit logos"
 msgstr "로고 편집"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "로고 및 배지"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "이미지를 드래그하거나, 새로운 파일을 업로드하거나, 귀하의 라이브러리에서 파일을 선택합니다."
+msgstr ""
+"이미지를 드래그하거나, 새로운 파일을 업로드하거나, 귀하의 라이브러리에서 파일"
+"을 선택합니다."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "신뢰를 구축하려면 로고, 배지 또는 인증서를 추가합니다."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "고객"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "증명"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "사용 소감"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1077,138 @@ msgstr "위치 편집"
 msgid "Map style"
 msgstr "지도 스타일"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "잘못된 API 키 또는 너무 많은 요청"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google 지도"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "Google 지도에 핀을 고정하려면 위치 또는 주소를 입력합니다."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "장소 또는 주소 검색..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "적용"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "지도"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "주소를 추가하고 Google 지도에 핀을 고정합니다."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "주소"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "지도"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "Google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "지도 스타일 선택"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "지도 설정"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "확대/축소 수준"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "지도 높이(픽셀)"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "확대/축소 수준"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "표식 크기"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "세부 제어 옵션이 설정되었습니다."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "지도 제어 옵션을 설정하려면 토글합니다."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "지도 제어"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "지도 유형"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "표준 및 위성 지도 보기 사이의 전환이 설정되었습니다."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "표준 및 위성 지도 사이의 전환을 설정하려면 토글합니다."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "확대/축소 제어"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "지도 확대/축소 제어를 표시합니다."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "확대/축소 제어가 있는 지도에서 확대 및 축소를 설정하려면 토글합니다."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "스트리트 뷰"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "스트리트 뷰 지도 제어를 표시합니다."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "오른쪽 하단에 스트리트 뷰 제어를 표시하려면 토글합니다."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "전체 화면 토글"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "전체 화면 지도 제어를 표시합니다."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "전체 화면 지도 제어를 표시하려면 토글합니다."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google 지도 API 키"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "귀하의 Google 지도 API 키를 추가합니다. 이 API 키를 업데이트하면 귀하의 모든 지도가 새 키를 사용하도록 설정합니다."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"귀하의 Google 지도 API 키를 추가합니다. 이 API 키를 업데이트하면 귀하의 모든 "
+"지도가 새 키를 사용하도록 설정합니다."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "키 검색"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "도움이 필요하신가요?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Google API 키 입력..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "저장됨"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "표준"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "실버"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "레트로"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "다크"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "밤"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "보라빛"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1218,9 @@ msgstr "오른쪽에 미디어"
 msgid "Media on left"
 msgstr "왼쪽에 미디어"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "미디어 카드"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "오프셋 카드와 나란히 이미지 또는 비디오를 추가합니다."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "이미지"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "비디오"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1234,18 @@ msgstr "카드 그림자를 표시합니다."
 msgid "Toggle to add a card shadow."
 msgstr "카드 그림자를 추가하려면 토글합니다."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s 그림자"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "%s 그림자를 표시합니다."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "%s 그림자를 추가하려면 토글합니다."
 
@@ -1545,40 +1269,171 @@ msgstr "미디어를 교체하려면 마우스 놓기"
 msgid "Edit media"
 msgstr "미디어 편집"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s 표"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "gist URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "플랜 %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "회전식"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "gist URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "색 설정"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "이 항목의 가격을 표시합니다."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "gist 메타데이터를 표시하려면 토글합니다."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "콜투액션 버튼을 표시합니다."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "gist 메타데이터를 표시하려면 토글합니다."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "기능 설정"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "왼쪽에 미디어"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "오른쪽에 미디어"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "열 크기"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "‌‌gist 설정"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "가격표"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "가격표"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "가격표"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "가격표"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "가격표를 추가합니다."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "랜딩"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "플랜 %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "비교"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "가격표 설정"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "표"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1451,171 @@ msgstr "플랜 A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "가격표 항목"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "가격표 블록 내에 있는 열입니다."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "%s에 배경 추가"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "열"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "직속 하위 열입니다."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "너비"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "열 설정"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "컨테이너 주변의 공간입니다."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "너비"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "레이아웃 변경"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "1"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "2"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "3"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "4"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "%s에 배경 추가"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "열 1개"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "열 2개"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "열 3개"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "열 4개"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "행 레이아웃"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "행"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "이제 이 %s 열 행의 레이아웃을 선택합니다."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "이 행의 열 수를 선택합니다."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "행 열 선택"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "행 레이아웃 선택"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "열로 돌아가기"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "열 블록의 구조화된 래퍼를 추가한 다음 해당 열에 원하는 콘텐츠 블록을 추가합니다."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"열 블록의 구조화된 래퍼를 추가한 다음 해당 열에 원하는 콘텐츠 블록을 추가합니"
+"다."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "행"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "열"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "레이아웃"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "레이아웃"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "‌행 설정"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "없음"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1625,9 @@ msgstr "정방형"
 msgid "Circle"
 msgstr "원"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "서비스"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "표시할 서비스의 열을 최대 4개까지 추가합니다."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "기능"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1649,7 @@ msgstr "콜투액션 버튼을 표시합니다."
 msgid "Toggle to show call to action buttons."
 msgstr "콜투액션 버튼을 표시하려면 토글합니다."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "서비스"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "서비스 블록 내의 단일 서비스 항목입니다."
 
@@ -1785,264 +1670,227 @@ msgid "Toggle to show a call to action button."
 msgstr "콜투액션 버튼을 표시하려면 토글합니다."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "좌우로 뒤집기"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "상하로 뒤집기"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "도형 구분선"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "페이지 섹션을 시각적으로 구분하려면 도형 구분선을 추가합니다."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "구분 요소"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "도형 색상"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "구분선 설정"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "도형 높이(픽셀)"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "배경 높이(픽셀)"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "방향"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "도형 색상"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Twitter에 공유"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Facebook에 공유"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Twitter에 공유"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Pinterest에 공유"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "LinkedIn에 공유"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "이메일을 통한 공유"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Tumblr에 공유"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Google에 공유"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Reddit에 공유"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "공유"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "소셜"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
 msgstr "좋아요를 받고 공유하려면 소셜 공유 링크를 추가합니다."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "소셜 색상"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "아이콘 크기"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "원 크기"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "버튼 크기"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "아이콘"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "이메일"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "공유 버튼 색상이 설정되었습니다."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
 msgstr "각각의 소셜 미디어 플랫폼에서 공식 색상을 사용하려면 토글합니다."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "소셜 색상"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Facebook 프로필 추가"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Twitter 프로필 추가"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Instagram 프로필 추가"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Pinterest 프로필 추가"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "LinkedIn 프로필 추가"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "YouTube 프로필 추가"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Yelp 프로필 추가"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Houzz 프로필 추가"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "소셜 프로필"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "링크"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "소셜 미디어 프로필에 링크를 표시합니다."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "프로필 링크"
 
@@ -2057,18 +1905,6 @@ msgstr "배경 제거"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "배경"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "자동"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "커버"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "포함"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1962,6 @@ msgstr "배경 제거"
 msgid "Remove "
 msgstr "제거 "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "반복하지 않음"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "가로로 반복"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "세로로 반복"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "이미지 뒤로 이동"
@@ -2150,17 +1974,14 @@ msgstr "이미지 앞으로 이동"
 msgid "Link To"
 msgstr "링크 대상:"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s 갤러리"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "이미지 업로드"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "라이트"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +1995,110 @@ msgstr "첨부 페이지"
 msgid "Custom URL"
 msgstr "사용자 지정 URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "픽셀"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "방향"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "백분율"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "재설정"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "단위 선택"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s 단위"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "고급 %s 설정 끄기"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s 상단"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s 오른쪽"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s 하단"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s 왼쪽"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "비동기화"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "동기화"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "동기화 단위"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "상단"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "오른쪽"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "하단"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "왼쪽"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "고급 %s 설정"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "고급"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "기본"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "레이아웃"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2117,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "전체 화면 모드를 설정하려면 토글합니다."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "머리글 %d"
@@ -2263,43 +2126,16 @@ msgstr "머리글 %d"
 msgid "Custom color picker"
 msgstr "사용자 지정 색 선택"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "원본"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "회색조"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "세피아"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "채도"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "흐리게"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "빈티지"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "필터 적용"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "방향 선택"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "높이"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "모바일 %s"
@@ -2333,7 +2169,8 @@ msgid "Five Seconds"
 msgstr "5초"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "6초"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2189,22 @@ msgstr "9초"
 msgid "Ten Seconds"
 msgstr "10초"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "화살표 탐색"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "점선 탐색"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "초"
@@ -2361,21 +2214,25 @@ msgid "second"
 msgstr "초"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "%1$d %2$s 후로 진행"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "다음 슬라이드로 자동 진행합니다."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "데스크톱 및 모바일 기기에서 드래그 및 터치 지원."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
 msgstr "데스크톱 및 모바일 기기에서 드래그 기능을 설정하려면 토글합니다."
 
 #: src/components/slider-panel/index.js:35
@@ -2387,44 +2244,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "슬라이드 탐색 화살표를 표시하려면 토글합니다."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "점선 탐색 화살표를 표시합니다."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "점선 탐색을 표시하려면 토글합니다."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "컨테이너 내부 공간입니다."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "비디오를 음소거하려면 토글합니다."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "비디오를 반복 재생하려면 토글합니다."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "슬라이더 설정"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "자동 재생"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "전환 속도"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "드래그 가능"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "화살표 탐색"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "점선 탐색"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "대문자로 시작"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "보통"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2331,6 @@ msgstr "하단 간격 없음"
 msgid "Change typography"
 msgstr "입력 체계 변경"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "굵게"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "대문자"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "소문자"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "모바일에서 스택"
@@ -2487,25 +2347,29 @@ msgstr "더 작은 뷰포트에서 상단에 있는 스택 요소가 서로 토�
 msgid "Remove Top Spacing"
 msgstr "상단 간격 제거"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "이 블록에서 상단 여백이 제거됩니다."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "카드 그림자를 추가하려면 토글합니다."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "이 블록의 상단에 적용된 여백을 제거하려면 토글합니다."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "점선 탐색을 표시하려면 토글합니다."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "하단 간격 제거"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "이 블록에서 하단 여백이 제거됩니다."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "카드 그림자를 추가하려면 토글합니다."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "이 블록의 하단에 적용된 여백을 제거하려면 토글합니다."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "점선 탐색을 표시하려면 토글합니다."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2383,14 @@ msgstr "전체 너비로 표시합니다."
 msgid "Toggle to display button as full width."
 msgstr "전체 너비로 버튼을 표시하려면 토글합니다."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "원형"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "‌‌Hero 설정"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "그림자"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "확인란"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "대문자"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2416,793 @@ msgstr "이 블록이 해당 페이지에 추가되며 현재 해제할 수 없�
 msgid "Disable all"
 msgstr "모두 사용 안 함"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "‘%s’ 블록을 찾을 수 없음."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s 갤러리"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "열기 표시"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "아코디언 제목 추가..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "아코디언 항목"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "탭"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "자주 묻는 질문(FAQ)"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "공지"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "메시지"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "소개"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "프로필"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "링크"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "공유"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "Twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "공백"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "서비스"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "메뉴"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "음식점"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "전자메일"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "메일"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "성"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "텍스트 영역"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "여러 줄 텍스트"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "이메일"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "정보"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "연락처"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "갤러리"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "사진"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "밤"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "애니메이션"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "코드"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "버튼"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "콜투액션"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "텍스트"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "단락"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "아이콘"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "고객"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "증명"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "사용 소감"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "주소"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "지도"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "Google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "이미지"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "비디오"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "주소"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "랜딩"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "비교"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "행"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "열"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "레이아웃"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "기능"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "구분 요소"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "소셜"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "링크"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "열기 표시"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "아코디언 항목 추가"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "아코디언"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "텍스트 쓰기..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "제목 쓰기..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "알림"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "작성자"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "버튼"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "트윗하려면 클릭"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynamic HR(구분선)"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "기능"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "기능"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "식품"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "식품 및 음료"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "이메일"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "이름"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "메시지"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "양식"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "회전식"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "석조"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "쌓기"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "gist URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "하이라이트"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "아이콘"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "로고 및 배지"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "지도"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "미디어 카드"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "회전식"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "가격표"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "가격표 항목"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "열"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "행"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "서비스"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "서비스"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "도형 구분선"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "공유"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "소셜 프로필"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "정보"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "성공"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "경고"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "오류"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "점"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "선"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "전체 너비"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "그리드"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "목록"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "기본"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "레이어"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "윤곽선"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "채워짐"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "쌓기"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "가로로 반복"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "물결선"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "언덕"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "물결"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "구부러짐"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "경사짐"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "둥근 모양"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "삼각형"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "뾰족한 모양"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "마스크"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "아이콘"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "텍스트"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "아이콘 및 텍스트"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "원형"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "왼쪽 하단"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "왼쪽 상단"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "아바타로 추가하려면 마우스 놓기"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "작성자"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3224,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "기능을 강조 표시할 때 사용할 수 있는 기능 블록입니다."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "Hero 머리글 추가..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "일반적으로 한 두 가지의 콜투액션이 수반되는 페이지의 소개 영역인 Hero 콘텐츠를 추가합니다."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"일반적으로 한 두 가지의 콜투액션이 수반되는 페이지의 소개 영역인 Hero 콘텐츠"
+"를 추가합니다."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "기본 작업 추가..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "보조 작업 추가..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3266,125 @@ msgstr "콘텐츠 추가..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "이 텍스트를 카드 이미지에 맞는 설명 문구로 대치합니다. 그런 다음 이 카드에 버튼, 목록 또는 이미지 등의 블록을 더 추가합니다."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"이 텍스트를 카드 이미지에 맞는 설명 문구로 대치합니다. 그런 다음 이 카드에 버"
+"튼, 목록 또는 이미지 등의 블록을 더 추가합니다."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "제목 쓰기..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "설명 쓰기..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "버튼 설정"
+
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "모바일에서 스택"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "동적 HR 설정"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "없음"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "없음"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "작게"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
 msgstr "보통"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "사용자 정의"
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "크게"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "아주 크게"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "없음"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "작게"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "보통"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "크게"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,8 +3903,11 @@ msgstr "음악 마이크 노래 아티스트 창조 미디어 오디오"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "마이크 팟캐스트 컴퓨터 기기 음악 마이크로폰 노래 아티스트 창조 미디어 오디오"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"마이크 팟캐스트 컴퓨터 기기 음악 마이크로폰 노래 아티스트 창조 미디어 오디오"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,7 +3931,9 @@ msgstr "필름 비디오 감독 프로듀서 미디어 창조"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
 msgstr "비디오 동영상 감독 프로듀서 비디어 창조 카메라 사진 작가 사진 조리개"
 
 #: src/blocks/icon/svgs.js:85
@@ -3302,12 +3951,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "팔레트 디자인 색상 아티스트 창조 미디어 페인트 브러시"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "표준"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "실버"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "레트로"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "다크"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "밤"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "보라빛"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "원형"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "그림자"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "기본"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "없음"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "확인란"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "메뉴 제목..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "작게"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "보통"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "크게"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "아주 크게"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "자동"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "커버"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "포함"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "왼쪽 상단"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "가운데 상단"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "오른쪽 상단"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "왼쪽 중앙"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "가운데 중앙"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "오른쪽 중앙"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "왼쪽 하단"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "가운데 하단"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "오른쪽 하단"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "반복하지 않음"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "반복"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "가로로 반복"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "세로로 반복"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "링크 관계"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "다크"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "라이트"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "없음"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "이미지"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "픽셀"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "백분율"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "원본"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "회색조"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "미디어 파일"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "채도"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "빈티지 필터"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "빈티지 필터"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "대문자로 시작"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "보통"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "굵게"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "기본"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "대문자"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "소문자"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4299,14 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks는 워드프레스 구텐베르그 블록 에디터의 전문 <strong>페이지 구축 콘텐츠 블록</strong> 제품군입니다. 당사 블록은 워드프레스에서 멋지고 풍부한 페이지를 만들 수 있도록 제작자에게 힘을 싣는 데 주안점을 둡니다."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks는 워드프레스 구텐베르그 블록 에디터의 전문 <strong>페이지 구축 콘텐"
+"츠 블록</strong> 제품군입니다. 당사 블록은 워드프레스에서 멋지고 풍부한 페이"
+"지를 만들 수 있도록 제작자에게 힘을 싣는 데 주안점을 둡니다."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4316,169 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "속임수인가요?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "리뷰 쓰기"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s년"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "1년"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s주"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "1주"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s일"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "1일"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s시간"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "1시간"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s분"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "1분"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s초"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "1초"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s 워드프레스 플러그인"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "%s이(가) 마음에 드시나요?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "귀하는 현재 %2$s 동안 %1$s을(를) 사용하고 있습니다. 리뷰를 남겨 귀하의 생각을 알려주시겠어요? 정말 감사합니다!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "리뷰 쓰기"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"귀하는 현재 %2$s 동안 %1$s을(를) 사용하고 있습니다. 리뷰를 남겨 귀하의 생각"
+"을 알려주시겠어요? 정말 감사합니다!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "감사하지만 필요 없습니다. / 이미 갖고 있습니다."
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "새로운 워드프레스 블록 에디터를 위한 프리미어 페이지 작성기인 CoBlocks를 선택해 주셔서 감사합니다."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"새로운 워드프레스 블록 에디터를 위한 프리미어 페이지 작성기인 CoBlocks를 선택"
+"해 주셔서 감사합니다."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "다양한 유용한 블롯 및 새로운 페이지 작성기 툴킷을 워드프레스 편집기에 추가했습니다. CoBlocks를 이용하면 %1$s다양한 블록%2$s, %1$s페이지 작성기 경험%2$s 및 %1$s사용자 지정 입력 체계 제어%2$s 등과 같은 획기적인 기능 모음을 사용할 수 있습니다."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"다양한 유용한 블롯 및 새로운 페이지 작성기 툴킷을 워드프레스 편집기에 추가했"
+"습니다. CoBlocks를 이용하면 %1$s다양한 블록%2$s, %1$s페이지 작성기 경험%2$s "
+"및 %1$s사용자 지정 입력 체계 제어%2$s 등과 같은 획기적인 기능 모음을 사용할 "
+"수 있습니다."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "시작하는 데 도움이 되는 몇 가지 비디오:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "%s을(를) 통해 첫 페이지를 만드는 방법 보기"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "첫 페이지 만드는 방법 보기"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "행 및 도형 구분선 블록 사용 방법 보기"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "미디어 카드 블록 사용 방법 보기"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "마음에 드시나요? %1$s저희 YouTube 채널을 구독%2$s해 주세요. 새로운 비디오 튜토리얼이 나오면 알려드리겠습니다."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"마음에 드시나요? %1$s저희 YouTube 채널을 구독%2$s해 주세요. 새로운 비디오 튜"
+"토리얼이 나오면 알려드리겠습니다."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "문의 사항이나 피드백이 있는 경우, %1$sTwitter%4$s 또는 저희 %2$sFacebook 그룹%4$s을 통해 알려주세요. 또한, 새로운 소식 및 예정된 이벤트를 비롯한 최신 소식을 받으려면 %3$s당사 뉴스레터를 구독%4$s하시기 바랍니다."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"문의 사항이나 피드백이 있는 경우, %1$sTwitter%4$s 또는 저희 %2$sFacebook 그"
+"룹%4$s을 통해 알려주세요. 또한, 새로운 소식 및 예정된 이벤트를 비롯한 최신 소"
+"식을 받으려면 %3$s당사 뉴스레터를 구독%4$s하시기 바랍니다."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "혜택을 누리세요!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "여기에서 CoBlocks를 시작해 보세요."
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4492,27 @@ msgstr "스팸 방지 양식을 위한 Google reCAPTCHA 사이트 키"
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "스팸 방지 양식을 위한 Google reCAPTCHA 비밀 키"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "이름"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "이름"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "성"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "메시지"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "제출"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "메시지가 전송됨:"
 
@@ -3490,3 +4527,85 @@ msgstr "LinkedIn에 공유하기"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "알림 유형"
+
+#~ msgid "Edit image"
+#~ msgstr "이미지 편집"
+
+#~ msgid "Remove image"
+#~ msgstr "이미지 제거"
+
+#~ msgid "Heading..."
+#~ msgstr "머리글..."
+
+#~ msgid "Author Name"
+#~ msgstr "작성자 이름"
+
+#~ msgid "Write biography..."
+#~ msgstr "소개 쓰기..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "작성자 소개를 추가합니다."
+
+#~ msgid "%s Settings"
+#~ msgstr "%s 설정"
+
+#~ msgid "Caption Color"
+#~ msgstr "캡션 색"
+
+#~ msgid "Highlight text."
+#~ msgstr "텍스트를 강조 표시합니다."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s 표"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "가격표 설정"
+
+#~ msgid "Tables"
+#~ msgstr "표"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "가격표 블록 내에 있는 열입니다."
+
+#~ msgid "Sepia"
+#~ msgstr "세피아"
+
+#~ msgid "Dim"
+#~ msgstr "흐리게"
+
+#~ msgid "Vintage"
+#~ msgstr "빈티지"
+
+#~ msgid "Select Orientation"
+#~ msgstr "방향 선택"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "이 블록에서 상단 여백이 제거됩니다."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "이 블록의 상단에 적용된 여백을 제거하려면 토글합니다."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "이 블록에서 하단 여백이 제거됩니다."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "이 블록의 하단에 적용된 여백을 제거하려면 토글합니다."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "기본 작업 추가..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "보조 작업 추가..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "보통"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "여기에서 CoBlocks를 시작해 보세요."

--- a/languages/coblocks-mr.po
+++ b/languages/coblocks-mr.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "प्रदर्शित उघडा"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "एकॉर्डियन शीर्षक जोडा..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "एकॉर्डियन आयटम"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "संकुचित करण्यायोग्य एकॉर्डियन आयटम एकॉर्डियनला जोडा."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "टॅब"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "वारंवार विचारले जाणारे प्रश्न"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "डिफॉल्टनुसार उघडले गेलेले 
 msgid "Accordion Item Settings"
 msgstr "एकॉर्डियन आयटम सेटींग"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "प्रदर्शित उघडा"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "रंग सेटींग"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "पार्श्वभूमी रंग"
@@ -103,14 +63,6 @@ msgstr "पार्श्वभूमी रंग"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "मुख्य मजकूर रंग"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "एकॉर्डियन आयटम जोडा"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "एकॉर्डियन"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -129,140 +81,78 @@ msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
 msgstr "JavaScript polyfill लोड करून इंटरनेट एक्सप्लोररसाठी समर्थन जोडा."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
 msgstr "JavaScript polyfill या पृष्ठावर लोड करून इंटरनेट एक्सप्लोररला समर्थन करा."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "चेतावणी"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "त्रुटी"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "सतर्कता प्रकार"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "डिफॉल्ट"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "माहिती"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "यशस्वी"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "शीर्षक लिहा..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "मजकूर लिहा..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "सतर्कता"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "संदर्भ अभिप्राय संदेश प्रदान करा."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "सूचना"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "संदेश"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "मजकूर रंग"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "प्रतिमा संपादित करा"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "गॅलरी संपादित करा"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "प्रतिमा काढून टाका"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "शीर्षक लिहा..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "अवतारप्रमाणे जोडण्यासाठी सोडून द्या"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "शीर्षक..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "\nलेखकाचे नाव"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "जीवनचरित्र लिहा..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "फॉर्म सेटिंग"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "लेखक"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"\n"
+"एकाधिक बटणांसह, अभ्यागतांना कृती करण्यास प्रवृत्त करा."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "लेखकाचे जीवनचरित्र जोडा."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "जीवनचरित्र"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "प्रोफाइल"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "बटणे"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "\nएकाधिक बटणांसह, अभ्यागतांना कृती करण्यास प्रवृत्त करा."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "लिंक"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "बटण सेटिंग"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "मोबाइलवरील स्टॅक"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -270,7 +160,9 @@ msgstr "मोबाइलवरील स्टॅकींग बटणे."
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Toggle to stack buttons on mobile."
-msgstr "\nमोबाइलवर बटणे स्टॅक करण्यासाठी टॉगल करा."
+msgstr ""
+"\n"
+"मोबाइलवर बटणे स्टॅक करण्यासाठी टॉगल करा."
 
 #: src/blocks/click-to-tweet/controls.js:44
 msgid "Twitter Username"
@@ -280,31 +172,25 @@ msgstr "Twitter वापरकर्तानाव"
 msgid "Username"
 msgstr "वापरकर्तानाव"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "बटण जोडा..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "ट्वीट करण्यासाठी कोट जोडा..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "ट्वीटवर क्लिक करा"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Twitter द्वारे ट्वीट करताना वाचकांसाठी कोट जोडा."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "सामायिक करा"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +198,18 @@ msgid "Text Settings"
 msgstr "मजकूर सेटिंग"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "बटण रंग"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "डायनॅमिक एचआर"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "इतर ब्लॉक्समध्ये आकार बदलणारा स्पेसर जोडा."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "स्पेसर"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "डायनॅमिक एचआर सेटिंग"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "पिक्सेल्स मध्ये उंची"
 
@@ -347,17 +221,12 @@ msgstr "पिक्सेल्स मधील डायनॅमिक वि
 msgid "Color"
 msgstr "रंग"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "पार्श्वभूमी म्हणून जोडा"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "वैशिष्ट्य"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "पालक वैशिष्ट्ये ब्लॉकमधील एकल मुलाचा स्तंभ."
 
@@ -366,73 +235,54 @@ msgid "Feature Settings"
 msgstr "वैशिष्ट्य सेटिंग"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "पॅ‍डिंग"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "वैशिष्ट्ये"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "आपले उत्पादन किंवा सेवांसाठी लहान नोंदी असलेले तीन स्तंभ जोडा."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "सेवा"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "समास"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "समोरासमोरील पृष्ठांमधील कोरी जागा"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "प्रत्येक स्तंभामधील जागा."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "लहान"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "मध्यम"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +292,8 @@ msgstr "मोठे"
 msgid "Features Settings"
 msgstr "वैशिष्ट्ये सेटिंग"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "स्तंभ"
 
@@ -455,76 +305,74 @@ msgstr "मेनू विभाग जोडा"
 msgid "Menu title..."
 msgstr "मेनू शीर्षक..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "ग्रिड"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "सूची"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "पुनर्स्थित करण्यासाठी प्रतिमा सोडून द्या"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "प्रतिमा काढून टाका"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "शीर्षक जोडा..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "मसालेदार"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "गरम"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "शाकाहारी"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "ग्लूटेन मुक्त"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "पेस्कॅटेरियन"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "वेगन"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
-msgstr "\nवर्णन जोडा..."
+msgstr ""
+"\n"
+"वर्णन जोडा..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0.00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "खाद्यपदार्थ"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "खाद्यपदार्थ आणि पेय ब्लॉकमधील खाद्यपदार्थ आणि पेय."
 
@@ -560,62 +408,46 @@ msgstr "या आयटमसाठी किंमत दाखवण्या
 msgid "Item Attributes"
 msgstr "आयटम गुणधर्म"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "मसालेदार"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "प्रतिमा सेटिंग"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Alt Text (Alternative Text)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "प्रतिमेचा उद्देश स्पष्ट करा"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "प्रतिमा संपूर्णपणे सजावट केलेली असल्यास रिक्त सोडा."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "केंद्र बिंदू"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "खाद्यपदार्थ आणि पेय"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "आपला मेनु किंवा किंमत सूची प्रदर्शित करा."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "रेस्टॉरंट"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "मेनु"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "शैली"
@@ -648,134 +480,88 @@ msgstr "प्रत्येक आयटमची किंमत दाखव
 msgid "Toggle to show the price of each item."
 msgstr "या आयटमसाठी किंमत दाखवण्याकरिता टॉगल करा."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "ईमेल"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "ई-मेल"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "मेल"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "ईमेल पत्ता फील्ड"
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "संदेश"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "मजकूरक्षेत्र"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "अनेक ओळीचा मजकूर"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "विस्तारित प्रतिसादसाठी मजकूर बॉक्स"
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "‌‌%s वैध ईमेल पत्ता नाही."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s आणि %s वैध ईमेल पत्ते नाहीत."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "‌‌%s वैध ईमेल पत्ते नाहीत."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "ईमेल पत्ता"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "विषय"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "फॉर्म सेटिंग"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "\nआपला फॉर्म स्पॅमपासून संरक्षित करण्यासाठी आपली reCAPTCHA साइट आणि गोपनीय की जोडा."
+msgstr ""
+"\n"
+"आपला फॉर्म स्पॅमपासून संरक्षित करण्यासाठी आपली reCAPTCHA साइट आणि गोपनीय की जोडा."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
-msgstr "\nकी व्युत्पन्न करा"
+msgstr ""
+"\n"
+"की व्युत्पन्न करा"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "माझ्या की"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "मदत मिळवा"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "साइट की"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "गुप्त की"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "जतन करत आहे"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "जतन करा"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "काढून टाका"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "पहिले"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "शेवटचे"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "नाव"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "\nनावांसाठी मजकूर फील्ड."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "ईमेल पत्ता फील्ड"
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "लेबल जोडा..."
 
@@ -783,41 +569,40 @@ msgstr "लेबल जोडा..."
 msgid "Required"
 msgstr "आवश्यक"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "नाव फील्ड सेटिंग"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "आडनाव"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "नाव आणि आडनाव फील्ड दाखवत आहे."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "आडनाव फील्ड जोडण्याकरिता टॉगल करा."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "फॉर्म"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr ""
+"\n"
+"नावांसाठी मजकूर फील्ड."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "विस्तारित प्रतिसादसाठी मजकूर बॉक्स"
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "आपल्या पृष्ठावर साधा फॉर्म जोडा."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "ईमेल"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "विषयी"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "संपर्क"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "विषय"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +612,219 @@ msgstr "मजकूर जोडा..."
 msgid "Button Text Color"
 msgstr "बटण मजकूर रंग"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "गॅलरी संपादित करा"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "करोसेल"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "गॅलरीमध्ये %2$d पैकी%1$d प्रतिमा"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "शीर्षक लिहा..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "करोसेल"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "चांगल्या करोसेल गॅलरीमध्ये एकाधिक प्रतिमा प्रदर्शित करा."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "गॅलरी"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "फोटो"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s सेटिंग"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "रेषेची उंची"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "डॉट नेव्हिगेशन बाण दाखवत आहे."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "मीडिया शीर्षक दाखवण्यासाठी टॉगल करा."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "रंग सेटींग"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "आकारमान"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "गोल कोपरे"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "शीर्षक रंग"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "लागू करा"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "रचना"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr ""
+"\n"
+"वर्णन लिहा..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "रचना केलेल्या आयोजित गॅलरीमध्ये एकाधिक प्रतिमा प्रदर्शित करा."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "चांगल्या करोसेल गॅलरीमध्ये एकाधिक प्रतिमा प्रदर्शित करा."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "स्तंभ आकार"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "प्रतिमा सेटिंग"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "गॅलरी आयटमला गोल कोपरे जोडा."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "सावली"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "शीर्षक"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "शीर्षक शैली"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "प्रत्येक मीडिया आयटमसाठी शीर्षक दाखवत आहे."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "मीडिया शीर्षक दाखवण्यासाठी टॉगल करा."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "रचना"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "रचना केलेल्या आयोजित गॅलरीमध्ये एकाधिक प्रतिमा प्रदर्शित करा."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "नकाशा नियंत्रण पर्यायांना सक्षम करण्याकरिता टॉगल करा."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "‌‌नकाशा सेटिंग"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "स्तंभ आकार"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "गॅलरी आयटमला गोल कोपरे जोडा."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "प्रकाश"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "रचलेला"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "एकच स्तंभ रचलेल्या गॅलरीमध्ये एकाधिक प्रतिमा प्रदर्शित करा."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "पूर्ण रूंदी प्रतिमा"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "पूर्ण रूंदी प्रतिमा"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "बॉक्सची सावली"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "पूर्ण रूंदी प्रतिमा सक्षम आहेत."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
 msgstr "उपलब्ध असलेले गॅलरी क्षेत्र पूर्णपणे पूर्ण रूंदी प्रतिमांसह भरण्यासाठी टॉगल करा."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "आयटम सेटींग"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "पूर्ण रूंदी प्रतिमा"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "पूर्ण रूंदी प्रतिमा"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "gif काढा"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "या gif मध्ये alt गुणधर्म आहेत"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Giphy वर त्यासाठीची योग्य gif शोधा"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "gifs साठी शोधा"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "gif निवडा, कोणतीही gif"
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "अॅनिमेटेड"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +850,11 @@ msgstr "GitHub फाइल"
 msgid "File"
 msgstr "फाइल"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "हे gist GitHub वर पहा"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist URL"
 
@@ -1024,12 +867,9 @@ msgid "Loading Gist"
 msgstr "Gist लोड होत आहे"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "gist लिंक जोडून GitHub gists एम्बेड करा."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "कोड"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +892,163 @@ msgid "Gist Meta"
 msgstr "Gist मेटा"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "लेआउट बदला"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "%s च्या पार्श्वभूमीत जोडा"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "हिरो"
-
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
 msgstr "पृष्ठाचे प्रास्तविक क्षेत्र हे लहान मजकूर आणि कॉल टू अॅक्शन सह आहे."
 
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "बटण"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "कॉल टु अॅक्शन"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "सामग्रीची रूंदी पिक्सेल्समध्ये"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "हिरो सेटिंग"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "कंटेनरच्या आतील जागा"
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "शीर्षकडून डावीकडे"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "शीर्ष मध्य"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "शीर्षकडून उजवीकडे"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "मध्याकडून डावीकडे"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "मध्य मध्य"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "मध्याकडून उजवीकडे"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "तळाकडून डावीकडे"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "तळाकडून मध्य"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "तळाकडून उजवीकडे"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
-msgstr "\nहायलाइट केलेला मजकूर जोडा..."
+msgstr ""
+"\n"
+"हायलाइट केलेला मजकूर जोडा..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "हायलाइट"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "हायलाइट केलेला मजकूर."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "मजकूर"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "परिच्छेद"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "आयकॉन"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "\nकाहीतरी अधिक संप्रेषण करण्यासाठी एक शैलीकृत ग्राफिक चिन्ह जोडा."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "आयकॉन्स"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "खूप मोठे"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr ""
+"\n"
+"काहीतरी अधिक संप्रेषण करण्यासाठी एक शैलीकृत ग्राफिक चिन्ह जोडा."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "आयकॉन सेटिंग"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "%s प्रगत सेटिंग्ज बंद करा"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "रिसेट करा"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "सानुकूल %s आकार"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "प्रगत %s सेटिंग"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "सानुकूल"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "प्रगत"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
-msgstr "\nत्रिज्या"
+msgstr ""
+"\n"
+"त्रिज्या"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "आयकॉन शोध"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "कोणतेही परिणाम आढळले नाहीत."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "लिंक सेटिंग"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "लिंक URL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "लिंक Rel"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "नवीन टॅबमध्ये उघडत आहे"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "नवीन टॅबमध्ये उघडा"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "आयकॉन रंग"
 
@@ -1261,30 +1057,19 @@ msgid "Edit logos"
 msgstr "लोगो संपादित करा"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "लोगो आणि बिल्ले"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "\nप्रतिमा ड्रॅग करा, नवीन अपलोड करा किंवा आपल्या ग्रंथालयातून फायली निवडा."
+msgstr ""
+"\n"
+"प्रतिमा ड्रॅग करा, नवीन अपलोड करा किंवा आपल्या ग्रंथालयातून फायली निवडा."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "लोगो, बिल्ले किंवा विश्वासार्हता निर्माण करण्यासाठी प्रमाणपत्रे जोडा."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "क्लाएंट्स"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "पुरावा"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "प्रशंसापत्रे"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1091,148 @@ msgstr "स्थान संपादित करा"
 msgid "Map style"
 msgstr "नकाशा शैली"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "अवैध API की किंवा बर्‍याच विनंत्या"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Map"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "\nGoogle map वर पिन टाकण्यासाठी एक स्थान किंवा पत्ता प्रविष्ट करा."
+msgstr ""
+"\n"
+"Google map वर पिन टाकण्यासाठी एक स्थान किंवा पत्ता प्रविष्ट करा."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "स्थान किंवा पत्त्यासाठी शोधा..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "लागू करा"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "नकाशा"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Google map वर पत्ता जोडा आणि पिन ड्रॉप करा."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "पत्ता"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "नकाशे"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "नकाशा शैली निवडा"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "‌‌नकाशा सेटिंग"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "झूम पातळी"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "नकाशाची उंची पिक्सेल्स मध्ये"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "झूम पातळी"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "मार्कर आकार"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
-msgstr "छान \nनियंत्रण पर्याय सक्षम केले आहेत."
+msgstr ""
+"छान \n"
+"नियंत्रण पर्याय सक्षम केले आहेत."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "नकाशा नियंत्रण पर्यायांना सक्षम करण्याकरिता टॉगल करा."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "नकाशा नियंत्रणे"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "नकाशा प्रकार"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "\nमानक आणि उपग्रह नकाशे दृश्यांमधील स्विचिंग सक्षम केले आहे."
+msgstr ""
+"\n"
+"मानक आणि उपग्रह नकाशे दृश्यांमधील स्विचिंग सक्षम केले आहे."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "\nमानक आणि उपग्रह नकाशांमधील स्विचिंग सक्षम करण्यासाठी टॉगल करा."
+msgstr ""
+"\n"
+"मानक आणि उपग्रह नकाशांमधील स्विचिंग सक्षम करण्यासाठी टॉगल करा."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "झूम नियंत्रणे"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "नकाशा झूम नियंत्रणे दाखवत आहे."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "झूम नियंत्रणांसह झूम इन आणि झूम आउट सक्षम करण्यासाठी टॉगल करा."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Street View"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "street view नियंत्रण दाखवत आहे."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "तळापासून उजवीकडील street view नियंत्रण दाखवण्यासाठी टॉगल करा."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "पूर्णस्क्रीन टॉगल"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "पूर्णस्क्रीन नकाशा नियंत्रण दाखवत आहे."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "पूर्णस्क्रीन नकाशा नियंत्रण दाखवण्याकरिता टॉगल करा."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google Maps API की"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "आपली Google Maps API की जोडा. \nही API की अद्यतनित केल्याने नवीन की वापरण्यासाठी आपले सर्व नकाशे सेट होतील."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"आपली Google Maps API की जोडा. \n"
+"ही API की अद्यतनित केल्याने नवीन की वापरण्यासाठी आपले सर्व नकाशे सेट होतील."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
-msgstr "\nआपली की पुनर्प्राप्त करा"
+msgstr ""
+"\n"
+"आपली की पुनर्प्राप्त करा"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "मदतीची आवश्यकता आहे का?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Google API की प्रविष्ट करा..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "जतन केले"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "मानक"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "चांदी"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "मागे"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "गडद"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "रात्र"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "वांगे"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1242,9 @@ msgstr "उजवीकडील मीडिया"
 msgid "Media on left"
 msgstr "डावीकडील मीडिया"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "मीडिया कार्ड"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "ऑफसेट कार्डसह प्रतिमा किंवा व्हिडिओ जोडा."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "प्रतिमा"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "व्हिडिओ"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1258,18 @@ msgstr "कार्डची सावली दाखवत आहे."
 msgid "Toggle to add a card shadow."
 msgstr "कार्डची सावली जोडण्याकरिता टॉगल करा."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s सावली"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "%s सावली दाखवत आहे."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "%s सावली जोडण्याकरिता टॉगल करा."
 
@@ -1545,40 +1293,171 @@ msgstr "मीडिया पुनर्स्थित करण्यास�
 msgid "Edit media"
 msgstr "मीडिया संपादित करा"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s सारण्या"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "योजना %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "करोसेल"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "रंग सेटींग"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "या आयटमसाठी किंमत दाखवत आहे."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "gist मेटा डेटा दाखवण्याकरिता टॉगल करा."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "कॉल टू अॅक्शन बटण दाखवत आहे."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "gist मेटा डेटा दाखवण्याकरिता टॉगल करा."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "वैशिष्ट्य सेटिंग"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "डावीकडील मीडिया"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "उजवीकडील मीडिया"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "स्तंभ आकार"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gist सेटिंग"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "किंमत सारणी"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "किंमत सारणी"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "किंमत सारणी"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "किंमत सारणी"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "किंमत सारण्या जोडा."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "लँडिंग"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "योजना %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "तुलना"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "किंमत सारणी सेटिंग"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "सारण्या"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1475,173 @@ msgstr "योजना A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "किंमत सारणी आयटम"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "किंमत सारणी ब्लॉकमध्ये असलेला स्तंभ."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "%s च्या पार्श्वभूमीत जोडा"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "स्तंभ"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "लगतची उपपंक्ती."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "रुंदी"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "स्तंभ सेटिंग"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
-msgstr "\nकंटेनर भोवतीची जागा."
+msgstr ""
+"\n"
+"कंटेनर भोवतीची जागा."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "रुंदी"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "लेआउट बदला"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "एक"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "दोन"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "तीन"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "चार"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "%s च्या पार्श्वभूमीत जोडा"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "एक स्तंभ"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "दोन स्तंभ"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "तीन स्तंभ"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "चार स्तंभ"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "पंक्तीचे लेआउट"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "पंक्ती"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "%s या स्तंभ पंक्तीसाठी आता लेआउट निवडा."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "या पंक्तीसाठी स्तंभांची संख्या निवडा."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "पंक्ती स्तंभ निवडा"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "पंक्ती लेआउट निवडा"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "मागे स्तंभावर जा"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "\nस्तंभ ब्लॉक्ससाठी संरचित रॅपर जोडा, त्यानंतर स्तंभांमध्येआपल्याला आवडणारे सामग्री ब्लॉक जोडा."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"\n"
+"स्तंभ ब्लॉक्ससाठी संरचित रॅपर जोडा, त्यानंतर स्तंभांमध्येआपल्याला आवडणारे सामग्री ब्लॉक जोडा."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "पंक्ती"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "स्तंभ"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "लेआउट्स"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "लेआउट"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "पंक्ती सेटिंग"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "काहीही नाही"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1651,9 @@ msgstr "चौकोन"
 msgid "Circle"
 msgstr "वर्तुळ"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "सेवा"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "प्रदर्शित करण्यासाठी सेवांचे चार स्तंभ जोडा."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "वैशिष्ट्ये"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1675,7 @@ msgstr "कॉल टू अॅक्शन बटणे दाखवत आह�
 msgid "Toggle to show call to action buttons."
 msgstr "कॉल टू अॅक्शन बटण दाखवण्याकरिता टॉगल करा."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "सेवा"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "सेवा ब्लॉकमधील एकच सेवा आयटम."
 
@@ -1785,264 +1696,237 @@ msgid "Toggle to show a call to action button."
 msgstr "कॉल टू अॅक्शन बटण दाखवण्याकरिता टॉगल करा."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "क्षैतिजरित्या फ्लिप करा"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
-msgstr "\nअनुलंबरित्या फ्लिप करा"
+msgstr ""
+"\n"
+"अनुलंबरित्या फ्लिप करा"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "आकार विभाजक"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "\nपृष्ठ विभाग दृश्यमानपणे वेगळे करण्यासाठी आकार विभाजक जोडा."
+msgstr ""
+"\n"
+"पृष्ठ विभाग दृश्यमानपणे वेगळे करण्यासाठी आकार विभाजक जोडा."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "विभाजक"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "आकार रंग"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "विभाजक सेटिंग"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "पिक्सेल्स मध्ये आकाराची उंची"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
-msgstr "पिक्सेल्स मध्ये \nपार्श्वभूमी उंची"
+msgstr ""
+"पिक्सेल्स मध्ये \n"
+"पार्श्वभूमी उंची"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "अभिमुखता"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "आकार रंग"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Twitter वर सामायिक करा"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Facebook वर सामायिक करा"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Twitter वर सामायिक करा"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Pinterest वर सामायिक करा"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Linkedin वर सामायिक करा"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "ईमेलद्वारे सामायिक करा"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Tumblr वर सामायिक करा"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Google वर सामायिक करा"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Reddit वर सामायिक करा"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "सामायिक करा"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "सामाजिक"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "आपल्याला पसंती आणि सामायिकीकरणे मिळविण्यात मदत करण्यासाठी सामाजिक सामायिकीकरण लिंक जोडा."
+msgstr ""
+"आपल्याला पसंती आणि सामायिकीकरणे मिळविण्यात मदत करण्यासाठी सामाजिक सामायिकीकरण लिंक "
+"जोडा."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "सामाजिक रंग"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "आयकॉन आकार"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "वर्तुळ आकार"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "बटण आकार"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "आयकॉन्स"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "ईमेल"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "सामायिक करा बटण रंग सक्षम केले आहेत."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "\nप्रत्येक सामाजिक मीडिया प्लॅटफॉर्मवरुन अधिकृत रंग वापरण्यासाठी टॉगल करा."
+msgstr ""
+"\n"
+"प्रत्येक सामाजिक मीडिया प्लॅटफॉर्मवरुन अधिकृत रंग वापरण्यासाठी टॉगल करा."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "सामाजिक रंग"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Facebook प्रोफाइल जोडा"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Twitter प्रोफाइल जोडा"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Instagram प्रोफाइल जोडा"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Pinterest प्रोफाइल जोडा"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "LinkedIn प्रोफाइल जोडा"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "YouTube प्रोफाइल जोडा"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube प्रोफाइल जोडा"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Yelp प्रोफाइल जोडा"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Houzz प्रोफाइल जोडा"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "सामाजिक प्रोफाइल्स"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "लिंक्स"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "सामाजिक मीडिया प्रोफाइलवर लिंक्स प्रदर्शित करा."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "प्रोफाइल लिंक्स"
 
@@ -2058,25 +1942,15 @@ msgstr "पार्श्वभूमी काढून टाका"
 msgid "Background"
 msgstr "पार्श्वभूमी"
 
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "स्वयं"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "कव्‍हर"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "समाविष्ट करा"
-
 #: src/components/background/panel.js:113
 msgid "Background Settings"
 msgstr "पार्श्वभूमी सेटिंग"
 
 #: src/components/background/panel.js:119
 msgid "Fixed Background"
-msgstr "\nनिश्चित पार्श्वभूमी"
+msgstr ""
+"\n"
+"निश्चित पार्श्वभूमी"
 
 #: src/components/background/panel.js:135
 msgid "Background Opacity"
@@ -2096,23 +1970,33 @@ msgstr "प्रदर्शित करा"
 
 #: src/components/background/panel.js:193
 msgid "Mute Video"
-msgstr "नि:शब्द \nव्हिडिओ"
+msgstr ""
+"नि:शब्द \n"
+"व्हिडिओ"
 
 #: src/components/background/panel.js:194
 msgid "Muting the background video."
-msgstr "पार्श्वभूमीचा \nव्हिडिओ नि:शब्द करा."
+msgstr ""
+"पार्श्वभूमीचा \n"
+"व्हिडिओ नि:शब्द करा."
 
 #: src/components/background/panel.js:194
 msgid "Toggle to mute the video."
-msgstr "\nव्हिडिओ नि:शब्द करण्यासाठी टॉगल करा."
+msgstr ""
+"\n"
+"व्हिडिओ नि:शब्द करण्यासाठी टॉगल करा."
 
 #: src/components/background/panel.js:201
 msgid "Loop Video"
-msgstr "लूप \nव्हिडिओ"
+msgstr ""
+"लूप \n"
+"व्हिडिओ"
 
 #: src/components/background/panel.js:202
 msgid "Looping the background video."
-msgstr "पार्श्वभूमीचा \nव्हिडिओ लूप करत आहे"
+msgstr ""
+"पार्श्वभूमीचा \n"
+"व्हिडिओ लूप करत आहे"
 
 #: src/components/background/panel.js:202
 msgid "Toggle to loop the video."
@@ -2126,41 +2010,32 @@ msgstr "पार्श्वभूमी काढून टाका"
 msgid "Remove "
 msgstr "काढून टाका "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "पुनरावृत्ती नाही"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "क्षैतिजरित्या पुनरावृत्ती करा"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "\nअनुलंबरित्या पुनरावृत्ती करा"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
-msgstr "\nप्रतिमा मागे हलवा"
+msgstr ""
+"\n"
+"प्रतिमा मागे हलवा"
 
 #: src/components/block-gallery/gallery-image.js:197
 msgid "Move Image Forward"
-msgstr "\nप्रतिमा पुढे हलवा"
+msgstr ""
+"\n"
+"प्रतिमा पुढे हलवा"
 
 #: src/components/block-gallery/gallery-link-settings.js:67
 msgid "Link To"
 msgstr "ला लिंक केले"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s गॅलरी"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
-msgstr "\nप्रतिमा अपलोड करा"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "प्रकाश"
+msgstr ""
+"\n"
+"प्रतिमा अपलोड करा"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2049,110 @@ msgstr "संलग्नक पृष्ठ"
 msgid "Custom URL"
 msgstr "सानुकूल URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "पिक्सेल"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "अभिमुखता"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "\nटक्केवारी"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "रिसेट करा"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "एकक निवडा"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s एकके"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "%s प्रगत सेटिंग्ज बंद करा"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s वर"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s उजवा"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s तळ"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s डावा"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "संकालन नाही"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "संकालन करा"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "संकालन एकके"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "वर"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "उजवा"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "तळ"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "डावा"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "प्रगत %s सेटिंग"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "प्रगत"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "डिफॉल्ट"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "लेआउट"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2171,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "पूर्णस्क्रीन मोड सक्षम करण्याकरिता टॉगल करा."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "शीर्षक %d"
@@ -2263,43 +2180,16 @@ msgstr "शीर्षक %d"
 msgid "Custom color picker"
 msgstr "सानुकूल रंग निवडक"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "मूळ"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "ग्रेस्केल"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "गर्द तपकिरी रंग"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "\nसंपृक्तता"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "अंधुक"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "व्हिंटेज"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "फिल्टर लागू करा"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "अभिमुखता निवडा"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "उंची"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "मोबाइल %s"
@@ -2333,7 +2223,8 @@ msgid "Five Seconds"
 msgstr "पाच सेकंद"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "सहा सेकंद"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2243,22 @@ msgstr "नऊ सेकंद"
 msgid "Ten Seconds"
 msgstr "दहा सेकंद"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "बाण नेव्हिगेशन"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "डॉट नेव्हिगेशन"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "सेकंद"
@@ -2361,21 +2268,27 @@ msgid "second"
 msgstr "सेकंद"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "%1$d %2$s नंतर प्रगती करत आहे."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
-msgstr "\nपुढील स्लाइड स्वयंचलितपणे प्रगत करा."
+msgstr ""
+"\n"
+"पुढील स्लाइड स्वयंचलितपणे प्रगत करा."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "डेस्कटॉप आणि मोबाइलवर ड्रॅगिंग आणि फिकिंग सक्षम केले आहे."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
 msgstr "डेस्कटॉप आणि मोबाइलवर ड्रॅग कार्यक्षमता सक्षम करण्यासाठी टॉगल करा."
 
 #: src/components/slider-panel/index.js:35
@@ -2387,44 +2300,64 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "स्लाइड नेव्हिगेशन बाण दाखवण्याकरिता टॉगल करा."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "डॉट नेव्हिगेशन बाण दाखवत आहे."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "डॉट नेव्हिगेशन दाखवण्याकरिता टॉगल करा."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "कंटेनरच्या आतील जागा"
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr ""
+"\n"
+"व्हिडिओ नि:शब्द करण्यासाठी टॉगल करा."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "व्हिडिओ लूप करण्यासाठी टॉगल करा."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "स्लाइडर सेटिंग"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "स्वयंप्ले"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
-msgstr "\nसंक्रमण वेग"
+msgstr ""
+"\n"
+"संक्रमण वेग"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "ड्रॅग करण्यास सक्षम"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "बाण नेव्हिगेशन"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "डॉट नेव्हिगेशन"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "मोठे अक्षर लिहीणे"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "सामान्य"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2391,6 @@ msgstr "तळ अंतर नाही"
 msgid "Change typography"
 msgstr "मुद्रणशैली बदला"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "ठळक"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "अपरकेस"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "लोअरकेस"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "मोबाइलवरील स्टॅक"
@@ -2487,25 +2407,29 @@ msgstr "लहान व्ह्यूपोर्टवर एकमेका�
 msgid "Remove Top Spacing"
 msgstr "शीर्ष अंतर काढून टाका"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "या ब्लॉकवरील शीर्ष समास काढून टाका."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "कार्डची सावली जोडण्याकरिता टॉगल करा."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "या ब्लॉकच्या शीर्षावर लागू केलेला कुठलाही समास काढून टाकण्याकरिता टॉगल करा."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "डॉट नेव्हिगेशन दाखवण्याकरिता टॉगल करा."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "तळाशी असलेले अंतर काढून टाका"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "या ब्लॉकवरील तळाचा समास काढून टाका."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "कार्डची सावली जोडण्याकरिता टॉगल करा."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "या ब्लॉकच्या तळाशी लागू केलेला कुठलाही समास काढून टाकण्याकरिता टॉगल करा."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "डॉट नेव्हिगेशन दाखवण्याकरिता टॉगल करा."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2443,14 @@ msgstr "पूर्णरूंदी सारखे प्रदर्शि�
 msgid "Toggle to display button as full width."
 msgstr "बटण पूर्णरूंदी सारखे प्रदर्शित होण्याकरिता टॉगल करा."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "परिपत्रक"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "हिरो सेटिंग"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "सावली"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "चेकबॉक्स"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "अपरकेस"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2470,801 @@ msgstr "ब्लॉकसाठी शोधा"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "\nहा ब्लॉक पृष्ठावर जोडला गेला आहे आणि सध्या अक्षम केला जाऊ शकत नाही"
+msgstr ""
+"\n"
+"हा ब्लॉक पृष्ठावर जोडला गेला आहे आणि सध्या अक्षम केला जाऊ शकत नाही"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "सर्व अक्षम करा"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "\"%s\" ब्लॉक सापडत नाही."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s गॅलरी"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "प्रदर्शित उघडा"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "एकॉर्डियन शीर्षक जोडा..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "एकॉर्डियन आयटम"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "टॅब"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "वारंवार विचारले जाणारे प्रश्न"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "सूचना"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "संदेश"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "जीवनचरित्र"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "प्रोफाइल"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "लिंक"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "सामायिक करा"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "स्पेसर"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "सेवा"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "मेनु"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "रेस्टॉरंट"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "ई-मेल"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "मेल"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "आडनाव"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "मजकूरक्षेत्र"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "अनेक ओळीचा मजकूर"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "ईमेल"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "विषयी"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "संपर्क"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "गॅलरी"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "फोटो"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "रात्र"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "अॅनिमेटेड"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "कोड"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "बटण"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "कॉल टु अॅक्शन"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "मजकूर"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "परिच्छेद"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "आयकॉन्स"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "क्लाएंट्स"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "पुरावा"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "प्रशंसापत्रे"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "पत्ता"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "नकाशे"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "प्रतिमा"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "व्हिडिओ"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "पत्ता"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "लँडिंग"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "तुलना"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "पंक्ती"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "स्तंभ"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "लेआउट्स"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "वैशिष्ट्ये"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "विभाजक"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "सामाजिक"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "लिंक्स"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "प्रदर्शित उघडा"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "एकॉर्डियन आयटम जोडा"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "एकॉर्डियन"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "मजकूर लिहा..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "शीर्षक लिहा..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "सतर्कता"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "लेखक"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "बटणे"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "ट्वीटवर क्लिक करा"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "डायनॅमिक एचआर"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "वैशिष्ट्य"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "वैशिष्ट्ये"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "खाद्यपदार्थ"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "खाद्यपदार्थ आणि पेय"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "ईमेल"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "नाव"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "संदेश"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "फॉर्म"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "करोसेल"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "रचना"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "रचलेला"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "हिरो"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "हायलाइट"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "आयकॉन"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "लोगो आणि बिल्ले"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "नकाशा"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "मीडिया कार्ड"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "करोसेल"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "किंमत सारणी"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "किंमत सारणी आयटम"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "स्तंभ"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "पंक्ती"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "सेवा"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "सेवा"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "आकार विभाजक"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "सामायिक करा"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "सामाजिक प्रोफाइल्स"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "माहिती"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "यशस्वी"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "चेतावणी"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "त्रुटी"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "बिंदू"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "रेषा"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "पूर्ण रूंदी"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "ग्रिड"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "सूची"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "डिफॉल्ट"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "थर"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "बाह्यरेखा"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "भरलेले"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "रचलेला"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "क्षैतिजरित्या पुनरावृत्ती करा"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "नागमोडी"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "डोंगराच्या आकाराचे"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "नागमोडी"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "कोनाच्या आकाराचे"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "उतरते"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "गोलाकार"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "त्रिकोण"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "टोकदार"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "मुखवटा"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "आयकॉन"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "मजकूर"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "आयकॉन & मजकूर"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "परिपत्रक"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "तळाकडून डावीकडे"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "शीर्षकडून डावीकडे"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "अवतारप्रमाणे जोडण्यासाठी सोडून द्या"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "लेखक"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3286,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "हा वैशिष्ट्य ब्लॉक आहे तो आपण वैशिष्ट्ये हायलाइट करण्यासाठी वापरू शकता."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "हिरो शीर्षक जोडा..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "कॉल टू अॅक्शन किंवा दोघांसह विशिष्टरित्या पृष्‍ठाचा परिचयात्मक भाग असलेली हिरो सामग्री जोडा."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"कॉल टू अॅक्शन किंवा दोघांसह विशिष्टरित्या पृष्‍ठाचा परिचयात्मक भाग असलेली हिरो सामग्री "
+"जोडा."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "प्राथमिक क्रिया जोडा..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "दुय्यम क्रिया जोडा..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3328,127 @@ msgstr "सामग्री जोडा..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "कार्ड प्रतिमेसह जाण्यासाठी हा मजकूर वर्णनात्मक प्रतीने बदला. \nनंतर या कार्डमध्ये अधिक ब्लॉक्स जोडा, जसे की बटणे, सारण्या किंवा प्रतिमा."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"कार्ड प्रतिमेसह जाण्यासाठी हा मजकूर वर्णनात्मक प्रतीने बदला. \n"
+"नंतर या कार्डमध्ये अधिक ब्लॉक्स जोडा, जसे की बटणे, सारण्या किंवा प्रतिमा."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "शीर्षक लिहा..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
-msgstr "\nवर्णन लिहा..."
+msgstr ""
+"\n"
+"वर्णन लिहा..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "सामान्य"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "बटण सेटिंग"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "सानुकूल"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "मोबाइलवरील स्टॅक"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "डायनॅमिक एचआर सेटिंग"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "काहीही नाही"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "काहीही नाही"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "लहान"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "मोठे"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "अति मोठे"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "काहीही नाही"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "लहान"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "मोठे"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -2785,7 +3493,9 @@ msgstr "CoBlocks"
 #: src/blocks/icon/svgs.js:142
 msgctxt "label"
 msgid "Doodle"
-msgstr "\nडूडल"
+msgstr ""
+"\n"
+"डूडल"
 
 #: src/blocks/icon/svgs.js:147
 msgctxt "label"
@@ -3080,7 +3790,9 @@ msgstr "कोड ग्रीक गणित"
 #: src/blocks/icon/svgs.js:143
 msgctxt "tags"
 msgid "drawing doodle art creative type font pencil marker"
-msgstr "चित्र काढणे डूडल कला \nसर्जनशील प्रकार फॉन्ट पेन्सिल मार्कर"
+msgstr ""
+"चित्र काढणे डूडल कला \n"
+"सर्जनशील प्रकार फॉन्ट पेन्सिल मार्कर"
 
 #: src/blocks/icon/svgs.js:15
 msgctxt "tags"
@@ -3125,7 +3837,10 @@ msgstr "युएसबी कनेक्ट हब उपकरण साम�
 #: src/blocks/icon/svgs.js:20
 msgctxt "tags"
 msgid "music microphone podcast song artist creative media audio"
-msgstr "संगीत \nमायक्रोफोन पोडकास्ट गाणे कलाकार \nसर्जनशील मीडिया ऑडिओ"
+msgstr ""
+"संगीत \n"
+"मायक्रोफोन पोडकास्ट गाणे कलाकार \n"
+"सर्जनशील मीडिया ऑडिओ"
 
 #: src/blocks/icon/svgs.js:209
 msgctxt "tags"
@@ -3165,7 +3880,9 @@ msgstr "ठिकाण नकाशा सार्वजनिक व्यव
 #: src/blocks/icon/svgs.js:263
 msgctxt "tags"
 msgid "food drink restaurant menu fork spoon taste"
-msgstr "खाद्यपदार्थ पेय रेस्टॉरंट मेनु \nकाटा चमचा चव"
+msgstr ""
+"खाद्यपदार्थ पेय रेस्टॉरंट मेनु \n"
+"काटा चमचा चव"
 
 #: src/blocks/icon/svgs.js:268
 msgctxt "tags"
@@ -3180,7 +3897,9 @@ msgstr "मजा मेजवानी आनंदी उत्सव चव �
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "पाकळी अत्तर वास छान आराम रमणीय भूप्रदेश \nबागकाम घराबाहेर बाहेर"
+msgstr ""
+"पाकळी अत्तर वास छान आराम रमणीय भूप्रदेश \n"
+"बागकाम घराबाहेर बाहेर"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3200,7 +3919,9 @@ msgstr "कोडे प्लगइन विजेट कार्यसंघ
 #: src/blocks/icon/svgs.js:309
 msgctxt "tags"
 msgid "security bio defense biometric safe secure"
-msgstr "सुरक्षा बायो \nसंरक्षण बायोमेट्रिक सुरक्षित सुरक्षित"
+msgstr ""
+"सुरक्षा बायो \n"
+"संरक्षण बायोमेट्रिक सुरक्षित सुरक्षित"
 
 #: src/blocks/icon/svgs.js:314
 msgctxt "tags"
@@ -3210,22 +3931,32 @@ msgstr "भाषा जागतिक जग भाषण"
 #: src/blocks/icon/svgs.js:319
 msgctxt "tags"
 msgid "music microphone song artist creative media audio badge"
-msgstr "\nसंगीत \nमायक्रोफोन गाणे कलाकार \nसर्जनशील मीडिया ऑडिओ बिल्ला"
+msgstr ""
+"\n"
+"संगीत \n"
+"मायक्रोफोन गाणे कलाकार \n"
+"सर्जनशील मीडिया ऑडिओ बिल्ला"
 
 #: src/blocks/icon/svgs.js:32
 msgctxt "tags"
 msgid "microphone audio beats bose headphones"
-msgstr "मायक्रोफोन गाणे ठेका बोस \nहेडफोन"
+msgstr ""
+"मायक्रोफोन गाणे ठेका बोस \n"
+"हेडफोन"
 
 #: src/blocks/icon/svgs.js:325
 msgctxt "tags"
 msgid "flower camera photography artist creative"
-msgstr "फूल कॅमेरा छायाचित्रण कलाकार \nसर्जनशील"
+msgstr ""
+"फूल कॅमेरा छायाचित्रण कलाकार \n"
+"सर्जनशील"
 
 #: src/blocks/icon/svgs.js:330
 msgctxt "tags"
 msgid "design creative build develop engineer"
-msgstr "डिझाइन \nसर्जनशील निर्माण विकसित अभियंता"
+msgstr ""
+"डिझाइन \n"
+"सर्जनशील निर्माण विकसित अभियंता"
 
 #: src/blocks/icon/svgs.js:335
 msgctxt "tags"
@@ -3255,22 +3986,35 @@ msgstr "सुधारणे जोडा अपलोड सॉफ्टवे
 #: src/blocks/icon/svgs.js:37
 msgctxt "tags"
 msgid "music microphone song artist creative media audio"
-msgstr "\nसंगीत \nमायक्रोफोन गाणे कलाकार \nसर्जनशील मीडिया ऑडिओ"
+msgstr ""
+"\n"
+"संगीत \n"
+"मायक्रोफोन गाणे कलाकार \n"
+"सर्जनशील मीडिया ऑडिओ"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "मायक्रोफोन पोडकास्ट संगणक उपकरण \nसंगीत मायक्रोफोन गाणे कलाकार \nसर्जनशील मीडिया ऑडिओ"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"मायक्रोफोन पोडकास्ट संगणक उपकरण \n"
+"संगीत मायक्रोफोन गाणे कलाकार \n"
+"सर्जनशील मीडिया ऑडिओ"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
 msgid "photo photographer photography camera film creative media"
-msgstr "फोटो छायाचित्रकार छायाचित्रण कॅमेरा चित्रपट \nसर्जनशील मीडिया"
+msgstr ""
+"फोटो छायाचित्रकार छायाचित्रण कॅमेरा चित्रपट \n"
+"सर्जनशील मीडिया"
 
 #: src/blocks/icon/svgs.js:55
 msgctxt "tags"
 msgid "photo photographer photography camera aperture film creative media"
-msgstr "फोटो छायाचित्रकार छायाचित्रण कॅमेरा छिद्र चित्रपट \nसर्जनशील मीडिया"
+msgstr ""
+"फोटो छायाचित्रकार छायाचित्रण कॅमेरा छिद्र चित्रपट \n"
+"सर्जनशील मीडिया"
 
 #: src/blocks/icon/svgs.js:61
 msgctxt "tags"
@@ -3280,12 +4024,18 @@ msgstr "फोटो फोटोज प्रतिमा मीडिया �
 #: src/blocks/icon/svgs.js:67
 msgctxt "tags"
 msgid "film videography director producer media creative"
-msgstr "चित्रपट \nव्हिडिओग्राफी दिग्दर्शक निर्माता मीडिया सर्जनशील"
+msgstr ""
+"चित्रपट \n"
+"व्हिडिओग्राफी दिग्दर्शक निर्माता मीडिया सर्जनशील"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "व्हिडिओ व्हिडिओग्राफी दिग्दर्शक निर्माता मीडिया सर्जनशील कॅमेरा छायाचित्रकार छायाचित्रण छिद्र"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"व्हिडिओ व्हिडिओग्राफी दिग्दर्शक निर्माता मीडिया सर्जनशील कॅमेरा छायाचित्रकार छायाचित्रण "
+"छिद्र"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +4052,352 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "पॅलेट डिझाइन रंग कलाकार सर्जनशील मीडिया रंग"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "मानक"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "चांदी"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "मागे"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "गडद"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "रात्र"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "वांगे"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "परिपत्रक"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "सावली"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "डिफॉल्ट"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "काहीही नाही"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "चेकबॉक्स"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "मेनू शीर्षक..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "लहान"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "मोठे"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "अति मोठे"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "स्वयं"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "कव्‍हर"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "समाविष्ट करा"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "शीर्षकडून डावीकडे"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "शीर्ष मध्य"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "शीर्षकडून उजवीकडे"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "मध्याकडून डावीकडे"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "मध्य मध्य"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "मध्याकडून उजवीकडे"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "तळाकडून डावीकडे"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "तळाकडून मध्य"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "तळाकडून उजवीकडे"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "पुनरावृत्ती नाही"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "पुनरावृत्ती करा"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "क्षैतिजरित्या पुनरावृत्ती करा"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr ""
+"\n"
+"अनुलंबरित्या पुनरावृत्ती करा"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "लिंक Rel"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "गडद"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "प्रकाश"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "काहीही नाही"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "प्रतिमा"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "पिक्सेल"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr ""
+"\n"
+"टक्केवारी"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "मूळ"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "ग्रेस्केल"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "मीडिया फाइल"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr ""
+"\n"
+"संपृक्तता"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "व्हिंटेज फिल्टर"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "व्हिंटेज फिल्टर"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "मोठे अक्षर लिहीणे"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "सामान्य"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "ठळक"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "डिफॉल्ट"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "अपरकेस"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "लोअरकेस"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4406,14 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks हे WordPress Gutenberg ब्लॉक संपादकासाठी असलेला व्यावसायिक <strong>पृष्ठ निर्माण करणे सामग्री ब्लॉक्सचा</strong> एक संच आहे. आमचे ब्लॉक्स WordPress मधील सुंदर समृद्ध पृष्ठे निर्माण करण्यासाठी निर्मात्यांना सक्षम बनवण्यावर अधिक लक्षकेंद्रित करतात."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks हे WordPress Gutenberg ब्लॉक संपादकासाठी असलेला व्यावसायिक <strong>पृष्ठ "
+"निर्माण करणे सामग्री ब्लॉक्सचा</strong> एक संच आहे. आमचे ब्लॉक्स WordPress मधील सुंदर "
+"समृद्ध पृष्ठे निर्माण करण्यासाठी निर्मात्यांना सक्षम बनवण्यावर अधिक लक्षकेंद्रित करतात."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4423,169 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "फसवणूक करत आहे हह?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "पुनरावलोकन करा"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s वर्षे"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "वर्ष"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s आठवडे"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "आठवडे"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s दिवस"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "दिवस"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s तास"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "तास"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s मिनिटे"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "मिनिट"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s सेकंद"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "सेकंद"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPress प्लगइन"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "आपण%s आनंद घेत आहात का?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "आता आपण %2$s साठी %1$s वापरत आहात. \nआपल्याला काय वाटते हे आम्हाला समजून घेण्याकरिता एक पुनरावलोकन करण्याचे लक्षात ठेवा? आम्ही खरोखर त्याचे कौतुक करतो!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "पुनरावलोकन करा"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"आता आपण %2$s साठी %1$s वापरत आहात. \n"
+"आपल्याला काय वाटते हे आम्हाला समजून घेण्याकरिता एक पुनरावलोकन करण्याचे लक्षात ठेवा? आम्ही "
+"खरोखर त्याचे कौतुक करतो!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "नको धन्यवाद / माझ्याकडे अगोदरच आहे"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "नवीन WordPress ब्लॉॅक संपादकासाठी प्रीमियर पृष्ठ निर्माता, CoBlocks निवडल्याबद्दल धन्यवाद."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"नवीन WordPress ब्लॉॅक संपादकासाठी प्रीमियर पृष्ठ निर्माता, CoBlocks निवडल्याबद्दल "
+"धन्यवाद."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "आपण आत्ताच बर्‍याच उपयुक्त ब्लॉक्स आणि WordPress संपादकात नवीन पृष्ठ निर्माता टूलकिट जोडली आहे. CoBlocks आपल्याला खेळ-बदलणार्‍या वैशिष्ट्यांचा सेट देते: %1$s दहापट ब्लॉक्स%2$s, एक %1$sपृष्ठ-निर्माता अनुभव%2$s आणि %1$s सानुकूल टायपोग्राफी नियंत्रणे%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"आपण आत्ताच बर्‍याच उपयुक्त ब्लॉक्स आणि WordPress संपादकात नवीन पृष्ठ निर्माता टूलकिट "
+"जोडली आहे. CoBlocks आपल्याला खेळ-बदलणार्‍या वैशिष्ट्यांचा सेट देते: %1$s दहापट ब्लॉक्स"
+"%2$s, एक %1$sपृष्ठ-निर्माता अनुभव%2$s आणि %1$s सानुकूल टायपोग्राफी नियंत्रणे%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "आपल्याला प्रारंभ करण्यात मदत करण्यासाठी येथे काही व्हिडिओ आहेत:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "आपले पहिले पृष्ठ %s सह कसे तयार करायचे ते पहा"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "आपले पहिले पृष्ठ कसे तयार करायचे ते पहा"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "पंक्ती आणि आकार विभाजक ब्लॉक कसे वापरायचे ते पहा"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "मीडिया कार्ड अवरोधित करा कसे वापरायचे ते पहा"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "आपण जे पाहता त्याप्रमाणे? %1$s आमच्या YouTube चॅनलची सदस्यता घ्या %2$s आणि नवीन व्हिडीओ ट्युटोरिअल्स केव्हा प्रकाशित केले जातात ते आम्ही आपल्याला कळवू."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"आपण जे पाहता त्याप्रमाणे? %1$s आमच्या YouTube चॅनलची सदस्यता घ्या %2$s आणि नवीन "
+"व्हिडीओ ट्युटोरिअल्स केव्हा प्रकाशित केले जातात ते आम्ही आपल्याला कळवू."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "आपल्याला काही प्रश्न किंवा अभिप्राय असल्यास, आम्हाला %1$sTwitter%4$s किंवा आमच्या %2$sFacebook संघावर%4$s कळवा. आपल्याला CoBlocks वरील नवीन आणि आगामी गोष्टींसह, अद्ययावत रहायचे असल्यास आमच्या%3$sवृत्तपत्राची सदस्यता देखील घ्या%4$s."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"आपल्याला काही प्रश्न किंवा अभिप्राय असल्यास, आम्हाला %1$sTwitter%4$s किंवा आमच्या "
+"%2$sFacebook संघावर%4$s कळवा. आपल्याला CoBlocks वरील नवीन आणि आगामी गोष्टींसह, "
+"अद्ययावत रहायचे असल्यास आमच्या%3$sवृत्तपत्राची सदस्यता देखील घ्या%4$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "आनंद घ्या!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "CoBlocks सह प्रारंभ केला:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4599,27 @@ msgstr "फॉर्म स्पॅम सुरक्षेसाठी Google
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "फॉर्म स्पॅम सुरक्षेसाठी Google reCaptcha गुप्त की"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "नाव"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "पहिले"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "शेवटचे"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "संदेश"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "सबमिट करा"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "आपला संदेश पाठवला गेला:"
 
@@ -3490,3 +4634,87 @@ msgstr "Linkedin वर सामायिक करा"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "सतर्कता प्रकार"
+
+#~ msgid "Edit image"
+#~ msgstr "प्रतिमा संपादित करा"
+
+#~ msgid "Remove image"
+#~ msgstr "प्रतिमा काढून टाका"
+
+#~ msgid "Heading..."
+#~ msgstr "शीर्षक..."
+
+#~ msgid "Author Name"
+#~ msgstr ""
+#~ "\n"
+#~ "लेखकाचे नाव"
+
+#~ msgid "Write biography..."
+#~ msgstr "जीवनचरित्र लिहा..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "लेखकाचे जीवनचरित्र जोडा."
+
+#~ msgid "%s Settings"
+#~ msgstr "%s सेटिंग"
+
+#~ msgid "Caption Color"
+#~ msgstr "शीर्षक रंग"
+
+#~ msgid "Highlight text."
+#~ msgstr "हायलाइट केलेला मजकूर."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s सारण्या"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "किंमत सारणी सेटिंग"
+
+#~ msgid "Tables"
+#~ msgstr "सारण्या"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "किंमत सारणी ब्लॉकमध्ये असलेला स्तंभ."
+
+#~ msgid "Sepia"
+#~ msgstr "गर्द तपकिरी रंग"
+
+#~ msgid "Dim"
+#~ msgstr "अंधुक"
+
+#~ msgid "Vintage"
+#~ msgstr "व्हिंटेज"
+
+#~ msgid "Select Orientation"
+#~ msgstr "अभिमुखता निवडा"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "या ब्लॉकवरील शीर्ष समास काढून टाका."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "या ब्लॉकच्या शीर्षावर लागू केलेला कुठलाही समास काढून टाकण्याकरिता टॉगल करा."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "या ब्लॉकवरील तळाचा समास काढून टाका."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "या ब्लॉकच्या तळाशी लागू केलेला कुठलाही समास काढून टाकण्याकरिता टॉगल करा."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "प्राथमिक क्रिया जोडा..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "दुय्यम क्रिया जोडा..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "सामान्य"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "CoBlocks सह प्रारंभ केला:"

--- a/languages/coblocks-nb_NO.po
+++ b/languages/coblocks-nb_NO.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Vis åpen"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Legg til trekkspill-tittel ..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Trekkspill-element"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Legg til trekkspill-elementer som kan skjules til trekkspill"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "faner"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "vanlige spørsmål"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,40 @@ msgstr "Trekkspill-element er åpent som standard."
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Aktiver/deaktiver dette trekkspill-elementet slik at det er åpent som standard."
+msgstr ""
+"Aktiver/deaktiver dette trekkspill-elementet slik at det er åpent som "
+"standard."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Innstillinger for trekkspill-element"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Vis åpen"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Fargeinnstillinger"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Bakgrunnsfarge"
@@ -103,14 +65,6 @@ msgstr "Bakgrunnsfarge"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Farge på titteltekst"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Legg til trekkspill-element"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Trekkspill"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +80,82 @@ msgstr "Internet Explorer-støtte"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Legg til støtte for Internet Explorer ved å laste inn en JavaScript-polyfill."
+msgstr ""
+"Legg til støtte for Internet Explorer ved å laste inn en JavaScript-polyfill."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Støtte Internet Explorer ved å laste inn en JavaScript-polyfill på denne siden."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Støtte Internet Explorer ved å laste inn en JavaScript-polyfill på denne "
+"siden."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Advarsel"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Feil"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Varseltype"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Standard"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Informasjon"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Suksess"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Skriv inn tittel ..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Skriv tekst ..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Varsel"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Oppgi kontekstavhengige tilbakemeldingsmeldinger."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "varsel"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "melding"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Tekstfarge"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Rediger bilde"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Rediger galleri"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Fjern bilde"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Skriv bildetekst …"
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Dropp for å legge til som avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Overskrift ..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Navn på forfatter"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Skriv biografi ..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Skjemainnstillinger"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Forfatter"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Legg til en forfatterbiografi."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografi"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profil"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "Knapper"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "Be besøkende om å utføre en handling med flere knapper side ved side."
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "kobling"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "handlingsoppfordring"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Innstillinger for knapper"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Stabel på mobilen."
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "Knapper"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +173,25 @@ msgstr "Twitter-brukernavn"
 msgid "Username"
 msgstr "Brukernavn"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Legg til knapp ..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Legg til et sitat du vil tweete ..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Klikk for å tweete"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Legg til et sitat lesere kan lese via Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "del"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +199,19 @@ msgid "Text Settings"
 msgstr "Tekstinnstillinger"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Knappefarge"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynamisk HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
-msgstr "Legg til et mellomlegg som det kan endres størrelse på mellom andre blokker."
-
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "mellomlegg"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Dynamiske HR-innstillinger"
+msgstr ""
+"Legg til et mellomlegg som det kan endres størrelse på mellom andre blokker."
 
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Høyde i piksler"
 
@@ -347,17 +223,12 @@ msgstr "Høyde for det dynamiske skillelinjeelementet i piksler."
 msgid "Color"
 msgstr "Farge"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Legg til som bakgrunn"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Funksjon"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "En enklelt underordnet kolonne innenfor en overordnet funksjon-blokk."
 
@@ -366,73 +237,56 @@ msgid "Feature Settings"
 msgstr "Funksjonsinnstillinger"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Utfylling"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Funksjoner"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Legg til opptil tre kolonner med små beskjeder for produktene eller tjenestene dine."
+msgstr ""
+"Legg til opptil tre kolonner med små beskjeder for produktene eller "
+"tjenestene dine."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "tjenester"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Marg"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Innbindingsmarg"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Mellomrom mellom hver kolonne"
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Lite"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Middels"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +296,8 @@ msgstr "Stort"
 msgid "Features Settings"
 msgstr "Funksjonsinnstillinger"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Kolonner"
 
@@ -455,76 +309,72 @@ msgstr "Legg til Meny-del"
 msgid "Menu title..."
 msgstr "Menytittel ..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Grid"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Oppfør"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Slipp bilde for å erstatte det"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Fjern bilde"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Legg til tittel ..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Krydret"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Sterk"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetarisk"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Glutenfri"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescetarianer"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Vegansk"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Legg til beskrivelse ..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0,00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Matvare"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "En mat- og drikkevare i Mat- og drikkevare-blokken."
 
@@ -560,62 +410,46 @@ msgstr "Aktiver/deaktiver for å vise prisen for dette elementet."
 msgid "Item Attributes"
 msgstr "Elementattributter"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Mer krydret"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Bildeinnstillinger"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Alt Text (Alternativ tekst)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Beskriv formålet med bildet"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "La det stå tomt hvis bildet bare er dekorativt."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Fokuspunkt"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Mat og drikke"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Vis en meny eller en prisliste"
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restaurant"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "meny"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Stiler"
@@ -648,134 +482,86 @@ msgstr "Vise prisen for hvert element"
 msgid "Toggle to show the price of each item."
 msgstr "Aktiver/deaktiver for å vise prisen for hvert element."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "E-post"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "e-post"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "mail"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Et e-postadresse-felt."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Melding"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Textarea"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Tekst på flere linjer"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "En tekstboks for lengre svar."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "‌‌%s er ikke en gyldig e-postadresse."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s og %s er ikke gyldige e-postadresser."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s er ikke en gyldig e-postadresse."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "E-postadresse"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Emne"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Skjemainnstillinger"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Legg til dine reCAPTCHA nettstedsnøkler og hemmelige nøkler for å beskytte skjemaet ditt mot søppelpost."
+msgstr ""
+"Legg til dine reCAPTCHA nettstedsnøkler og hemmelige nøkler for å beskytte "
+"skjemaet ditt mot søppelpost."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Generer nøkler"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Mine nøkler"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Få hjelp"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Nettstedsnøkkel"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Hemmelig nøkkel"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Lagrer"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Lagre"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Fjern"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Første"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Siste"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Navn"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Et tekstfelt for navn."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Et e-postadresse-felt."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Legg til etikett …"
 
@@ -783,41 +569,38 @@ msgstr "Legg til etikett …"
 msgid "Required"
 msgstr "Påkrevd"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Innstillinger for navnefelt"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Etternavn"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Vise både fornavn- og etternavn-felt."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Aktiver/deaktiver for å legge til et etternavn-felt."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Skjema"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Et tekstfelt for navn."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "En tekstboks for lengre svar."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Legg til et enkelt skjema til nettstedet ditt."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "e-post:"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "om"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "kontakt"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Emne"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +610,219 @@ msgstr "Legg til tekst …"
 msgid "Button Text Color"
 msgstr "Farge på knappetekst"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Rediger galleri"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Karusell"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "bilde %1$d av %2$d i galleriet"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Skriv bildetekst …"
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Karusell"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Vis flere bilder i et vakkert karusellgalleri."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galleri"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "bilder"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s-innstillinger"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Linjehøyde"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Vise piler for punktnavigering."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Aktiver/deaktiver for å vise media-bildetekster."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Fargeinnstillinger"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Størrelse"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Avrundede kanter"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Bildetekst-farge"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Bruk"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Murverk"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Skriv beskrivelse ..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Vis flere bilder i et organisert murverk-galleri."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Vis flere bilder i et vakkert karusellgalleri."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Kolonnestørrelse"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Bildeinnstillinger"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Legg til avrundede kanter til gallerielementene."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Skygge"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Bildetekster"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Bildetekst-stil"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Vise bildetekster for hvert media-element."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Aktiver/deaktiver for å vise media-bildetekster."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Murverk"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Vis flere bilder i et organisert murverk-galleri."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Aktiver/deaktiver for å aktivere alternativer for kartkontroll."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Kartinnstillinger"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Kolonnestørrelse"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Legg til avrundede kanter til gallerielementene."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Lys"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Stablet"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Vis flere bilder i et stablet galleri med en kolonne."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Bilder i full bredde"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Bilde i full bredde"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "‌‌Boksskygge"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Bilder i full bredde er aktivert."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Aktiver/deaktiver for å fylle det tilgjengelige galleri-området med bilder som er i full bredde."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Aktiver/deaktiver for å fylle det tilgjengelige galleri-området med bilder "
+"som er i full bredde."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Elementinnstillinger"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Bilder i full bredde"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Bilde i full bredde"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Fjern gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Denne gif-en har en tom alternativ attributt"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Søk etter den perfekte gif-en på Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Søk etter gif-er"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Velg en gif, en hvilken som helst gif."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animert"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +848,11 @@ msgstr "GitHub-fil"
 msgid "File"
 msgstr "Fil"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Vis denne gist-en på GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL-adresse for Gist"
 
@@ -1024,12 +865,9 @@ msgid "Loading Gist"
 msgstr "Laster inn Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Bygg inn GitHub-gist-er ved å legge til gist-koblingen."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "kode"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +890,159 @@ msgid "Gist Meta"
 msgstr "Gist-meta"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Endre oppsett"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Legg til bakgrunn til %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hovedbanner"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Et introduksjonsområde på en side ledsaget av en liten tekst og en "
+"handlingsoppfordring."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Et introduksjonsområde på en side ledsaget av en liten tekst og en handlingsoppfordring."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "knapp"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "handlingsoppfordring"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Innholdsbredde i piksler"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Hovedbanner-innstillinger"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Mellomrom i beholderen."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Øverst til venstre"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Midtstilt øverst"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Øverst til høyre"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Midtstilt til venstre"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Midten-midten"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Midtstilt til høyre"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Nederst til venstre"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Midtstilt nederst"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Nederst til høyre"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Legg til uthevet tekst ..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Uthev"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Uthev tekst."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "tekst"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "tekstavsnitt"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Ikon"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Legg til et stilisert grafisk symbol for å kommunisere noe mer."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "ikoner"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Stort"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Legg til et stilisert grafisk symbol for å kommunisere noe mer."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Ikoninnstillinger"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Slå av avanserte %s-innstillinger"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Tilbakestill"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Tilpasset %s størrelse"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Avanserte %s-innstillinger"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Tilpass"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Avansert"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Radius"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Ikonsøk"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Ingen resultater ble funnet."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Koblingsinnstillinger"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "Koblings-URL:"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Koble til Rel"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Åpner i ny fane"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Åpne i ny fane"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Ikonfarge"
 
@@ -1261,30 +1051,19 @@ msgid "Edit logos"
 msgstr "Rediger logoer"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logoer og merker"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Dra bilder, last opp nye bilder eller velg bilder fra biblioteket ditt."
+msgstr ""
+"Dra bilder, last opp nye bilder eller velg bilder fra biblioteket ditt."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Legg til logoer, merker eller sertifiseringer for å skape troverdighet."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "kunder"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "bevis"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "attester"
+msgstr ""
+"Legg til logoer, merker eller sertifiseringer for å skape troverdighet."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1085,139 @@ msgstr "Rediger sted"
 msgid "Map style"
 msgstr "Kartstil"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Ugyldig API-nøkkel eller for mange forespørsler"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Maps"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Angi et sted eller en adresse for å feste en knappenål på et Google-kart."
+msgstr ""
+"Angi et sted eller en adresse for å feste en knappenål på et Google-kart."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Søk etter et sted eller en adresse …"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Bruk"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Kart"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Legg til en adresse eller fest en knappenål på et Google-kart."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "adresse"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "kart"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Velg kartstil"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Kartinnstillinger"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Zoomenivå"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Høyde for kart i piksler"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Zoomenivå"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Indikatorstørrelse"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Alternativer for finkontroll er aktivert."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Aktiver/deaktiver for å aktivere alternativer for kartkontroll."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Kartkontroller"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Karttype"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "Bytting mellom standard- og satellittkart-visninger er aktivert."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "Aktiver/deaktiver for å bytte mellom standardkart og satellittkart."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Zoomkontroller"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Viser zoomkontroller for kart."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "Aktiver/deaktiver for å zoome inn og ut på kartet med zoomkontroller."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Gatevisning"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Vise kartkontrollen for gatevisning."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "Aktiver/deaktiver for å vise gatevisning nederst til høyre."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Aktiver/deaktiver fullskjerm"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Viser kartkontrollen for fullskjerm."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Aktiver/deaktiver for å vise kartkontrollen for fullskjerm."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google Maps API-nøkkel"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Legg til din Google Maps API-nøkkel Oppdatering av denne API-nøkkelen vil konfigurere alle kartene dine til å bruke den nye nøkkelen."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Legg til din Google Maps API-nøkkel Oppdatering av denne API-nøkkelen vil "
+"konfigurere alle kartene dine til å bruke den nye nøkkelen."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Hent nøkkelen din."
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Trenger du hjelp?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Angi Google API-nøkkel …"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Lagret"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standard"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Sølv"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Dark"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Natt"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Aubergine"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1227,9 @@ msgstr "Medier til høyre"
 msgid "Media on left"
 msgstr "Medier til venstre"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Mediekort"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Legg til et bilde eller en video med et forskjøvet kort side ved side."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "bilde"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1243,18 @@ msgstr "Vise kortskygge."
 msgid "Toggle to add a card shadow."
 msgstr "Aktiver/deaktiver for å vise kortskygge."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s skygge"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Viser %s skygge"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Aktiver/deaktiver for å legge til en %s-skygge"
 
@@ -1545,40 +1278,171 @@ msgstr "Slipp for å erstatte medie"
 msgid "Edit media"
 msgstr "Rediger medie"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s tabeller"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL-adresse for Gist"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "%s-plan"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Karusell"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL-adresse for Gist"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Fargeinnstillinger"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Vise prisen for dette elementet."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Aktiver/deaktiver for å vise metadata for gist."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Vise handlingsoppfordring-knappen."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Aktiver/deaktiver for å vise metadata for gist."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Funksjonsinnstillinger"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Medier til venstre"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Medier til høyre"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Kolonnestørrelse"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gist-innstillinger"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Pristabell"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Pristabell"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Pristabell"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Pristabell"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Legg til pristabeller."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "målside"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "%s-plan"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "sammenligning"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Pristabell-innstillinger"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabeller"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1460,171 @@ msgstr "Plan A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Pristabell-element"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "En kolonne innenfor pristabell-blokken."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Legg til bakgrunn til %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Kolonne"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Et underordnet område i en rad."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Bredde"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Kolonneinnstillinger"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Mellomrom rundt beholderen."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Bredde"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Endre oppsett"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "en"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "to"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "tre"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "fire"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Legg til bakgrunn til %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "En kolonne"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "To kolonner"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Tre kolonner"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Fire kolonner"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Radoppsett"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Rad"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Velg nå et oppsett for denne %s-kolonneraden."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Velg antallet kolonner for denne raden."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Velg radkolonner"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Velg radoppsett"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Tilbake til kolonner"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Legg til en strukturert wrapper for kolonneblokker. Deretter legger du til de innholdsblokkene du ønsker i kolonnene."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Legg til en strukturert wrapper for kolonneblokker. Deretter legger du til "
+"de innholdsblokkene du ønsker i kolonnene."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "rader"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "kolonner"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "oppsett"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Layout"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Innstillinger for rad"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Ingen"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1634,9 @@ msgstr "Firkant"
 msgid "Circle"
 msgstr "Sirkel"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Tjenester"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Legg til opptil fire kolonner med tjenester som skal vises."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "funksjoner"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1658,7 @@ msgstr "Vise handlingsoppfordring-knapper."
 msgid "Toggle to show call to action buttons."
 msgstr "Aktiver/deaktiver for å vise handlingsoppfordring-knapper."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Tjeneste"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Et enkelt tjenesteelement i en tjenesteblokk."
 
@@ -1785,264 +1679,231 @@ msgid "Toggle to show a call to action button."
 msgstr "Aktiver/deaktiver for å vise handlingsoppfordring-knapper."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Vend horisontalt"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Flip vertikalt"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Form-delelinje"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "Legg til en form-delelinje for å visuelt skille side-seksjoner."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "skillelinje"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Form-farge"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Skillelinje-innstillinger"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Formhøyde i piksler"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Bakgrunnshøyde i piksler"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Retning"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Form-farge"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Del på Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Del på Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Del på Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Del på Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Del på LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Del via e-post"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Del på Twitter"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Del på Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Del på Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Del"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "sosial medier"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Legg til sosiale medier-koblinger for å hjelpe deg med å få Liker og delinger."
+msgstr ""
+"Legg til sosiale medier-koblinger for å hjelpe deg med å få Liker og "
+"delinger."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Sosiale medier-farger"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Ikonstørrelse"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Sirkelstørrelse"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Knappestørrelse"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Ikoner"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "E-post"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Knappefarger for deling er aktivert."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Aktiver/deaktiver for å bruke offisielle farger fra hver sosiale medier-plattform."
+msgstr ""
+"Aktiver/deaktiver for å bruke offisielle farger fra hver sosiale medier-"
+"plattform."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Sosiale medier-farger"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Legg til Facebook-profil"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Legg til Twitter-profil"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Legg til Instagram-profil"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Legg til Pinterest-profil"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Legg til LinkedIn-profil"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Legg til YouTube-profil"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Legg til Yelp-profil"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Legg til Houzz-profil"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Sosiale medier-profiler"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "koblinger"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Vis koblinger til sosiale medier-profiler."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Profil-koblinger"
 
@@ -2057,18 +1918,6 @@ msgstr "Fjern bakgrunn"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Bakgrunn"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Auto"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Omslag"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Inneholder"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1975,6 @@ msgstr "Fjern bakgrunn"
 msgid "Remove "
 msgstr "Fjern "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Ingen gjentakelse"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Gjenta horisontalt"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Gjenta vertikalt"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Fjern bilde bakover"
@@ -2150,17 +1987,14 @@ msgstr "Fjern bilde forover"
 msgid "Link To"
 msgstr "Koble til"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s-galleri"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Last opp et bilde"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Lys"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2008,110 @@ msgstr "Vedleggsside"
 msgid "Custom URL"
 msgstr "Egendefinert URL-adresse"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Piksel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Retning"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Prosentandel"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Tilbakestill"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Velg enheter"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s enheter"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Slå av avanserte %s-innstillinger"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s øverst"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s høyre"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s nederst"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s venstre"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Opphev synkronisering"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Synkroniser"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Synkroniser enheter"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Topp"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Høyre"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Nederst"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Venstre"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Avanserte %s-innstillinger"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Avansert"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Standard"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Layout"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2130,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Aktiver/deaktiver for å aktivere fullskjermmodus."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Overskrift %d"
@@ -2263,43 +2139,16 @@ msgstr "Overskrift %d"
 msgid "Custom color picker"
 msgstr "Egendefinert fargevelger"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Original"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Gråtone"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sepia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Metning"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Dim"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Bruk filter"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Velg retning"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Høyde"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Mobil %s"
@@ -2333,7 +2182,8 @@ msgid "Five Seconds"
 msgstr "Fem‌ sekunder"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Seks sekunder"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2202,22 @@ msgstr "Ni sekunder"
 msgid "Ten Seconds"
 msgstr "Ti sekunder"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Pilnavigering"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Punktnavigering"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "sekunder"
@@ -2361,22 +2227,27 @@ msgid "second"
 msgstr "sekund"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Går videre etter %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Går automatisk videre til det neste lysbildet."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Dra og sveip aktivert på stasjonære og mobile enheter."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Aktiver/deaktiver for å dra funksjonalitet på stasjonære og mobile enheter."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Aktiver/deaktiver for å dra funksjonalitet på stasjonære og mobile enheter."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2258,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Aktiver/deaktiver for å vise piler for lysbildenavigering."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Vise piler for punktnavigering."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Aktiver/deaktiver for å vise punktnavigering."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Mellomrom i beholderen."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Aktiver/deaktiver for å dempe videoen."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Aktiver/deaktiver for å repetere videoen."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Glidebryterinnstillinger"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Autokjør"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Overgangshastighet"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Kan dras"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Pilnavigering"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Punktnavigering"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Stor forbokstav"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2345,6 @@ msgstr "Ingen avstand nederst"
 msgid "Change typography"
 msgstr "Endre typografi"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Fet"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Store bokstaver"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Små bokstaver"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Stabel på mobilen"
@@ -2481,31 +2355,37 @@ msgstr "Svartid er aktivert."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Aktiver/deaktiver for å stable elementer oppå hverandre på mindre visningsporter."
+msgstr ""
+"Aktiver/deaktiver for å stable elementer oppå hverandre på mindre "
+"visningsporter."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Fjern avstand øverst"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Den øverste margen er fjernet på denne blokken."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Aktiver/deaktiver for å vise kortskygge."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Aktiver/deaktiver for å fjerne eventuelle marger som er brukt øverst på denne blokken."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Aktiver/deaktiver for å vise punktnavigering."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Fjern avstand nederst"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Den nederste margen er fjernet på denne blokken."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Aktiver/deaktiver for å vise kortskygge."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Aktiver/deaktiver for å fjerne eventuelle marger som er brukt nederst på denne blokken."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Aktiver/deaktiver for å vise punktnavigering."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2399,14 @@ msgstr "Viser som full bredde."
 msgid "Toggle to display button as full width."
 msgstr "Aktiver/deaktiver for å vise knapp som full bredde."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Sirkelformet"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Hovedbanner-innstillinger"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Skygge"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Avmerkingsboks"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Store bokstaver"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2432,793 @@ msgstr "Denne blokken er lagt til siden og kan for øyeblikket ikke deaktiveres"
 msgid "Disable all"
 msgstr "Deaktiver alle"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Fant ingen \"%s\"-blokker."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s gallerier"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Vis åpen"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Legg til trekkspill-tittel ..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Trekkspill-element"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "faner"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "vanlige spørsmål"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "varsel"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "melding"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografi"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "kobling"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "handlingsoppfordring"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "del"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "mellomlegg"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "tjenester"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "meny"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restaurant"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "e-post"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "mail"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Etternavn"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Textarea"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Tekst på flere linjer"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "e-post:"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "om"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "kontakt"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galleri"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "bilder"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Natt"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animert"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "kode"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "knapp"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "handlingsoppfordring"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "tekst"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "tekstavsnitt"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "ikoner"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "kunder"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "bevis"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "attester"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "adresse"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "kart"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "bilde"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "adresse"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "målside"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "sammenligning"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "rader"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "kolonner"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "oppsett"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "funksjoner"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "skillelinje"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "sosial medier"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "koblinger"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Vis åpen"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Legg til trekkspill-element"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Trekkspill"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Skriv tekst ..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Skriv inn tittel ..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Varsel"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Forfatter"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Knapper"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Klikk for å tweete"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynamisk HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Funksjon"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Funksjoner"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Matvare"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Mat og drikke"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "E-post"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Navn"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Melding"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Skjema"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Karusell"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Murverk"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Stablet"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL-adresse for Gist"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hovedbanner"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Uthev"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Ikon"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logoer og merker"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Kart"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Mediekort"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Karusell"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Pristabell"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Pristabell-element"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Kolonne"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Rad"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Tjenester"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Tjeneste"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Form-delelinje"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Del"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Sosiale medier-profiler"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Informasjon"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Suksess"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Advarsel"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Feil"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Punkt"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Linje"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Full bredde"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Grid"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Oppfør"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Standard"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Lag"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Omrisset"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Fylt"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Stablet"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Gjenta horisontalt"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Bølgete"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Åser"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Bølger"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Vinklende"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Skrånende"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Avrundet"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Trekant"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Spisset"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Maske"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Ikon"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Tekst"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Ikon og tekst"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Sirkelformet"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Nederst til venstre"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Øverst til venstre"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Dropp for å legge til som avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Forfatter"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3240,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "Dette er en funksjonsblokk som du kan bruke til å utheve funksjoner."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "Legg til hovedbanner-overskrift ..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Legg til hovedbanner-innhold, som vanligvis er et introduksjonsområde på en side ledsaget av en handlingsoppfordring eller to."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Legg til hovedbanner-innhold, som vanligvis er et introduksjonsområde på en "
+"side ledsaget av en handlingsoppfordring eller to."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Legg til primær handling ..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Legg til sekundær handling ..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3282,126 @@ msgstr "Legg til innhold ..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Erstatt denne teksten med beskrivende tekst som skal gå sammen med kortbildet. Deretter legger du til flere blokker til dette kortet, som for eksempel knapper, lister eller bilder."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Erstatt denne teksten med beskrivende tekst som skal gå sammen med "
+"kortbildet. Deretter legger du til flere blokker til dette kortet, som for "
+"eksempel knapper, lister eller bilder."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Skriv inn tittel ..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Skriv beskrivelse ..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Innstillinger for knapper"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Tilpass"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Stabel på mobilen."
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Dynamiske HR-innstillinger"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Ingen"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Ingen"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Lite"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Middels"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Stort"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Ekstra stor"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Ingen"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Lite"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Middels"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Stort"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,8 +3920,12 @@ msgstr "musikk mikrofon sang artist kreativ media audio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "mikrofon podcast datamaskin enhet musikk mikrofon sang artist kreativ media audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"mikrofon podcast datamaskin enhet musikk mikrofon sang artist kreativ media "
+"audio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3949,12 @@ msgstr "film videografi regissør produsent media kreativ"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "video videografi regissør produsent media kreativ kamera fotograf fotografi blenderåpning"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"video videografi regissør produsent media kreativ kamera fotograf fotografi "
+"blenderåpning"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3971,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "palett design farger artist kreativ media maling malerkost"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standard"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Sølv"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Dark"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Natt"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Aubergine"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Sirkelformet"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Skygge"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Standard"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Ingen"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Avmerkingsboks"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Menytittel ..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Lite"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Middels"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Stort"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Ekstra stor"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Auto"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Omslag"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Inneholder"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Øverst til venstre"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Midtstilt øverst"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Øverst til høyre"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Midtstilt til venstre"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Midten-midten"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Midtstilt til høyre"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Nederst til venstre"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Midtstilt nederst"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Nederst til høyre"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Ingen gjentakelse"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Gjenta"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Gjenta horisontalt"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Gjenta vertikalt"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Koble til Rel"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Dark"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Lys"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Ingen"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Bilde"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Piksel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Prosentandel"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Original"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Gråtone"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Mediefil"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Metning"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Vintage filter"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Vintage filter"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Stor forbokstav"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Fet"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Standard"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Store bokstaver"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Små bokstaver"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4319,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks er en programserie av profesjonelle <strong>blokke for sidebygging</strong> for blokkredigeringsprogrammet WordPress Gutenberg. Våre blokker er hyperfokusert på å gjøre de som lager sider i stand til å skape vakre sider i WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks er en programserie av profesjonelle <strong>blokke for sidebygging</"
+"strong> for blokkredigeringsprogrammet WordPress Gutenberg. Våre blokker er "
+"hyperfokusert på å gjøre de som lager sider i stand til å skape vakre sider "
+"i WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4337,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Hæ, jukser du?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Skriv en vurdering"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s år"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "et år"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s uker"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "en uke"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s dager"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "en dag"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s timer"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "en time"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minutter"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "et minutt"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s sekunder"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "et sekund"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPress-plugin-modul"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Liker du %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Du har nå brukt %1$s i %2$s. Kunne du tenke deg å legge igjen en vurdering for å fortelle oss hva du synes? Vi ville satt virkelig stor pris på det!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Skriv en vurdering"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Du har nå brukt %1$s i %2$s. Kunne du tenke deg å legge igjen en vurdering "
+"for å fortelle oss hva du synes? Vi ville satt virkelig stor pris på det!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Nei takk / Jeg har allerede gjort det"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Takk for at du valgte CoBlocks, den beste sidebyggeren for det nye blokkredigeringsprogrammet for WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Takk for at du valgte CoBlocks, den beste sidebyggeren for det nye "
+"blokkredigeringsprogrammet for WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Du har nettopp lagt til mange nyttige blokker og et nytt sidebygger-verktøysett til WordPress-redigeringsprogrammet. CoBlocks gir deg et banebrytende knippe funksjoner: %1$s flere titalls blokker%2$s, en %1$s sidebygger-opplevelse %2$s og %1$s egendefinerte typografikontroller%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Du har nettopp lagt til mange nyttige blokker og et nytt sidebygger-"
+"verktøysett til WordPress-redigeringsprogrammet. CoBlocks gir deg et "
+"banebrytende knippe funksjoner: %1$s flere titalls blokker%2$s, en %1$s "
+"sidebygger-opplevelse %2$s og %1$s egendefinerte typografikontroller%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Her er et par videoer for å hjelpe deg med å komme i gang."
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Se hvordan du lager din første side med %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Se hvordan du lager din første side"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Se hvordan du bruker blokkene rad, form og skillelinje"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Se hvordan du bruker Media Card-blokkeringen"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Liker du det du ser? %1$sAbonner på YouTube-kanalen vår%2$s, så gir vi beskjed når det slippes nye videoopplæringer."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Liker du det du ser? %1$sAbonner på YouTube-kanalen vår%2$s, så gir vi "
+"beskjed når det slippes nye videoopplæringer."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Hvis du har spørsmål eller tilbakemelding, sier du ifra på vår %1$sTwitter%4$s-gruppe eller vår %2$sFacebook-gruppe %4$s. Du kan også %3$sabonnere på nyhetsbrevet vårt%4$s hvis du ønsker å holde deg oppdatert om hva som er nytt og kommende CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Hvis du har spørsmål eller tilbakemelding, sier du ifra på vår %1$sTwitter"
+"%4$s-gruppe eller vår %2$sFacebook-gruppe %4$s. Du kan også %3$sabonnere på "
+"nyhetsbrevet vårt%4$s hvis du ønsker å holde deg oppdatert om hva som er "
+"nytt og kommende CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Kos deg!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Kom i gang med CoBlocks her:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4508,36 @@ msgstr "Aktiver eller deaktiver blokker"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "Nettstedsnøkkel for Google reCaptcha for skjema for beskyttelse mot nettsøppel"
+msgstr ""
+"Nettstedsnøkkel for Google reCaptcha for skjema for beskyttelse mot "
+"nettsøppel"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
-msgstr "Hemmelig nøkkel for Google reCaptcha for å beskytte skjema mot søppelpost"
+msgstr ""
+"Hemmelig nøkkel for Google reCaptcha for å beskytte skjema mot søppelpost"
+
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Navn"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Første"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Siste"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Melding"
 
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Send inn"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Meldingen din ble sendt:"
 
@@ -3490,3 +4552,89 @@ msgstr "Del på LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "Varseltype"
+
+#~ msgid "Edit image"
+#~ msgstr "Rediger bilde"
+
+#~ msgid "Remove image"
+#~ msgstr "Fjern bilde"
+
+#~ msgid "Heading..."
+#~ msgstr "Overskrift ..."
+
+#~ msgid "Author Name"
+#~ msgstr "Navn på forfatter"
+
+#~ msgid "Write biography..."
+#~ msgstr "Skriv biografi ..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Legg til en forfatterbiografi."
+
+#~ msgid "%s Settings"
+#~ msgstr "%s-innstillinger"
+
+#~ msgid "Caption Color"
+#~ msgstr "Bildetekst-farge"
+
+#~ msgid "Highlight text."
+#~ msgstr "Uthev tekst."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s tabeller"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Pristabell-innstillinger"
+
+#~ msgid "Tables"
+#~ msgstr "Tabeller"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "En kolonne innenfor pristabell-blokken."
+
+#~ msgid "Sepia"
+#~ msgstr "Sepia"
+
+#~ msgid "Dim"
+#~ msgstr "Dim"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Velg retning"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Den øverste margen er fjernet på denne blokken."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Aktiver/deaktiver for å fjerne eventuelle marger som er brukt øverst på "
+#~ "denne blokken."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Den nederste margen er fjernet på denne blokken."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Aktiver/deaktiver for å fjerne eventuelle marger som er brukt nederst på "
+#~ "denne blokken."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Legg til primær handling ..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Legg til sekundær handling ..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Kom i gang med CoBlocks her:"

--- a/languages/coblocks-nl_NL.po
+++ b/languages/coblocks-nl_NL.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Weergave open"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Accordeontitel toevoegen..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Accordeonitem"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Voeg items toe aan de opvouwbare accordeon."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "tabbladen"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "veelgestelde vragen"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "Schakel dit in om het accordeonitem standaard op open in te stellen."
 msgid "Accordion Item Settings"
 msgstr "Instellingen accordeonitem"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Weergave open"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Kleurinstellingen"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Achtergrondkleur"
@@ -103,14 +63,6 @@ msgstr "Achtergrondkleur"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Kleur titeltekst"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Accordeonitem toevoegen"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Accordeon"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +78,83 @@ msgstr "Ondersteuning Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Voeg ondersteuning voor Internet Explorer toe door een JavaScript polyfill te laden."
+msgstr ""
+"Voeg ondersteuning voor Internet Explorer toe door een JavaScript polyfill "
+"te laden."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Internet Explorer wordt ondersteund door op deze pagina een JavaScript polyfill te laden."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Internet Explorer wordt ondersteund door op deze pagina een JavaScript "
+"polyfill te laden."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Waarschuwing"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Fout"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Meldingstype"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Standaard"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Info"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Geslaagd"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Titel schrijven..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Tekst schrijven..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Waarschuwing"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Voer contextuele feedbackberichten in."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "kennisgeving"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "bericht"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Tekstkleur"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Afbeelding bewerken"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Galerij bewerken"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Afbeelding verwijderen"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Bijschrift schrijven..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Neerzetten om als avatar toe te voegen"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Kop..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Naam auteur"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Biografie schrijven..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Formulierinstellingen"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Auteur"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Voeg een biografie van de auteur toe."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografie"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profiel"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "Knoppen"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "Vraag bezoekers actie te ondernemen met meerdere knoppen naast elkaar."
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "link"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Instellingen knoppen"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Stapel op mobiel apparaat"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "Knoppen"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +172,25 @@ msgstr "Twitter-gebruikersnaam"
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Knop toevoegen..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Een citaat toevoegen om te tweeten..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Klik op te tweeten"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Voeg een citaat voor lezers toe om via Twitter te tweeten."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "delen"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +198,20 @@ msgid "Text Settings"
 msgstr "Tekstinstellingen"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Knopkleur"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynamische HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
-msgstr "Voer een tussenstuk tussen andere blokken toe waarvan je de grootte kunt aanpassen."
-
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "tussenstuk"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Instellingen dynamische HR"
+msgstr ""
+"Voer een tussenstuk tussen andere blokken toe waarvan je de grootte kunt "
+"aanpassen."
 
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Hoogte in pixels"
 
@@ -347,92 +223,70 @@ msgstr "Hoogte in pixels voor dynamisch scheidingselement."
 msgid "Color"
 msgstr "Kleur"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Toevoegen als achtergrond"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Kenmerk"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
-msgstr "Een enkele onderliggende kolom binnen een bovenliggend blok met functies."
+msgstr ""
+"Een enkele onderliggende kolom binnen een bovenliggend blok met functies."
 
 #: src/blocks/features/feature/inspector.js:68
 msgid "Feature Settings"
 msgstr "Functie-instellingen"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Opvulling"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Functies"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Voeg tot drie kolommen met kleine notities toe voor je product of service."
+msgstr ""
+"Voeg tot drie kolommen met kleine notities toe voor je product of service."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "services"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Marge"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Rugmarge"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "De ruimte tussen de kolommen."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Klein"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Gemiddeld"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +296,8 @@ msgstr "Groot"
 msgid "Features Settings"
 msgstr "Functie-instellingen"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Kolommen"
 
@@ -455,76 +309,72 @@ msgstr "Menusectie toevoegen"
 msgid "Menu title..."
 msgstr "Menutitel..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Raster"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Vermelden"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Afbeelding neerzetten om te vervangen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Afbeelding verwijderen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Titel toevoegen..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Pittig"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Heet"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetarisch"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Zonder gluten"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescatarisch"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Veganistisch"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Beschrijving toevoegen..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$ 0,00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Etenswaar"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Eten of drinken binnen het blok voor Eten en drinken."
 
@@ -560,62 +410,46 @@ msgstr "Schakel dit in om de prijs van dit item weer te geven."
 msgid "Item Attributes"
 msgstr "Itemeigenschappen"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Pittiger"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Instellingen afbeelding"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Alternatieve tekst"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Beschrijf het doel van de afbeelding"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Laat dit leeg als het een decoratieve afbeelding is."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Focuspunt"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Eten en drinken"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Geef een menu of prijslijst weer."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restaurant"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menu"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Stijlen"
@@ -648,134 +482,86 @@ msgstr "De prijs van elk item wordt weergegeven"
 msgid "Toggle to show the price of each item."
 msgstr "Schakel dit in om de prijs van elk item weer te geven."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "E-mail"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "e-mail"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "mail"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Een veld voor een e-mailadres."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Bericht"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Tekstgedeelte"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Meerregelige tekst"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Een tekstvak voor langere antwoorden."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "‌‌%s is geen geldig e-mailadres."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "‌‌%s en %s zijn geen geldige e-mailadressen."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "‌‌%s is geen geldig e-mailadres."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "E-mailadres"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "naam@voorbeeld.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Formulierinstellingen"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "reCAPTCHA van Google"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Voeg je reCAPTCHA-site en geheime sleutels toe om je formulier te beschermen tegen spam."
+msgstr ""
+"Voeg je reCAPTCHA-site en geheime sleutels toe om je formulier te beschermen "
+"tegen spam."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Sleutels genereren"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Mijn sleutels"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Hulp ontvangen"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Sitesleutel"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Geheime code"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Opslaan"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Opslaan"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Eerste"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Laatste"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Naam"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Een tekstveld voor namen."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Een veld voor een e-mailadres."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Label toevoegen..."
 
@@ -783,41 +569,38 @@ msgstr "Label toevoegen..."
 msgid "Required"
 msgstr "Vereist"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Instellingen naamveld"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Achternaam"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "De velden voor de voor- en achternaam worden weergegeven."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Schakel dit in om een veld voor de achternaam toe te voegen."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Formulier"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Een tekstveld voor namen."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Een tekstvak voor langere antwoorden."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Voeg een eenvoudig formulier toe aan je pagina."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "e-mail"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "over"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "contact"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Onderwerp"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +610,222 @@ msgstr "Tekst toevoegen..."
 msgid "Button Text Color"
 msgstr "Kleur knoptekst"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Galerij bewerken"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Carrousel"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "afbeelding %1$d van %2$d in galerij"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Bijschrift schrijven..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Carrousel"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Geef meerdere afbeeldingen weer in een mooie carrouselgalerij."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galerij"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "foto's"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Instellingen %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Regelhoogte"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "De pijlen voor stipnavigatie worden weergegeven."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Schakel dit in om mediabijschriften weer te geven."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Kleurinstellingen"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Grootte"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Afgeronde hoeken"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Kleur van bijschrift"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Toepassen"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Gemetselde stijl"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Beschrijving opstellen..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Geef meerdere afbeeldingen weer in een georganiseerde gemetselde galerij."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Geef meerdere afbeeldingen weer in een mooie carrouselgalerij."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Kolomgrootte"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Instellingen afbeelding"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Voeg afgeronde hoeken toe aan de galerij-items."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Schaduw"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Bijschriften"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Bijschriftstijl"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Voor elk media-item wordt een bijschrift weergegeven."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Schakel dit in om mediabijschriften weer te geven."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Gemetselde stijl"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr ""
+"Geef meerdere afbeeldingen weer in een georganiseerde gemetselde galerij."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Schakel dit in om de beheeropties voor de kaart in te schakelen."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Kaartinstellingen"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Kolomgrootte"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Voeg afgeronde hoeken toe aan de galerij-items."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Licht"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Gestapeld"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
-msgstr "Geef meerdere afbeeldingen weer in een enkele gestapelde kolom met een galerij."
+msgstr ""
+"Geef meerdere afbeeldingen weer in een enkele gestapelde kolom met een "
+"galerij."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Afbeeldingen op volledige breedte"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Afbeelding op volledige breedte"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Vakschaduw"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Afbeeldingen op volledige breedte zijn ingeschakeld."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Schakel dit in om de beschikbare ruimte in de galerij op te vullen met afbeeldingen op volledige breedte."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Schakel dit in om de beschikbare ruimte in de galerij op te vullen met "
+"afbeeldingen op volledige breedte."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Iteminstellingen"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Afbeeldingen op volledige breedte"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Afbeelding op volledige breedte"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "GIF verwijderen"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Deze GIF heeft een leeg alt-attribuut"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Ga op zoek naar die perfecte GIF op Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Zoeken naar GIFs"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Kies de allerbeste GIF."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "geanimeerd"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +851,11 @@ msgstr "GitHub-bestand"
 msgid "File"
 msgstr "Bestand"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Deze gist op GitHub weergeven"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist-URL"
 
@@ -1024,12 +868,9 @@ msgid "Loading Gist"
 msgstr "Gist laden"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Sluit de GitHub-gists in door de link naar de gist toe te voegen."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "code"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +893,161 @@ msgid "Gist Meta"
 msgstr "Gistmeta"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Lay-out wijzigen"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Achtergrond toevoegen aan %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Een inleidend onderdeel van een pagina samen met een kleine hoeveelheid "
+"tekst en een call-to-action."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Een inleidend onderdeel van een pagina samen met een kleine hoeveelheid tekst en een call-to-action."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "knop"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "call-to-action"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Breedte van content in pixels"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Hero-instellingen"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "De ruimte in de container."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Boven links"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Boven centraal"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Boven rechts"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Centraal links"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Centraal midden"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Centraal rechts"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Onder links"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Onder centraal"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Onder rechts"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Gemarkeerde tekst toevoegen..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Opvallend"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Markeer de tekst."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "tekst"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "paragraaf"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Pictogram"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Voeg een gestileerd grafisch symbool toe om wat meer informatie over te brengen."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "pictogrammen"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Zeer groot"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr ""
+"Voeg een gestileerd grafisch symbool toe om wat meer informatie over te "
+"brengen."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Pictograminstellingen"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Geavanceerde instellingen %s uitschakelen"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Opnieuw instellen"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Aangepaste grootte %s"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Geavanceerde instellingen %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Aangepast"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Geavanceerd"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Radius"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Pictogram zoeken"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Geen resultaten gevonden."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Linkinstellingen"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL link"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Link Rel"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Wordt in een nieuw tabblad geopend"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Openen in nieuw tabblad"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Pictogramkleur"
 
@@ -1261,30 +1056,19 @@ msgid "Edit logos"
 msgstr "Logo's bewerken"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logo's en badges"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Sleep afbeeldingen, upload nieuwe of selecteer bestanden uit je bibliotheek."
+msgstr ""
+"Sleep afbeeldingen, upload nieuwe of selecteer bestanden uit je bibliotheek."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Voeg logo's, badges of certificaten toe en vergroot je geloofwaardigheid."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "klanten"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "bewijs"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "getuigenissen"
+msgstr ""
+"Voeg logo's, badges of certificaten toe en vergroot je geloofwaardigheid."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1090,142 @@ msgstr "Locatie bewerken"
 msgid "Map style"
 msgstr "Kaartstijl"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Ongeldige API-code of te veel verzoeken"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Maps"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Voer een locatie of adres in om een pin neer te zetten op een kaart van Google."
+msgstr ""
+"Voer een locatie of adres in om een pin neer te zetten op een kaart van "
+"Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Zoeken naar een plaats of adres..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Toepassen"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Kaart"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Voeg een adres toe en zet een pin neer op een kaart van Google."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "adres"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "kaarten"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Kaartstijl selecteren"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Kaartinstellingen"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Zoomniveau"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Hoogte voor de kaart in pixels"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Zoomniveau"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Grootte markering"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "De opties voor gedetailleerd beheer zijn ingeschakeld."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Schakel dit in om de beheeropties voor de kaart in te schakelen."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Functies kaart"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Kaarttype"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "Schakelen tussen de standaard- en satellietkaart is ingeschakeld."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "Schakel dit in om te schakelen tussen standaard- en satellietkaarten."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Zoomfunctie"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "De functie om in te zoomen wordt weergegeven."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "Schakel dit in om in en uit te zoomen op de kaart met de zoomfunctie."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Straatweergave"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "De functie voor de straatweergave van de kaart wordt weergegeven."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Schakel dit in om de functie voor straatweergave rechtsonderin weer te geven."
+msgstr ""
+"Schakel dit in om de functie voor straatweergave rechtsonderin weer te geven."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Volledig scherm in- en uitschakelen"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "De functie voor de kaart op volledig scherm wordt weergegeven."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
-msgstr "Schakel dit in om de functie voor de kaart op volledig scherm weer te geven."
+msgstr ""
+"Schakel dit in om de functie voor de kaart op volledig scherm weer te geven."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "API-sleutel voor Google Maps"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Voeg je API-sleutel voor Google Maps toe. Als je deze API-sleutel bijwerkt, maken al je kaarten gebruik van de nieuwe sleutel."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Voeg je API-sleutel voor Google Maps toe. Als je deze API-sleutel bijwerkt, "
+"maken al je kaarten gebruik van de nieuwe sleutel."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Je sleutel ophalen"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Hulp nodig?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "De API-sleutel van Google invoeren..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Opgeslagen"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standaard"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Zilver"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Donker"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Nacht"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Aubergine"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1235,9 @@ msgstr "Media rechts"
 msgid "Media on left"
 msgstr "Media links"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Mediakaart"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Voeg een afbeelding of video toe met kaart ernaast."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "afbeelding"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1251,18 @@ msgstr "De schaduw van de kaart wordt weergegeven."
 msgid "Toggle to add a card shadow."
 msgstr "Schakel dit in om een schaduw aan de kaart toe te voegen."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Schaduw %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Schaduw van %s wordt weergegeven."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Schakel dit in om een schaduw van %s toe te voegen."
 
@@ -1545,40 +1286,171 @@ msgstr "Neerzetten om media te vervangen"
 msgid "Edit media"
 msgstr "Media bewerken"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Tabellen %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist-URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Abonnement %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Carrousel"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist-URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Kleurinstellingen"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "De prijs van dit item wordt weergegeven."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Schakel dit in om de metadata van de gist weer te geven."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "De knop voor call-to-action wordt weergegeven."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Schakel dit in om de metadata van de gist weer te geven."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Functie-instellingen"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Media links"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Media rechts"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Kolomgrootte"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gistinstellingen"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Tariefoverzicht"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Tariefoverzicht"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Tariefoverzicht"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Tariefoverzicht"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Voeg tariefoverzichten toe."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "landing"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Abonnement %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "vergelijking"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Instellingen tariefoverzicht"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabellen"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1468,171 @@ msgstr "Abonnement A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Item tariefoverzicht"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Een kolom geplaatst binnen het blok met het tariefoverzicht."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Achtergrond toevoegen aan %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Kolom"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Een onmiddellijk onderliggend element van een rij."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Breedte"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Kolominstellingen"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "De ruimte rondom de container."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Breedte"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Lay-out wijzigen"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "één"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "twee"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "drie"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "vier"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Achtergrond toevoegen aan %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Eén kolom"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Twee kolommen"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Drie kolommen"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Vier kolommen"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Lay-out rij"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Rij"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Selecteer nu een lay-out voor deze rij van %s kolom(men)."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Selecteer het aantal kolommen voor deze rij."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Rijkolommen selecteren"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Lay-out van rij selecteren"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Terug naar kolommen"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Voeg een gestructureerde omslag toe voor kolomblokken en voeg dan de gewenste contentblokken toe aan de kolommen."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Voeg een gestructureerde omslag toe voor kolomblokken en voeg dan de "
+"gewenste contentblokken toe aan de kolommen."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "rijen"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "kolommen"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "lay-outs"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Lay-out"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Rij-instellingen"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Geen"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1642,9 @@ msgstr "Vierkant"
 msgid "Circle"
 msgstr "Cirkel"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Services"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Voeg tot vier kolommen met services toe om weer te geven."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "functies"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1666,7 @@ msgstr "De knoppen voor call-to-actions worden weergegeven."
 msgid "Toggle to show call to action buttons."
 msgstr "Schakel dit in om de knoppen voor call-to-actions weer te geven."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Service"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Een enkel service-item binnen een blok met services."
 
@@ -1785,264 +1687,233 @@ msgid "Toggle to show a call to action button."
 msgstr "Schakel dit in om een knop voor een call-to-action weer te geven."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Horizontaal draaien"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Verticaal draaien"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Vormverdeelstuk"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Voeg een vormverdeelstuk toe om de paginasecties op visuele wijze van elkaar te onderscheiden."
+msgstr ""
+"Voeg een vormverdeelstuk toe om de paginasecties op visuele wijze van elkaar "
+"te onderscheiden."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "scheiding"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Vormkleur"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Instellingen scheiding"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Hoogte vorm in pixels"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Hoogte achtergrond in pixels"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Oriëntatie"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Vormkleur"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Delen op Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Delen op Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Delen op Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Delen op Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Delen op LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Delen via e-mail"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Delen op Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Delen op Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Delen op Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Delen"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "sociaal"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Voeg links naar sociale media toe om meer vind-ik-leuks en gedeelde items te krijgen."
+msgstr ""
+"Voeg links naar sociale media toe om meer vind-ik-leuks en gedeelde items te "
+"krijgen."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Kleuren sociale media"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Pictogramgrootte"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Cirkelgrootte"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Knopgrootte"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Pictogrammen"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "E-mail"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "De kleuren voor deelknoppen zijn ingeschakeld."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Schakel dit in om de officiële kleuren van elk platform voor sociale media te gebruiken."
+msgstr ""
+"Schakel dit in om de officiële kleuren van elk platform voor sociale media "
+"te gebruiken."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Kleuren sociale media"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Facebook-profiel toevoegen"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Twitter-profiel toevoegen"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Instagram-profiel toevoegen"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Pinterest-profiel toevoegen"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "LinkedIn-profiel toevoegen"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "YouTube-profiel toevoegen"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Yelp-profiel toevoegen"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Houzz-profiel toevoegen"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Sociale profielen"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "koppelingen"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Geef links weer naar profielen op sociale media."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Profiellinks"
 
@@ -2057,18 +1928,6 @@ msgstr "Achtergrond verwijderen"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Achtergrond"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Auto"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Omslag"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Bevat"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1985,6 @@ msgstr "Achtergrond verwijderen"
 msgid "Remove "
 msgstr "Verwijderen "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Geen herhaling"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Horizontaal herhalen"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Verticaal herhalen"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Afbeelding naar achteren verplaatsen"
@@ -2150,17 +1997,14 @@ msgstr "Afbeelding naar voren verplaatsen"
 msgid "Link To"
 msgstr "Link naar"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Galerij %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Een afbeelding uploaden"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Licht"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2018,110 @@ msgstr "Bijlagepagina"
 msgid "Custom URL"
 msgstr "Aangepaste URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Oriëntatie"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Percentage"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Opnieuw instellen"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Eenheden selecteren"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "Eenheden %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Geavanceerde instellingen %s uitschakelen"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "Top %s"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "Rechts %s"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "Onder %s"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "Links %s"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Niet meer synchroniseren"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Synchroniseren"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Eenheden synchronisatie"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Boven"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Rechts"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Onder"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Links"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Geavanceerde instellingen %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Geavanceerd"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Standaard"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Lay-out"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2140,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Schakel dit in om de modus voor volledig scherm in te schakelen."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Kop %d"
@@ -2263,43 +2149,16 @@ msgstr "Kop %d"
 msgid "Custom color picker"
 msgstr "Aangepaste kleuren kiezen"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Origineel"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Grijswaarden"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sepia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Verzadiging"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Dim"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Filter toepassen"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Oriëntatie selecteren"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Hoogte"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Mobiel %s"
@@ -2333,7 +2192,8 @@ msgid "Five Seconds"
 msgstr "Vijf seconden"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Zes seconden"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2212,22 @@ msgstr "Negen seconden"
 msgid "Ten Seconds"
 msgstr "Tien seconden"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Pijlnavigatie"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Stipnavigatie"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "seconden"
@@ -2361,22 +2237,28 @@ msgid "second"
 msgstr "seconde"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Doorgaan na %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Ga automatisch door naar de volgende dia."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Slepen en knijpen zijn ingeschakeld op desktops en mobiele apparaten."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Schakel dit in om de sleepfunctie in te schakelen op desktops en mobiele apparaten."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Schakel dit in om de sleepfunctie in te schakelen op desktops en mobiele "
+"apparaten."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2269,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Schakel dit in om de pijlen voor navigatie in dia's weer te geven."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "De pijlen voor stipnavigatie worden weergegeven."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Schakel dit in om de stipnavigatie weer te geven."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "De ruimte in de container."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Schakel dit in om de video te dempen."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Schakel dit in om de video te herhalen."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Instellingen schuifregelaar"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Automatisch afspelen"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Overgangssnelheid"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Sleepbaar"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Pijlnavigatie"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Stipnavigatie"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Hoofdletters gebruiken"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normaal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2356,6 @@ msgstr "Geen ruimte onderkant"
 msgid "Change typography"
 msgstr "Typografie wijzigen"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Vet"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Hoofdletters"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Kleine letters"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Stapel op mobiel apparaat"
@@ -2481,31 +2366,36 @@ msgstr "Reactieve modus is ingeschakeld."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Schakel dit in om elementen op elkaar te stapelen bij kleinere viewports."
+msgstr ""
+"Schakel dit in om elementen op elkaar te stapelen bij kleinere viewports."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Ruimte bovenkant verwijderen"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "De bovenste marge wordt bij dit blok verwijderd."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Schakel dit in om een schaduw aan de kaart toe te voegen."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Schakel dit in om de marge aan de bovenkant van dit blok te verwijderen."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Schakel dit in om de stipnavigatie weer te geven."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Ruimte onderkant verwijderen"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "De onderste marge wordt bij dit blok verwijderd."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Schakel dit in om een schaduw aan de kaart toe te voegen."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Schakel dit in om de marge aan de onderkant van dit blok te verwijderen."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Schakel dit in om de stipnavigatie weer te geven."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2409,14 @@ msgstr "Wordt op volledige breedte weergegeven."
 msgid "Toggle to display button as full width."
 msgstr "Schakel dit in om de knop op volledige breedte weer te geven."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Rond"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Hero-instellingen"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Schaduw"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Selectievakje"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Hoofdletters"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2436,801 @@ msgstr "Zoeken naar een blok"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Dit blok wordt toegevoegd aan de pagina en kan momenteel niet worden uitgeschakeld"
+msgstr ""
+"Dit blok wordt toegevoegd aan de pagina en kan momenteel niet worden "
+"uitgeschakeld"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Alles uitschakelen"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Geen blokken voor %s gevonden."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Galerijen %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Weergave open"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Accordeontitel toevoegen..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Accordeonitem"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "tabbladen"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "veelgestelde vragen"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "kennisgeving"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "bericht"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografie"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profiel"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "link"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "delen"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "tussenstuk"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "services"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menu"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restaurant"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "e-mail"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "mail"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Achternaam"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Tekstgedeelte"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Meerregelige tekst"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "e-mail"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "over"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "contact"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galerij"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "foto's"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Nacht"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "geanimeerd"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "code"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "knop"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "call-to-action"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "tekst"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "paragraaf"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "pictogrammen"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "klanten"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "bewijs"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "getuigenissen"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "adres"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "kaarten"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "afbeelding"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "adres"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "landing"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "vergelijking"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "rijen"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "kolommen"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "lay-outs"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "functies"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "scheiding"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "sociaal"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "koppelingen"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Weergave open"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Accordeonitem toevoegen"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Accordeon"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Tekst schrijven..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Titel schrijven..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Waarschuwing"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Auteur"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Knoppen"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Klik op te tweeten"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynamische HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Kenmerk"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Functies"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Etenswaar"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Eten en drinken"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "E-mail"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Naam"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Bericht"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Formulier"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Carrousel"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Gemetselde stijl"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Gestapeld"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist-URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Opvallend"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Pictogram"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logo's en badges"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Kaart"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Mediakaart"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Carrousel"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Tariefoverzicht"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Item tariefoverzicht"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Kolom"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Rij"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Services"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Service"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Vormverdeelstuk"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Delen"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Sociale profielen"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Info"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Geslaagd"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Waarschuwing"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Fout"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Stip"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Lijn"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Volledige breedte"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Raster"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Vermelden"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Standaard"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Lagen"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Uitgelijnd"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Opgevuld"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Gestapeld"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Horizontaal herhalen"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Golvend"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Heuvels"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Golven"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Gehoekt"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Aflopend"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Afgerond"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Driehoek"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Gepunt"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Masker"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Pictogram"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Tekst"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Pictogram en tekst"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Rond"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Onder links"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Boven links"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Neerzetten om als avatar toe te voegen"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Auteur"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3252,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "Dit is een functieblok waarmee je functies kunt uitlichten."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "Herokop toevoegen..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Voeg herocontent toe, hetgeen meestal een inleidend onderdeel van een pagina is samen met een of twee call-to-actions."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Voeg herocontent toe, hetgeen meestal een inleidend onderdeel van een pagina "
+"is samen met een of twee call-to-actions."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Primaire actie toevoegen..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Secundaire actie toevoegen..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3294,126 @@ msgstr "Content toevoegen..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Vervang deze tekst door een beschrijving die wordt toegevoegd aan de kaartafbeelding. Voeg dan meer blokken toe aan deze kaart, zoals knoppen, lijsten of afbeeldingen."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Vervang deze tekst door een beschrijving die wordt toegevoegd aan de "
+"kaartafbeelding. Voeg dan meer blokken toe aan deze kaart, zoals knoppen, "
+"lijsten of afbeeldingen."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Titel schrijven..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Beschrijving opstellen..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normaal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Instellingen knoppen"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Aangepast"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Stapel op mobiel apparaat"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Instellingen dynamische HR"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Geen"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Geen"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Klein"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Gemiddeld"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Groot"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Extra groot"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Geen"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Klein"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Gemiddeld"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Groot"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,8 +3932,12 @@ msgstr "muziek microfoon nummer artiest creatief media audio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "microfoon podcast computer apparaat muziek microfoon nummer artiest creatief media audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"microfoon podcast computer apparaat muziek microfoon nummer artiest creatief "
+"media audio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3961,12 @@ msgstr "film videografie regisseur producent media creatief"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "film videografie regisseur producent media creatief camera fotograaf fotografie sluitingstijd"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"film videografie regisseur producent media creatief camera fotograaf "
+"fotografie sluitingstijd"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3983,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "palet ontwerp kleuren artiest creatief media verf kwast"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standaard"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Zilver"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Donker"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Nacht"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Aubergine"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Rond"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Schaduw"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Standaard"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Geen"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Selectievakje"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Menutitel..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Klein"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Gemiddeld"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Groot"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Extra groot"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Auto"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Omslag"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Bevat"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Boven links"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Boven centraal"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Boven rechts"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Centraal links"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Centraal midden"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Centraal rechts"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Onder links"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Onder centraal"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Onder rechts"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Geen herhaling"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Herhalen"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Horizontaal herhalen"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Verticaal herhalen"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Link Rel"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Donker"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Licht"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Geen"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Afbeelding"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Pixel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Percentage"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Origineel"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Grijswaarden"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Mediabestand"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Verzadiging"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Vintage filter"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Vintage filter"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Hoofdletters gebruiken"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normaal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Vet"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Standaard"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Hoofdletters"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Kleine letters"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4331,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks is een pakket met professionele <strong>blokken content om pagina's te ontwikkelen</strong> voor de blokeditor van WordPress Gutenberg. Met onze blokken kunnen ontwikkelaars mooie en veelzijdige pagina's bouwen in WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks is een pakket met professionele <strong>blokken content om pagina's "
+"te ontwikkelen</strong> voor de blokeditor van WordPress Gutenberg. Met onze "
+"blokken kunnen ontwikkelaars mooie en veelzijdige pagina's bouwen in "
+"WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4349,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Dat is niet eerlijk!"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Een recensie schrijven"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s jaar"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "een jaar"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s weken"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "een week"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s dagen"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "een dag"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s uur"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "een uur"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minuten"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "een minuut"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s seconde"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "een seconde"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "WordPress Plugin %s"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Gebruik je %s graag?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Je gebruikt %1$s nu %2$s. We zijn benieuwd wat je vindt. Kun je een recensie schrijven? We zouden je eeuwig dankbaar zijn!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Een recensie schrijven"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Je gebruikt %1$s nu %2$s. We zijn benieuwd wat je vindt. Kun je een recensie "
+"schrijven? We zouden je eeuwig dankbaar zijn!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Nee bedankt/dat heb ik al gedaan"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Bedankt voor het kiezen van CoBlocks, de beste manier om pagina's te bouwen voor de nieuwe blokeditor van WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Bedankt voor het kiezen van CoBlocks, de beste manier om pagina's te bouwen "
+"voor de nieuwe blokeditor van WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Je hebt allerlei handige blokken toegevoegd aan de WordPress-editor samen met een nieuwe toolkit om pagina's te bouwen. Met CoBlocks heb je allerlei baanbrekende functies: %1$s tientallen blokken%2$s, een %1$s geweldige oplossing om pagina's te bouwen %2$s en %1$s functies voor aangepaste typografie%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Je hebt allerlei handige blokken toegevoegd aan de WordPress-editor samen "
+"met een nieuwe toolkit om pagina's te bouwen. Met CoBlocks heb je allerlei "
+"baanbrekende functies: %1$s tientallen blokken%2$s, een %1$s geweldige "
+"oplossing om pagina's te bouwen %2$s en %1$s functies voor aangepaste "
+"typografie%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Hier zijn een paar video's om aan de slag te gaan:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Kijk hoe je je eerste pagina maakt met %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Kijk hoe je je eerste pagina maakt"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Kijk hoe je de blokken voor rijen en het verdelen van vormen gebruikt"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Meer informatie over het gebruik van het Media Card-blok"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Ziet dat er goed uit? %1$sAbonneer je op ons YouTube-kanaal%2$s en ontvang een melding van nieuwe videolessen."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Ziet dat er goed uit? %1$sAbonneer je op ons YouTube-kanaal%2$s en ontvang "
+"een melding van nieuwe videolessen."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Stuur vragen of feedback op via %1$sTwitter%4$s of onze %2$sFacebook-groep %4$s. En %3$sabonneer je op onze nieuwsbrief%4$s als je op de hoogte wilt blijven van alle nieuwe ontwikkelingen bij CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Stuur vragen of feedback op via %1$sTwitter%4$s of onze %2$sFacebook-groep "
+"%4$s. En %3$sabonneer je op onze nieuwsbrief%4$s als je op de hoogte wilt "
+"blijven van alle nieuwe ontwikkelingen bij CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Veel plezier!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Ga hier aan de slag met CoBlocks:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4520,36 @@ msgstr "Blokken in- of uitschakelen"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "reCaptcha-sitesleutel van Google om het formulier tegen spam te beschermen"
+msgstr ""
+"reCaptcha-sitesleutel van Google om het formulier tegen spam te beschermen"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
-msgstr "Geheime reCaptcha-sleutel van Google om het formulier tegen spam te beschermen"
+msgstr ""
+"Geheime reCaptcha-sleutel van Google om het formulier tegen spam te "
+"beschermen"
+
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Naam"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Eerste"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Laatste"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Bericht"
 
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Verzenden"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Je bericht is verzonden:"
 
@@ -3490,3 +4564,87 @@ msgstr "Delen op LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "Meldingstype"
+
+#~ msgid "Edit image"
+#~ msgstr "Afbeelding bewerken"
+
+#~ msgid "Remove image"
+#~ msgstr "Afbeelding verwijderen"
+
+#~ msgid "Heading..."
+#~ msgstr "Kop..."
+
+#~ msgid "Author Name"
+#~ msgstr "Naam auteur"
+
+#~ msgid "Write biography..."
+#~ msgstr "Biografie schrijven..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Voeg een biografie van de auteur toe."
+
+#~ msgid "%s Settings"
+#~ msgstr "Instellingen %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Kleur van bijschrift"
+
+#~ msgid "Highlight text."
+#~ msgstr "Markeer de tekst."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Tabellen %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Instellingen tariefoverzicht"
+
+#~ msgid "Tables"
+#~ msgstr "Tabellen"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Een kolom geplaatst binnen het blok met het tariefoverzicht."
+
+#~ msgid "Sepia"
+#~ msgstr "Sepia"
+
+#~ msgid "Dim"
+#~ msgstr "Dim"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Oriëntatie selecteren"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "De bovenste marge wordt bij dit blok verwijderd."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Schakel dit in om de marge aan de bovenkant van dit blok te verwijderen."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "De onderste marge wordt bij dit blok verwijderd."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Schakel dit in om de marge aan de onderkant van dit blok te verwijderen."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Primaire actie toevoegen..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Secundaire actie toevoegen..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normaal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Ga hier aan de slag met CoBlocks:"

--- a/languages/coblocks-pl_PL.po
+++ b/languages/coblocks-pl_PL.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Wyświetl otwartą"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Dodaj tytuł harmonijki..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Element harmonijki"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Dodaj zwijane elementy harmonijki do harmonijek."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "karty"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "najczęściej zadawane pytania"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "Przełącz, aby ustawić ten element harmonijki jako domyślnie otwarty.
 msgid "Accordion Item Settings"
 msgstr "Ustawienia elementu harmonijki"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Wyświetl otwarty"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Ustawienia kolorów"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Kolor tła"
@@ -103,14 +63,6 @@ msgstr "Kolor tła"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Kolor tekstu tytułu"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Dodaj element harmonijki"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Harmonijka"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +78,85 @@ msgstr "Obsługa przeglądarki Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Dodaj obsługę przeglądarki Internet Explorer, wczytując element polyfill JavaScript."
+msgstr ""
+"Dodaj obsługę przeglądarki Internet Explorer, wczytując element polyfill "
+"JavaScript."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Obsługa przeglądarki Internet Explorer poprzez wczytanie elementu polyfill JavaScript na tej stronie."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Obsługa przeglądarki Internet Explorer poprzez wczytanie elementu polyfill "
+"JavaScript na tej stronie."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Ostrzeżenie"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Błąd"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Typ alertu"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Domyślny"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Informacja"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Sukces"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Wpisz tytuł..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Wpisz tekst..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Alert"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Podaj kontekstowe wiadomości dotyczące opinii."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "uwaga"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "wiadomość"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Kolor tekstu"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Edytuj obraz"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Edytuj galerię"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Usuń obraz"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Wpisz podpis…"
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Upuść, aby dodać jako awatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Nagłówek..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Imię i nazwisko autora"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Napisz biografię..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Ustawienia formularzy"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Autor"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Zachęć gości do podjęcia działania przy użyciu wielu przycisków "
+"umieszczonych obok siebie."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Dodaj biografię autora"
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografia"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profil"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Przyciski"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Zachęć gości do podjęcia działania przy użyciu wielu przycisków umieszczonych obok siebie."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "łącze"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Ustawienia przycisków"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Umieść w stosie na urządzeniu mobilnym"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +174,25 @@ msgstr "Nazwa użytkownika Twittera"
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Dodaj przycisk..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Dodaj cytat do tweeta..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Kliknij, aby tweetnąć"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Dodaj cytat dla czytelników do tweeta na Twitterze."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "udostępnij"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +200,18 @@ msgid "Text Settings"
 msgstr "Ustawienia tekstu"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Kolor przycisku"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynamiczny HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Dodaj rozdzielacz o zmiennym rozmiarze między innymi blokami."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "rozdzielacz"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Ustawienia dynamicznego HR"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Wysokość w pikselach"
 
@@ -347,17 +223,12 @@ msgstr "Wysokość elementu dynamicznego separatora w pikselach."
 msgid "Color"
 msgstr "Kolor"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Dodaj jako tło"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Funkcja"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "Pojedyncza kolumna podrzędna w nadrzędnym bloku funkcji."
 
@@ -366,73 +237,55 @@ msgid "Feature Settings"
 msgstr "Ustawienia funkcji"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Dopełnienie"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Funkcje"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Dodaj do trzech kolumn niewielkich uwag dotyczących produktu lub usługi."
+msgstr ""
+"Dodaj do trzech kolumn niewielkich uwag dotyczących produktu lub usługi."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "usługi"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Margines"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Oprawa"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Odstęp między poszczególnymi kolumnami"
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Mały"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Średni"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +295,8 @@ msgstr "Duży"
 msgid "Features Settings"
 msgstr "Ustawienia funkcji"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Kolumny"
 
@@ -455,76 +308,72 @@ msgstr "Dodaj sekcję menu"
 msgid "Menu title..."
 msgstr "Tytuł menu..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Siatka"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Lista"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Upuść obraz, aby zastąpić"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Usuń obraz"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Dodaj tytuł..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Pikantne"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Ostre"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Wegetariańskie"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Bezglutenowe"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescowegetariańskie"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Weganizm"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Dodaj opis..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0,00 USD"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Element żywności"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Element żywności i napoju w bloku Żywność i napoje."
 
@@ -560,62 +409,46 @@ msgstr "Przełącz, aby wyświetlić cenę tego elementu."
 msgid "Item Attributes"
 msgstr "Atrybuty elementu"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Pikantniejsze"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Ustawienia obrazów"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Tekst alternatywny"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Opisz cel tego obrazu"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Pozostaw pusty, jeśli obraz służy wyłącznie do dekoracji."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Punkt centralny"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Żywność i napoje"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Wyświetl menu lub cennik."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restauracja"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menu"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Style"
@@ -648,134 +481,85 @@ msgstr "Wyświetlanie ceny każdego elementu"
 msgid "Toggle to show the price of each item."
 msgstr "Przełącz, aby wyświetlić cenę każdego elementu."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Adres e-mail"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "e-mail"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "mail"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Pole adresu e-mail."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Komunikat"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Obszar tekstowy"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Tekst wielowierszowy"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Pole tekstowe dla dłuższych odpowiedzi."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s nie jest prawidłowym adresem e-mail."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s i %s nie są prawidłowymi adresami e-mail."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s nie są prawidłowymi adresami e-mail."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Adres e-mail"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "nazwa@przykład.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Temat"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Ustawienia formularzy"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Dodaj klucze reCAPTCHA witryny i tajny, aby ochronić formularz przed spamem."
+msgstr ""
+"Dodaj klucze reCAPTCHA witryny i tajny, aby ochronić formularz przed spamem."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Wygeneruj klucze"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Moje klucze"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Uzyskaj pomoc"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Klucz witryny"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Klucz tajny"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Zapisywanie"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Zapisz"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Usuń"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Imię"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Nazwisko"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Nazwa"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Pole tekstowe dla imion i nazwisk."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Pole adresu e-mail."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Dodaj etykietę…"
 
@@ -783,41 +567,38 @@ msgstr "Dodaj etykietę…"
 msgid "Required"
 msgstr "Wymagane"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Ustawienia pola imienia i nazwiska"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Nazwisko"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Wyświetlanie pól imienia i nazwiska."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Przełącz, aby dodać pole nazwiska."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Formularz"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Pole tekstowe dla imion i nazwisk."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Pole tekstowe dla dłuższych odpowiedzi."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Dodaj prosty formularz do strony."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "e-mail"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "informacje"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "kontakt"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Temat"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +608,219 @@ msgstr "Dodaj tekst…"
 msgid "Button Text Color"
 msgstr "Kolor tekstu przycisku"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Edytuj galerię"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Karuzela"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "obraz %1$d z %2$d w galerii"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Wpisz podpis…"
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Karuzela"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Wyświetl wiele obrazów w pięknej galerii karuzelowej."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galeria"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "zdjęcia"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s — ustawienia"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Wysokość linii"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Wyświetlanie strzałek nawigacji kropkami."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Przełącz, aby wyświetlić podpisy multimediów."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Ustawienia kolorów"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Rozmiar"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Zaokrąglone rogi"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Kolor podpisu"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Zastosuj"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Murowana"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Wpisz opis..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Wyświetl wiele obrazów w uporządkowanej galerii murowanej."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Wyświetl wiele obrazów w pięknej galerii karuzelowej."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Rozmiar kolumny"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Ustawienia obrazów"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Dodaj zaokrąglone rogi do elementów galerii."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Cień"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Podpisy"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Styl podpisu"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Wyświetlanie podpisów dla każdego elementu multimedialnego."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Przełącz, aby wyświetlić podpisy multimediów."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Murowana"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Wyświetl wiele obrazów w uporządkowanej galerii murowanej."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Przełącz, aby włączyć opcje sterowania mapą."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Ustawienia mapy"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Rozmiar kolumny"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Dodaj zaokrąglone rogi do elementów galerii."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Jasny"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "W stosie"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Wyświetl wiele obrazów w galerii z jedną kolumną w stosie."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Obrazy o pełnej szerokości"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Obraz o pełnej szerokości"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Cień ramki"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Obrazy o pełnej szerokości są włączone"
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Przełącz, aby wypełnić całkowicie obszar galerii obrazami o pełnej szerokości."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Przełącz, aby wypełnić całkowicie obszar galerii obrazami o pełnej "
+"szerokości."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Ustawienia elementu"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Obrazy o pełnej szerokości"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Obraz o pełnej szerokości"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Usuń plik GIF"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Ten plik GIF ma pusty atrybut alt"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Wyszukaj idealny plik GIF w serwisie Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Wyszukaj pliki GIF"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Wybierz dowolny plik GIF."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animowany"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +846,11 @@ msgstr "Plik GitHub"
 msgid "File"
 msgstr "Plik"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Wyświetl ten gist w serwisie GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Adres URL gistu"
 
@@ -1024,12 +863,9 @@ msgid "Loading Gist"
 msgstr "Ładowanie gistu"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Osadź gisty GitHub, dodająć łącze do gistu."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "kod"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +888,159 @@ msgid "Gist Meta"
 msgstr "Metadane gistu"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Zmień układ"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Dodaj tło do %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Widżet frontalny"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Obszar wprowadzenia do strony, któremu towarzyszy niewielka ilość tekstu i "
+"wezwanie do działania."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Obszar wprowadzenia do strony, któremu towarzyszy niewielka ilość tekstu i wezwanie do działania."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "przycisk"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "wezwanie do działania"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Szerokość zawartości w pikselach"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Ustawienia widżetu frontalnego"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Miejsce w kontenerze"
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Po lewej u góry"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Na środku u góry"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Po prawej u góry"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Na środku po lewej"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Na środku pośrodku"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Na środku po prawej"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Po lewej u dołu"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Na środku u dołu"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Po prawej u dołu"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Dodaj wyróżniony tekst..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Wyróżnienie"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Wyróżnij tekst."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "tekst"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "akapit"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Ikona"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Dodaj stylizowany symbol graficzny, aby przekazać coś więcej."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "ikony"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Duża"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Dodaj stylizowany symbol graficzny, aby przekazać coś więcej."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Ustawienia ikony"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Wyłącz ustawienia zaawansowane %s"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Zresetuj"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Niestandardowy rozmiar %s"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Ustawienia zaawansowane %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Niestandardowy"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Zaawansowane"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Promień"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Wyszukiwanie ikon"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Brak wyników."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Ustawienia łącza"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "Adres URL łącza"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Łącze relacji"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Otwieranie w nowej karcie"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Otwórz w nowej karcie"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Kolor ikony"
 
@@ -1261,30 +1049,17 @@ msgid "Edit logos"
 msgstr "Edytuj logo"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logo i odznaki"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr "Przeciągnij obrazy, prześlij nowe lub wybierz pliki z biblioteki."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "Dodaj logo, odznaki lub certyfikaty, aby budować wiarygodność."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "klienci"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "dowód"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "opinie"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1081,144 @@ msgstr "Edytuj lokalizację"
 msgid "Map style"
 msgstr "Styl mapy"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Nieprawidłowy klucz API lub zbyt dużo żądań"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Mapa Google"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "Wprowadź lokalizację lub adres, aby upuścić pinezkę na mapie Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Wyszukaj miejsce lub adres…"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Zastosuj"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Mapa"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Dodaj adres i upuść pinezkę na mapie Google."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "adres"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "mapy"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Wybierz styl mapy"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Ustawienia mapy"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Poziom powiększenia"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Wysokość mapy w pikselach"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Poziom powiększenia"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Rozmiar markera"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Opcje precyzyjnego sterowania są włączone."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Przełącz, aby włączyć opcje sterowania mapą."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Elementy sterujące mapą"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Typ mapy"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "Przełączanie między widokami mapy standardowej i satelitarnej jest włączone."
+msgstr ""
+"Przełączanie między widokami mapy standardowej i satelitarnej jest włączone."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Przełącz, aby włączyć przełączanie między mapą standardową a satelitarną."
+msgstr ""
+"Przełącz, aby włączyć przełączanie między mapą standardową a satelitarną."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Elementy sterujące powiększeniem"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Wyświetlanie elementów sterujących powiększeniem mapy."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Przełącz, aby włączyć powiększanie i pomniejszanie mapy przy użyciu elementów sterujących powiększeniem."
+msgstr ""
+"Przełącz, aby włączyć powiększanie i pomniejszanie mapy przy użyciu "
+"elementów sterujących powiększeniem."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Widok ulic"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Wyświetlanie elementu sterującego widokiem ulic na mapie."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Przełącz, aby wyświetlić element sterujący widokiem ulic w prawym dolnym rogu."
+msgstr ""
+"Przełącz, aby wyświetlić element sterujący widokiem ulic w prawym dolnym "
+"rogu."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Przełącznik pełnego ekranu"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Wyświetlanie elementu sterującego mapą pełnoekranową."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Przełącz, aby wyświetlić element sterujący mapą pełnoekranową."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Klucz API Map Google"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Dodaj klucz API Map Google. Aktualizacja tego klucza spowoduje ustawienie wszystkich map w celu użycia nowego klucza."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Dodaj klucz API Map Google. Aktualizacja tego klucza spowoduje ustawienie "
+"wszystkich map w celu użycia nowego klucza."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Pobierz klucz"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Potrzebujesz pomocy?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Wprowadź klucz API Map Google…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Zapisano"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standardowy"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Srebrny"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Ciemny"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Noc"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Ciemnofioletowy"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1228,9 @@ msgstr "Multimedia po prawej"
 msgid "Media on left"
 msgstr "Multimedia po lewej"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Karta multimediów"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Dodaj kartę obrazu lub filmu z przesunięciem obok siebie"
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "obraz"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "film"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1244,18 @@ msgstr "Wyświetlanie cienia karty."
 msgid "Toggle to add a card shadow."
 msgstr "Przełącz, aby dodać cień karty."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Cień %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Wyświetlanie cienia %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Przełącz, aby dodać cień %s."
 
@@ -1545,40 +1279,171 @@ msgstr "Upuść, aby zastąpić multimedia"
 msgid "Edit media"
 msgstr "Edytuj multimedia"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Tabele %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Adres URL gistu"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Plan %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Karuzela"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Adres URL gistu"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Ustawienia kolorów"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Wyświetlanie ceny tego elementu."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Przełącz, aby wyświetlić metadane gistu."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Wyświetlanie przycisku z wezwaniem do działania."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Przełącz, aby wyświetlić metadane gistu."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Ustawienia funkcji"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Multimedia po lewej"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Multimedia po prawej"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Rozmiar kolumny"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Ustawienia gistu"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Tabela cen"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Tabela cen"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Tabela cen"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Tabela cen"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Dodaj tabele cel."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "docelowa"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Plan %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "porównanie"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Ustawienia tabeli cen"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabele"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1461,171 @@ msgstr "Plan A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Element tabeli cen"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Kolumna umieszczona w bloku tabeli cen."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Dodaj tło do %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Kolumna"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Bezpośredni element podrzędny wiersza."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Szerokość"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Ustawienia kolumny"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Odstęp wokół kontenera"
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Szerokość"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Zmień układ"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "jedna"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "dwie"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "trzy"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "cztery"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Dodaj tło do %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Jedna kolumna"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Dwie kolumny"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Trzy kolumny"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Cztery kolumny"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Układ wierszy"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Wiersz"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Teraz wybierz układ dla tego wiersza kolumny %s."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Wybierz liczbę kolumn dla tego wiersza."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Wybierz kolumny wiersza"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Wybierz układ wierszy"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Powrót do kolumn"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Dodaj strukturalną otoczkę dla bloków kolumn, a następnie dodaj żądane bloki zawartości do kolumn."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Dodaj strukturalną otoczkę dla bloków kolumn, a następnie dodaj żądane bloki "
+"zawartości do kolumn."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "wiersze"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "kolumny"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "układy"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Układ"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Ustawienia wierszy"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Brak"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1635,9 @@ msgstr "Kwadrat"
 msgid "Circle"
 msgstr "Okrąg"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Usługi"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Dodaj maksymalnie cztery kolumny usług do wyświetlenia."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "funkcje"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1659,7 @@ msgstr "Wyświetlanie przycisków z wezwaniem do działania."
 msgid "Toggle to show call to action buttons."
 msgstr "Przełącz, aby wyświetlić przyciski z wezwaniem do działania."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Usługa"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Pojedynczy element usługi w bloku usług."
 
@@ -1785,264 +1680,231 @@ msgid "Toggle to show a call to action button."
 msgstr "Przełącz, aby wyświetlić przycisk z wezwaniem do działania."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Przerzuć w poziomie"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Przerzuć w pionie"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Separator kształtu"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "Dodaj separator kształtu, aby wizualnie odróżnić sekcje strony."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "separator"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Kolor kształtu"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Ustawienia separatora"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Wysokość kształtu w pikselach"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Wysokość tła w pikselach"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Orientacja"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Kolor kształtu"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Udostępnij na Twitterze"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Udostępnij na Facebooku"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Udostępnij na Twitterze"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Udostępnij w Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Udostępnij na LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Udostępnij pocztą e-mail"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Udostępnij na Twitterze"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Udostępnij na Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Udostępnij na Reddicie"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Udostępnij"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "społecznościowe"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Dodaj łącza udostępniania w sieciach społecznościowych, które pomogą uzyskać polubienia i udostępnienia."
+msgstr ""
+"Dodaj łącza udostępniania w sieciach społecznościowych, które pomogą uzyskać "
+"polubienia i udostępnienia."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Kolory mediów społecznościowych"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Rozmiar ikony"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Rozmiar okręgu"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Rozmiar przycisku"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Ikony"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Adres e-mail"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Kolory przycisku udostępniania są włączone."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Przełącz, aby użyć oficjalnych kolorów poszczególnych platform mediów społecznościowych."
+msgstr ""
+"Przełącz, aby użyć oficjalnych kolorów poszczególnych platform mediów "
+"społecznościowych."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Kolory mediów społecznościowych"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Dodaj profil na Facebooku"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Dodaj profil na Twitterze"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Dodaj profil na Instagramie"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Dodaj profil w Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Dodaj profil na LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Dodaj profil na YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Dodaj profil w Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Dodaj profil w Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Profile społecznościowe"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "łącza"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Wyświetl łącza do swoich profili w mediach społecznościowych."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Łącza do profili"
 
@@ -2057,18 +1919,6 @@ msgstr "Usuń tło"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Tło"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Automatycznie"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Tło"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Zawiera"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1976,6 @@ msgstr "Usuń tło"
 msgid "Remove "
 msgstr "Usuń "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Bez powtarzania"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Powtórz w poziomie"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Powtórz w pionie"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Przenieś obraz do tyłu"
@@ -2150,17 +1988,14 @@ msgstr "Przenieś obraz do przodu"
 msgid "Link To"
 msgstr "Łącze do"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Galeria %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Prześlij obraz"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Jasny"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2009,110 @@ msgstr "Strona załącznika"
 msgid "Custom URL"
 msgstr "Niestandardowy adres URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Piksel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Orientacja"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Procent"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Zresetuj"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Wybierz jednostki"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "Jednostki %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Wyłącz ustawienia zaawansowane %s"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s u góry"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s po prawej"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s u dołu"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s po lewej"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Wyłącz synchronizację"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Synchronizuj"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Synchronizuj jednostki"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Góra"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Prawo"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Dół"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Lewo"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Ustawienia zaawansowane %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Domyślny"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Układ"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2131,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Przełącz, aby włączyć tryb pełnoekranowy."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Nagłówek %d"
@@ -2263,43 +2140,16 @@ msgstr "Nagłówek %d"
 msgid "Custom color picker"
 msgstr "Selektor kolorów niestandardowych"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Oryginalny"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Odcienie szarości"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sepia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Nasycenie"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Przyciemniony"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Klasyczny"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Zastosuj filtr"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Wybierz orientację"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Wysokość"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Mobilny %s"
@@ -2333,7 +2183,8 @@ msgid "Five Seconds"
 msgstr "Pięć sekund"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Sześć sekund"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2203,22 @@ msgstr "Dziewięć sekund"
 msgid "Ten Seconds"
 msgstr "Dziesięć sekund"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Nawigacja strzałkami"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Nawigacja kropkami"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "s"
@@ -2361,22 +2228,29 @@ msgid "second"
 msgstr "s"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Przejście dalej po %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Przejdź automatycznie do następnego slajdu."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
-msgstr "Przeciąganie i przesuwanie włączone na komputerach i urządzeniach mobilnych."
+#, fuzzy
+msgid "Dragging and flicking enabled."
+msgstr ""
+"Przeciąganie i przesuwanie włączone na komputerach i urządzeniach mobilnych."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Przełącz, aby włączyć funkcję przeciągania na komputerach i urządzeniach mobilnych."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Przełącz, aby włączyć funkcję przeciągania na komputerach i urządzeniach "
+"mobilnych."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2261,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Przełącz, aby wyświetlić strzałki nawigacji między slajdami."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Wyświetlanie strzałek nawigacji kropkami."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Przełącz, aby wyświetlić nawigację kropkami."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Miejsce w kontenerze"
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Przełącz, aby wyciszyć film."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Przełącz, aby zapętlić film."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Ustawienia suwaka"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Automatyczne odtwarzanie"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Szybkość przejścia"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Możliwość przeciągania"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Nawigacja strzałkami"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Nawigacja kropkami"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Od wielkiej litery"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normalny"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2348,6 @@ msgstr "Brak odstępu od dołu"
 msgid "Change typography"
 msgstr "Zmień typografię"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Pogrubienie"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Wielkie litery"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Małe litery"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Umieść w stosie na urządzeniu mobilnym"
@@ -2481,31 +2358,36 @@ msgstr "Responsywność jest włączona."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Przełącz, aby umieszczać elementy w stosach w mniejszych okienkach ekranu."
+msgstr ""
+"Przełącz, aby umieszczać elementy w stosach w mniejszych okienkach ekranu."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Usuń odstęp od góry"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Górny margines został usunięty dla tego bloku."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Przełącz, aby dodać cień karty."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Przełącz, aby usunąć margines zastosowany na górze tego bloku."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Przełącz, aby wyświetlić nawigację kropkami."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Usuń odstęp od dołu"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Dolny margines został usunięty dla tego bloku."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Przełącz, aby dodać cień karty."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Przełącz, aby usunąć margines zastosowany na dole tego bloku."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Przełącz, aby wyświetlić nawigację kropkami."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2401,14 @@ msgstr "Wyświetlanie w pełnej szerokości"
 msgid "Toggle to display button as full width."
 msgstr "Przełącz, aby wyświetlić przycisk w pełnej szerokości."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Kołowy"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Ustawienia widżetu frontalnego"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Cień"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Pole wyboru"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Wielkie litery"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2434,793 @@ msgstr "Ten blok został dodany do strony i obecnie nie można go wyłączyć"
 msgid "Disable all"
 msgstr "Wyłącz wszystkie"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Nie znaleziono żadnych bloków „%s”"
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Galerie %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Wyświetl otwartą"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Dodaj tytuł harmonijki..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Element harmonijki"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "karty"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "najczęściej zadawane pytania"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "uwaga"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "wiadomość"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografia"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "łącze"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "udostępnij"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "rozdzielacz"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "usługi"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menu"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restauracja"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "e-mail"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "mail"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Nazwisko"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Obszar tekstowy"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Tekst wielowierszowy"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "e-mail"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "informacje"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "kontakt"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galeria"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "zdjęcia"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Noc"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animowany"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "kod"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "przycisk"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "wezwanie do działania"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "tekst"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "akapit"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "ikony"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "klienci"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "dowód"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "opinie"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "adres"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "mapy"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "obraz"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "film"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "adres"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "docelowa"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "porównanie"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "wiersze"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "kolumny"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "układy"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "funkcje"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "separator"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "społecznościowe"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "łącza"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Wyświetl otwarty"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Dodaj element harmonijki"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Harmonijka"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Wpisz tekst..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Wpisz tytuł..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Alert"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Autor"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Przyciski"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Kliknij, aby tweetnąć"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynamiczny HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Funkcja"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Funkcje"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Element żywności"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Żywność i napoje"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Adres e-mail"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Nazwa"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Komunikat"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Formularz"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Karuzela"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Murowana"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "W stosie"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Adres URL gistu"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Widżet frontalny"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Wyróżnienie"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Ikona"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logo i odznaki"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Mapa"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Karta multimediów"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Karuzela"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Tabela cen"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Element tabeli cen"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Kolumna"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Wiersz"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Usługi"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Usługa"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Separator kształtu"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Udostępnij"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Profile społecznościowe"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Informacja"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Sukces"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Ostrzeżenie"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Błąd"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Kropka"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Linia"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Pełna szerokość"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Siatka"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Lista"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Domyślny"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Warstwy"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Z konturem"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Wypełniony"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "W stosie"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Powtórz w poziomie"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Falisty"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Wzgórza"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Fale"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Ukośny"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Nachylony"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Zaokrąglony"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Trójkąt"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Zaostrzony"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Maska"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Ikona"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Tekst"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Ikona i tekst"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Kołowy"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Po lewej u dołu"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Po lewej u góry"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Upuść, aby dodać jako awatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Autor"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3242,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "To jest blok funkcji, za pomocą którego można wyróżniać funkcje."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "Dodaj nagłówek frontalny..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Dodaj zawartość frontalną, która zwykle stanowi obszar wprowadzenia strony wraz z jednym lub dwoma wezwaniami do działania."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Dodaj zawartość frontalną, która zwykle stanowi obszar wprowadzenia strony "
+"wraz z jednym lub dwoma wezwaniami do działania."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Dodaj podstawowe działanie..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Dodaj dodatkowe działanie..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3284,125 @@ msgstr "Dodaj zawartość..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Zastąp ten tekst opisem, który będzie towarzyszyć obrazowi karty. Następnie dodaj więcej bloków do tej karty, takich jak przyciski, listy lub obrazy."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Zastąp ten tekst opisem, który będzie towarzyszyć obrazowi karty. Następnie "
+"dodaj więcej bloków do tej karty, takich jak przyciski, listy lub obrazy."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Wpisz tytuł..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Wpisz opis..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normalny"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Ustawienia przycisków"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Niestandardowy"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Umieść w stosie na urządzeniu mobilnym"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Ustawienia dynamicznego HR"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Brak"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Brak"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Mały"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Średni"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Duży"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Bardzo duży"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Brak"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Mały"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Średni"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Duży"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3180,7 +3842,8 @@ msgstr "zabawa impreza szczęśliwy świętowanie smak żywność"
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "płatki zapach aromat miły relaks krajobraz ogrodnictwo na zewnątrz dwór"
+msgstr ""
+"płatki zapach aromat miły relaks krajobraz ogrodnictwo na zewnątrz dwór"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3259,8 +3922,12 @@ msgstr "muzyka mikrofon utwór artysta kreatywny multimedia dźwięk"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "mikrofon podcast komputer urządzenie muzyka mikrofon utwór artysta kreatywny multimedia dźwięk"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"mikrofon podcast komputer urządzenie muzyka mikrofon utwór artysta kreatywny "
+"multimedia dźwięk"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3951,12 @@ msgstr "film wideografia reżyser producent multimedia kreatywny"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "film wideografia reżyser producent multimedia kreatywny aparat fotograf fotografia przysłona"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"film wideografia reżyser producent multimedia kreatywny aparat fotograf "
+"fotografia przysłona"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3973,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "paleta projekt kolory artysta kreatywny multimedia farba pędzel"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standardowy"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Srebrny"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Ciemny"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Noc"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Ciemnofioletowy"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Kołowy"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Cień"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Domyślny"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Brak"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Pole wyboru"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Tytuł menu..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Mały"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Średni"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Duży"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Bardzo duży"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Automatycznie"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Tło"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Zawiera"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Po lewej u góry"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Na środku u góry"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Po prawej u góry"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Na środku po lewej"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Na środku pośrodku"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Na środku po prawej"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Po lewej u dołu"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Na środku u dołu"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Po prawej u dołu"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Bez powtarzania"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Powtórz"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Powtórz w poziomie"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Powtórz w pionie"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Łącze relacji"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Ciemny"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Jasny"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Brak"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Obraz"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Piksel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Procent"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Oryginalny"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Odcienie szarości"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Plik multimedialny"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Nasycenie"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Filtr klasyczny"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Filtr klasyczny"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Od wielkiej litery"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normalny"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Pogrubienie"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Domyślny"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Wielkie litery"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Małe litery"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4321,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks to pakiet profesjonalnych <strong>bloków zawartości do budowania strony</strong> dla edytora blokowego WordPress Gutenberg. Nasze bloki skupiają się na zapewnianiu twórcom możliwości budowania pięknych i rozbudowanych stron w systemie WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks to pakiet profesjonalnych <strong>bloków zawartości do budowania "
+"strony</strong> dla edytora blokowego WordPress Gutenberg. Nasze bloki "
+"skupiają się na zapewnianiu twórcom możliwości budowania pięknych i "
+"rozbudowanych stron w systemie WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4339,169 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Oszukujesz, prawda?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Napisz recenzję"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s lat(a)"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "rok"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s tyg."
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "tydzień"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s dni"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "dzień"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s godz."
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "godz."
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s min"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "min"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s s"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "s"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Wtyczka WordPressa %s"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Czy podoba Ci się %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Korzystasz z %1$s już od %2$s. Czy chcesz napisać recenzję, aby przekazać nam swoją opinię? Będziemy bardzo wdzięczni!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Napisz recenzję"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Korzystasz z %1$s już od %2$s. Czy chcesz napisać recenzję, aby przekazać "
+"nam swoją opinię? Będziemy bardzo wdzięczni!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Nie, dziękuję / Już to zostało zrobione"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Dziękujemy za wybranie CoBlocks, doskonałego kreatora stron dla nowego edytora blokowego WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Dziękujemy za wybranie CoBlocks, doskonałego kreatora stron dla nowego "
+"edytora blokowego WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Właśnie dodaliśmy mnóstwo przydatnych bloków i nowy zestaw narzędzi kreatora stron do edytora WordPress. CoBlocks zapewnia mnóstwo innowacyjnych funkcji: %1$s dziesiątki bloków%2$s, %1$s kreatora stron %2$s i %1$s niestandardowe elementy sterujące do typografii%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Właśnie dodaliśmy mnóstwo przydatnych bloków i nowy zestaw narzędzi kreatora "
+"stron do edytora WordPress. CoBlocks zapewnia mnóstwo innowacyjnych funkcji: "
+"%1$s dziesiątki bloków%2$s, %1$s kreatora stron %2$s i %1$s niestandardowe "
+"elementy sterujące do typografii%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Oto kilka filmów, które pomogą Ci rozpocząć:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Zobacz, jak utworzyć pierwszą stronę przy użyciu %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Zobacz, jak utworzyć pierwszą stronę"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Zobacz, jak używać bloków Wiersz i Separator kształtu"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Zobacz, jak używać bloku Karta multimediów"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Podoba Ci się to, co widzisz? %1$sZasubskrybuj nasz kanał YouTube%2$s, a powiadomimy Cię o udostępnieniu nowych samouczków wideo."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Podoba Ci się to, co widzisz? %1$sZasubskrybuj nasz kanał YouTube%2$s, a "
+"powiadomimy Cię o udostępnieniu nowych samouczków wideo."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Jeśli masz jakieś pytania lub opinie, powiadom nas na %1$sTwitterze%4$s lub w naszej %2$sgrupie na Facebooku %4$s. %3$sZasubskrybuj też nasz biuletyn%4$s, jeśli chcesz pozostawać na bieżąco z nowościami dotyczącymi CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Jeśli masz jakieś pytania lub opinie, powiadom nas na %1$sTwitterze%4$s lub "
+"w naszej %2$sgrupie na Facebooku %4$s. %3$sZasubskrybuj też nasz biuletyn"
+"%4$s, jeśli chcesz pozostawać na bieżąco z nowościami dotyczącymi CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Miłego korzystania!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Rozpocznij korzystanie z CoBlocks tutaj:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4509,34 @@ msgstr "Włącz lub wyłącz bloki"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "Klucz witryny usługi Google reCaptcha do ochrony formularzy przed spamem"
+msgstr ""
+"Klucz witryny usługi Google reCaptcha do ochrony formularzy przed spamem"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "Klucz tajny usługi Google reCaptcha do ochrony formularzy przed spamem"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Nazwa"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Imię"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Nazwisko"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Komunikat"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Prześlij"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Twoja wiadomość została wysłana:"
 
@@ -3490,3 +4551,85 @@ msgstr "Udostępnij na LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Typ alertu"
+
+#~ msgid "Edit image"
+#~ msgstr "Edytuj obraz"
+
+#~ msgid "Remove image"
+#~ msgstr "Usuń obraz"
+
+#~ msgid "Heading..."
+#~ msgstr "Nagłówek..."
+
+#~ msgid "Author Name"
+#~ msgstr "Imię i nazwisko autora"
+
+#~ msgid "Write biography..."
+#~ msgstr "Napisz biografię..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Dodaj biografię autora"
+
+#~ msgid "%s Settings"
+#~ msgstr "%s — ustawienia"
+
+#~ msgid "Caption Color"
+#~ msgstr "Kolor podpisu"
+
+#~ msgid "Highlight text."
+#~ msgstr "Wyróżnij tekst."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Tabele %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Ustawienia tabeli cen"
+
+#~ msgid "Tables"
+#~ msgstr "Tabele"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Kolumna umieszczona w bloku tabeli cen."
+
+#~ msgid "Sepia"
+#~ msgstr "Sepia"
+
+#~ msgid "Dim"
+#~ msgstr "Przyciemniony"
+
+#~ msgid "Vintage"
+#~ msgstr "Klasyczny"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Wybierz orientację"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Górny margines został usunięty dla tego bloku."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "Przełącz, aby usunąć margines zastosowany na górze tego bloku."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Dolny margines został usunięty dla tego bloku."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "Przełącz, aby usunąć margines zastosowany na dole tego bloku."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Dodaj podstawowe działanie..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Dodaj dodatkowe działanie..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normalny"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Rozpocznij korzystanie z CoBlocks tutaj:"

--- a/languages/coblocks-pt_BR.po
+++ b/languages/coblocks-pt_BR.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Exibir aberto"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Adicionar título do acordeão..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Item de acordeão"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Adicione aos acordeões itens que podem ser recolhidos."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "guia"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "perguntas frequentes"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "Selecione para que o item de acordeão fique aberto por padrão."
 msgid "Accordion Item Settings"
 msgstr "Configurações dos itens de acordeão"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Exibir aberto"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Configurações de cor"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Cor de fundo"
@@ -103,14 +63,6 @@ msgstr "Cor de fundo"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Cor do texto do título"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Adicionar item de acordeão"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Acordeão"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +78,82 @@ msgstr "Suporte ao Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Carregue um polyfill JavaScript para permitir o suporte ao Internet Explorer."
+msgstr ""
+"Carregue um polyfill JavaScript para permitir o suporte ao Internet Explorer."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Carregue um polyfill JavaScript nesta página para permitir o suporte ao Internet Explorer."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Carregue um polyfill JavaScript nesta página para permitir o suporte ao "
+"Internet Explorer."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Aviso"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Erro"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Tipo de alerta"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Padrão"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Informações"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Sucesso"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Escreva o título..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Escreva o texto..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Alerta"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Exiba mensagens com feedback contextual."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "aviso"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "mensagem"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Cor do texto"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Editar imagem"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Editar galeria"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Remover imagem"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Escreva a legenda…"
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Solte para adicionar como avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Cabeçalho..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Nome do autor"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Escreva a biografia..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Configurações de formulário"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Autor"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Adicione a biografia do autor."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografia"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "perfil"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "Botões"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "Solicita ações dos visitantes com vários botões lado a lado."
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "link"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Configurações de botões"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Empilhar em dispositivos móveis"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "Botões"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +171,25 @@ msgstr "Nome de usuário do Twitter"
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Adicione um botão..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Adicione uma citação ao tweet..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Clique para tuitar"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Adicione uma citação para que os leitores enviem pelo Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "compartilhar"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +197,18 @@ msgid "Text Settings"
 msgstr "Configurações de texto"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Cor do botão"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "HR (regra horizontal) dinâmica"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Adicione um espaçador redimensionável entre outros blocos."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "espaçador"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Configurações de HR (regra horizontal) dinâmica"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Altura em pixels"
 
@@ -347,17 +220,12 @@ msgstr "Altura (em pixels) do elemento de separador dinâmico."
 msgid "Color"
 msgstr "Cor"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Adicionar como plano de fundo"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Recurso"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "Uma única coluna filha em um bloco de recursos pais."
 
@@ -366,73 +234,56 @@ msgid "Feature Settings"
 msgstr "Configurações de recursos"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Preenchimento"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Recursos"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Adicione até três colunas de observações pequenas relacionadas ao seu produto ou serviço."
+msgstr ""
+"Adicione até três colunas de observações pequenas relacionadas ao seu "
+"produto ou serviço."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "Serviços"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Margem"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Medianiz"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Espaço entre cada coluna."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Pequeno"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Medium"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +293,8 @@ msgstr "Grande"
 msgid "Features Settings"
 msgstr "Configurações de recursos"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Colunas"
 
@@ -455,76 +306,72 @@ msgstr "Adicionar seção do menu"
 msgid "Menu title..."
 msgstr "Título do menu..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Grid"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Lista"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Solte uma imagem para substituir"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Remover imagem"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Adicione o título..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Apimentado"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Quente"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetariano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Sem glúten"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pescetariano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Vegano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Adicione a descrição..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "US$ 0,00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Item de alimentação"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Um item de alimentação ou bebida no bloco Alimentos e bebidas."
 
@@ -560,62 +407,46 @@ msgstr "Selecione para mostrar o preço deste item."
 msgid "Item Attributes"
 msgstr "Atributos do item"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Mais apimentado"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Configurações de imagens"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Texto alternativo"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Descreva o propósito desta imagem"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Deixe vazio se a imagem for decorativa."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Ponto de foco"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Alimentos e bebidas"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Exiba um cardápio ou uma tabela de preços."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restaurante"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menu"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Estilos"
@@ -648,134 +479,86 @@ msgstr "Mostrando o preço de cada item"
 msgid "Toggle to show the price of each item."
 msgstr "Selecione para mostrar o preço de cada item."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Email"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "email"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "mail"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Um campo de endereço de email."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Mensagem"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Área de texto"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Texto multilinhas"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Uma caixa de texto para respostas mais longas."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s não é um endereço de email válido."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s e %s não são endereços de email válidos."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s não são endereços de email válidos."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Endereço de email"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Sujeito"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Configurações de formulário"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Adicione suas chaves secreta e de site do reCAPTCHA para proteger seu formulário contra spam."
+msgstr ""
+"Adicione suas chaves secreta e de site do reCAPTCHA para proteger seu "
+"formulário contra spam."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Gerar chaves"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Minhas chaves"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Obter ajuda"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Chave de site"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Chave secreta"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Salvando"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Salvar"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Remover"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Primeira"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Última"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Nome"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Um campo de texto para nomes."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Um campo de endereço de email."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Adicionar rótulo..."
 
@@ -783,41 +566,38 @@ msgstr "Adicionar rótulo..."
 msgid "Required"
 msgstr "Obrigatório"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Configurações do campo de nome"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Sobrenome"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Mostrando os campos de nome e sobrenome."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Selecione para adicionar o campo de sobrenome."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Formulário"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Um campo de texto para nomes."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Uma caixa de texto para respostas mais longas."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Adicione um formulário simples à sua página."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "email"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "sobre"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "contato"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Sujeito"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +607,220 @@ msgstr "Adicione o texto..."
 msgid "Button Text Color"
 msgstr "Cor do texto do botão"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Editar galeria"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Carrossel"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "imagem %1$d de %2$d na galeria"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Escreva a legenda…"
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Carrossel"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Exiba várias imagens em uma bela galeria no formato carrossel."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galeria"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "fotos"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s Configurações"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Altura da linha"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Mostrando navegação por pontos."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Selecione para mostrar as legendas da mídia."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Configurações de cor"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Cantos arredondados"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Cor da legenda"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Aplicar"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Alvenaria"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Escreva a descrição..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Exiba várias imagens em uma galeria organizada em blocos."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Exiba várias imagens em uma bela galeria no formato carrossel."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Tamanho da coluna"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Configurações de imagens"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Adicione cantos arredondados aos itens da galeria."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Sombra"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Legendas"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Estilo da legenda"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Mostrando legendas para cada item de mídia."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Selecione para mostrar as legendas da mídia."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Alvenaria"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Exiba várias imagens em uma galeria organizada em blocos."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Selecione para habilitar as opções de controle do mapa."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Configurações do mapa"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Tamanho da coluna"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Adicione cantos arredondados aos itens da galeria."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Claro"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Empilhado"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
-msgstr "Exiba várias imagens em uma galeria com os itens empilhados em uma coluna."
+msgstr ""
+"Exiba várias imagens em uma galeria com os itens empilhados em uma coluna."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Imagens com largura total"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Imagem com largura total"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Sombreamento de elementos"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "As imagens com largura total estão habilitadas."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Selecione para inserir imagens com largura completa na área disponível da galeria."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Selecione para inserir imagens com largura completa na área disponível da "
+"galeria."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Configurações de itens"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Imagens com largura total"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Imagem com largura total"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Remover GIF"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Este GIF tem um atributo alternativo vazio"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Encontre o GIF perfeito no Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Pesquisas GIFs"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Escolha qualquer GIF."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animado"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +846,11 @@ msgstr "Arquivo do GitHub"
 msgid "File"
 msgstr "Arquivo"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Ver este gist no GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL do gist"
 
@@ -1024,12 +863,9 @@ msgid "Loading Gist"
 msgstr "Carregando gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Adicione os links dos gists do GitHub para incorporá-los."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "código"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +888,161 @@ msgid "Gist Meta"
 msgstr "Metadados do gist"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Alterar layout"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Adicionar plano de fundo a %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Uma área introdutória de uma página, acompanhada por um pequeno texto e uma "
+"chamada para ação."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Uma área introdutória de uma página, acompanhada por um pequeno texto e uma chamada para ação."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "botão"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "chamada para ação"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Largura do conteúdo em pixels"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Configurações da área principal (Hero)"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Espaço dentro do contêiner."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Superior esquerda"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Superior central"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Superior direita"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Central esquerda"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Central"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Central direita"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Inferior esquerda"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Inferior central"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Inferior direita"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Adicione o texto destacado..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Destaque"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Texto de destaque."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "texto"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "parágrafo"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Ícone"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Adicione um símbolo estilizado, que funcionará como mais um elemento de comunicação."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "ícones"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Enorme"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr ""
+"Adicione um símbolo estilizado, que funcionará como mais um elemento de "
+"comunicação."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Configurações do ícone"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Desativar configurações avançadas de %s"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Redefinir"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Tamanho personalizado de %s"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Configurações avançadas de %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Personalizar"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Avançado"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Raio"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Pesquisa de ícones"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Nenhum resultado encontrado."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Configurações de link"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL do link"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Atributo rel do link"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Abrindo em nova guia"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Abrir em nova guia"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Cor do ícone"
 
@@ -1261,30 +1051,20 @@ msgid "Edit logos"
 msgstr "Editar logotipos"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logotipos e selos"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Arraste imagens, faça upload de imagens novas ou selecione arquivos da biblioteca."
+msgstr ""
+"Arraste imagens, faça upload de imagens novas ou selecione arquivos da "
+"biblioteca."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Adicione logotipos, selos ou certificações para demonstrar credibilidade."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "clientes"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "prova"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "testemunhos"
+msgstr ""
+"Adicione logotipos, selos ou certificações para demonstrar credibilidade."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1086,147 @@ msgstr "Editar localização"
 msgid "Map style"
 msgstr "Estilo do mapa"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Chave de API inválida ou excesso de solicitações"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Maps"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Insira uma localização ou um endereço para adicionar um alfinete ao Google Maps."
+msgstr ""
+"Insira uma localização ou um endereço para adicionar um alfinete ao Google "
+"Maps."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Pesquise um local ou endereço..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Aplicar"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Mapa"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Adicione um endereço e insira um alfinete no Google Maps."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "endereço"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "maps"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Selecionar estilo de mapa"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Configurações do mapa"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Nível de zoom"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Altura do mapa em pixels"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Nível de zoom"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Tamanho do marcador"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "As opções de controle refinado estão habilitadas."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Selecione para habilitar as opções de controle do mapa."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Controles do mapa"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Tipo de mapa"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "O recurso de alternar entre a visualização de mapa padrão e por satélite está habilitada."
+msgstr ""
+"O recurso de alternar entre a visualização de mapa padrão e por satélite "
+"está habilitada."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Selecione para habilitar o recurso de alternar entre o mapa padrão e o por satélite."
+msgstr ""
+"Selecione para habilitar o recurso de alternar entre o mapa padrão e o por "
+"satélite."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Controles de zoom"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Mostrando controles de zoom do mapa."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Selecione para habilitar a ampliação e redução do mapa com os controles de zoom."
+msgstr ""
+"Selecione para habilitar a ampliação e redução do mapa com os controles de "
+"zoom."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Street View"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Mostrando o controle de Street View do mapa."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Selecione para mostrar o controle de Street View na parte inferior direita."
+msgstr ""
+"Selecione para mostrar o controle de Street View na parte inferior direita."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Tela inteira"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Mostrando o controle de mapa em tela inteira."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Selecione para mostrar o controle de mapa em tela inteira."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Chave da API do Google Maps"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Adicione a chave da API do Google Maps. Se você atualizar a chave de API, todos os mapas usarão a chave nova."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Adicione a chave da API do Google Maps. Se você atualizar a chave de API, "
+"todos os mapas usarão a chave nova."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Recuperar chave"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Precisa de ajuda?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Insira a chave de API do Google..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Salvo"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Padrão"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Prateado"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retrô"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Escuro"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Noite"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Verde e roxo"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1236,9 @@ msgstr "Mídia à direita"
 msgid "Media on left"
 msgstr "Mídia à esquerda"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Cartão de mídia"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Adicione uma imagem ou um vídeo com um cartão lado a lado."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "imagem"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "Vídeo"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1252,18 @@ msgstr "Mostrando sombra do cartão."
 msgid "Toggle to add a card shadow."
 msgstr "Selecione para adicionar sombra ao cartão."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Sombra de %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Mostrando sombra de %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Selecione para adicionar a sobra de %s."
 
@@ -1545,40 +1287,171 @@ msgstr "Solte para substituir a mídia"
 msgid "Edit media"
 msgstr "Editar mídia"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Tabelas de %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL do gist"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Plano %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Carrossel"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL do gist"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Configurações de cor"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Mostrando o preço deste item."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Selecione para mostrar os metadados do gist."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Mostrando o botão de chamada para ação."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Selecione para mostrar os metadados do gist."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Configurações de recursos"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Mídia à esquerda"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Mídia à direita"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Tamanho da coluna"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Configurações de gist"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Tabela de preços"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Tabela de preços"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Tabela de preços"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Tabela de preços"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Adicione tabelas de preços."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "destino"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Plano %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "comparação"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Configurações da tabela de preços"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabelas"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1469,171 @@ msgstr "Plano A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Item da tabela de preços"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Uma coluna no bloco da tabela de preços."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Adicionar plano de fundo a %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Coluna"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Um filho imediato de uma linha."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Largura"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Configurações de coluna"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Espaço em torno do contêiner."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Largura"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Alterar layout"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "um"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "dois"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "três"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "quatro"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Adicionar plano de fundo a %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Uma coluna"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Duas colunas"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Três colunas"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Quatro colunas"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Layout da linha"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Linha"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Agora, selecione um layout para esta linha da coluna %s."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Selecione o número de colunas desta linha."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Selecionar colunas da linha"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Selecionar layout da linha"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Voltar para as colunas"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Adicione um wrapper estruturado para blocos de colunas. Em seguida, adicione às colunas os blocos de conteúdo que quiser."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Adicione um wrapper estruturado para blocos de colunas. Em seguida, adicione "
+"às colunas os blocos de conteúdo que quiser."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "linhas"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "colunas"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "layouts"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Layout"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Configurações de linha"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Nenhum"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1643,9 @@ msgstr "Square"
 msgid "Circle"
 msgstr "Círculo"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Serviços"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Adicione até quatro colunas de serviços para exibir."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "recursos"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1667,7 @@ msgstr "Mostrando os botões de chamada para ação."
 msgid "Toggle to show call to action buttons."
 msgstr "Selecione para mostrar os botões de chamada para ação."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Serviço"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Um item de serviço único em um bloco de serviços."
 
@@ -1785,264 +1688,231 @@ msgid "Toggle to show a call to action button."
 msgstr "Selecione para mostrar um botão de chamada para ação."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Virar horizontalmente"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Virar verticalmente"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Divisor de formas"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Adicione um divisor de formas para realizar a distinção visual das seções de uma página."
+msgstr ""
+"Adicione um divisor de formas para realizar a distinção visual das seções de "
+"uma página."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "separador"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Cor da forma"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Configurações do divisor"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Altura da forma em pixels"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Altura do plano de fundo em pixels"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Orientação"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Cor da forma"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Compartilhar no Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Compartilhar no Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Compartilhar no Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Compartilhar no Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Compartilhar no LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Compartilhar por email"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Compartilhar no Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Compartilhar no Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Compartilhar no Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Compartilhar"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "social"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Adicione links das redes sociais para receber curtidas e compartilhamentos."
+msgstr ""
+"Adicione links das redes sociais para receber curtidas e compartilhamentos."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Cores das mídias sociais"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Tamanho do ícone"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Tamanho do círculo"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Tamanho do botão"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Ícones"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Conta do Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "As cores dos botões de compartilhamento estão habilitadas."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Selecione para usar as cores oficiais de cada plataforma de mídia social."
+msgstr ""
+"Selecione para usar as cores oficiais de cada plataforma de mídia social."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Cores das mídias sociais"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Adicionar perfil do Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Adicionar perfil do Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Adicionar perfil do Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Adicionar perfil do Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Adicionar perfil do LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Adicionar perfil do YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Adicionar perfil do Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Adicionar perfil do Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Perfis sociais"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "links"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Exibe links dos perfis de mídias sociais."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Links dos perfis"
 
@@ -2057,18 +1927,6 @@ msgstr "Remover plano de fundo"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Plano de fundo"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Automóveis"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Capa"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Contém"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1984,6 @@ msgstr "Remover plano de fundo"
 msgid "Remove "
 msgstr "Remover "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Não repetir"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Repetir horizontalmente"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Repetir verticalmente"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Mover imagem para trás"
@@ -2150,17 +1996,14 @@ msgstr "Mover imagem para frente"
 msgid "Link To"
 msgstr "Link para"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Galeria - %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Upload de uma imagem"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Claro"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2017,110 @@ msgstr "Página de anexo"
 msgid "Custom URL"
 msgstr "URL personalizada"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Orientação"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Porcentagem"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Redefinir"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Selecionar unidades"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "Unidades - %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Desativar configurações avançadas de %s"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s superior"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s à direita"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s inferior"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s à esquerda"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Cancelar sincronização"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Sincronizar"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Sincronizar unidades"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Topo"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Direita"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Parte inferior"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Esquerda"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Configurações avançadas de %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Avançado"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Padrão"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Layout"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2139,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Selecione para habilitar o modo de tela inteira."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Cabeçalho %d"
@@ -2263,43 +2148,16 @@ msgstr "Cabeçalho %d"
 msgid "Custom color picker"
 msgstr "Seletor de cor personalizada"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Original"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Escala de cinza"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sépia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Saturação"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Escurecimento"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Aplicar filtro"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Selecionar orientação"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Altura"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Dispositivo móvel %s"
@@ -2333,7 +2191,8 @@ msgid "Five Seconds"
 msgstr "Cinco segundos"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Seis segundos"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2211,22 @@ msgstr "Nove segundos"
 msgid "Ten Seconds"
 msgstr "Dez segundos"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Navegação por setas"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Navegação por pontos"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "segundos"
@@ -2361,22 +2236,28 @@ msgid "second"
 msgstr "segundo"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Avançando após %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Avançar automaticamente para o próximo slide."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Arraste e toque habilitados em computadores e dispositivos móveis."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Selecione para habilitar a funcionalidade de arraste em computadores e dispositivos móveis."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Selecione para habilitar a funcionalidade de arraste em computadores e "
+"dispositivos móveis."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2268,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Selecione para mostrar as setas de navegação."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Mostrando navegação por pontos."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Selecione para mostrar a navegação por pontos."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Espaço dentro do contêiner."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Selecione para silenciar o vídeo."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Selecione para executar o loop do vídeo."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Configurações do controle deslizante"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Reprodução automática"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Velocidade de transição"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Arrastável"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Navegação por setas"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Navegação por pontos"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Usar maiúsculas"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2355,6 @@ msgstr "Sem espaçamento inferior"
 msgid "Change typography"
 msgstr "Alterar tipografia"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Negrito"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Letra maiúscula"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Letra minúscula"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Empilhar em dispositivos móveis"
@@ -2481,31 +2365,36 @@ msgstr "A responsividade está habilitada."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Selecione para empilhar elementos uns sobre os outros em visores menores."
+msgstr ""
+"Selecione para empilhar elementos uns sobre os outros em visores menores."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Remover espaçamento superior"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "A margem superior foi removida neste bloco."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Selecione para adicionar sombra ao cartão."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Selecione para remover as margens aplicadas à parte superior deste bloco."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Selecione para mostrar a navegação por pontos."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Remover espaçamento inferior"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "A margem inferior foi removida neste bloco."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Selecione para adicionar sombra ao cartão."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Selecione para remover as margens aplicadas à parte inferior deste bloco."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Selecione para mostrar a navegação por pontos."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2408,14 @@ msgstr "Exibindo com largura total."
 msgid "Toggle to display button as full width."
 msgstr "Selecione para exibir o botão com largura total."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Circular"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Configurações da área principal (Hero)"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Sombra"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Caixa de seleção"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Letra maiúscula"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2435,800 @@ msgstr "Pesquisar um bloco"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Este bloco foi adicionado à página e não pode ser desabilitado no momento"
+msgstr ""
+"Este bloco foi adicionado à página e não pode ser desabilitado no momento"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Desabilitar tudo"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Nenhum bloco \"%s\" encontrado."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s galerias"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Exibir aberto"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Adicionar título do acordeão..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Item de acordeão"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "guia"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "perguntas frequentes"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "aviso"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "mensagem"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografia"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "perfil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "link"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "compartilhar"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "espaçador"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "Serviços"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menu"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restaurante"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "email"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "mail"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Sobrenome"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Área de texto"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Texto multilinhas"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "email"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "sobre"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "contato"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galeria"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "fotos"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Noite"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animado"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "código"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "botão"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "chamada para ação"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "texto"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "parágrafo"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "ícones"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "clientes"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "prova"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "testemunhos"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "endereço"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "maps"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "imagem"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "Vídeo"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "endereço"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "destino"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "comparação"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "linhas"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "colunas"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "layouts"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "recursos"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "separador"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "social"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "links"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Exibir aberto"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Adicionar item de acordeão"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Acordeão"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Escreva o texto..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Escreva o título..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Alerta"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Autor"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Botões"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Clique para tuitar"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "HR (regra horizontal) dinâmica"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Recurso"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Recursos"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Item de alimentação"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Alimentos e bebidas"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Nome"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Mensagem"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Formulário"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Carrossel"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Alvenaria"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Empilhado"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL do gist"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Destaque"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Ícone"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logotipos e selos"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Mapa"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Cartão de mídia"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Carrossel"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Tabela de preços"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Item da tabela de preços"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Coluna"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Linha"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Serviços"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Serviço"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Divisor de formas"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Compartilhar"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Perfis sociais"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Informações"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Sucesso"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Aviso"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Erro"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Ponto"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Linha"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Largura total"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Grid"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Lista"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Padrão"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Camadas"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Contornado"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Preenchido"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Empilhado"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Repetir horizontalmente"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Ondulado"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Colinas"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Ondas"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Angular"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Inclinado"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Arredondado"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Triângulo"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Pontudo"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Máscara"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Ícone"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Texto"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Ícone e texto"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Circular"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Inferior esquerda"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Superior esquerda"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Solte para adicionar como avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Autor"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3250,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "Este é um bloco que pode ser usado para destacar recursos."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "Adicione o cabeçalho principal..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Adicione o conteúdo principal, que normalmente é uma área introdutória de uma página, acompanhada por uma ou duas chamadas para ação."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Adicione o conteúdo principal, que normalmente é uma área introdutória de "
+"uma página, acompanhada por uma ou duas chamadas para ação."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Adicione a ação primária..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Adicione a ação secundária..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3292,126 @@ msgstr "Adicione o conteúdo..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Substitua este texto por conteúdo descritivo para acompanhar a imagem do cartão. Em seguida, adicione blocos ao cartão, como botões, listas ou imagens."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Substitua este texto por conteúdo descritivo para acompanhar a imagem do "
+"cartão. Em seguida, adicione blocos ao cartão, como botões, listas ou "
+"imagens."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Escreva o título..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Escreva a descrição..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Configurações de botões"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Personalizar"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Empilhar em dispositivos móveis"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Configurações de HR (regra horizontal) dinâmica"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Pequeno"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Grande"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Extragrande"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Pequeno"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Grande"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3105,7 +3776,8 @@ msgstr "computador apple monitor dispositivo pc mesa escritório"
 #: src/blocks/icon/svgs.js:182
 msgctxt "tags"
 msgid "computer ipad surface apple montior device pc desk office"
-msgstr "computador ipad superfície apple monitor dispositivo pc mesa escritório"
+msgstr ""
+"computador ipad superfície apple monitor dispositivo pc mesa escritório"
 
 #: src/blocks/icon/svgs.js:187
 msgctxt "tags"
@@ -3259,8 +3931,12 @@ msgstr "música microfone música artista criativo mídia áudio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "microfone podcast computador dispositivo música canção artista criativo mídia áudio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"microfone podcast computador dispositivo música canção artista criativo "
+"mídia áudio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3960,12 @@ msgstr "filme videografia diretor produtor mídia criativo"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "vídeo videografia diretor produtor mídia criativo câmera fotógrafo fotografia abertura"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"vídeo videografia diretor produtor mídia criativo câmera fotógrafo "
+"fotografia abertura"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3982,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "paleta design cores artista criativo mídia tinta pincel"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Padrão"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Prateado"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retrô"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Escuro"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Noite"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Verde e roxo"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Circular"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Sombra"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Padrão"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Caixa de seleção"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Título do menu..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Pequeno"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Grande"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Extragrande"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Automóveis"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Capa"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Contém"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Superior esquerda"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Superior central"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Superior direita"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Central esquerda"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Central"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Central direita"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Inferior esquerda"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Inferior central"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Inferior direita"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Não repetir"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Repetir"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Repetir horizontalmente"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Repetir verticalmente"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Atributo rel do link"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Escuro"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Claro"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Imagem"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Pixel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Porcentagem"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Original"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Escala de cinza"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Arquivo de mídia"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Saturação"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Filtro vintage"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Filtro vintage"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Usar maiúsculas"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Negrito"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Padrão"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Letra maiúscula"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Letra minúscula"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4330,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "O CoBlocks é um conjunto de <strong>blocos de conteúdo profissionais para criação de páginas</strong>, que pode ser usado com o editor de blocos Gutenberg do WordPress. Com nossos blocos altamente especializados, os desenvolvedores podem criar as mais belas e avançadas páginas no WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"O CoBlocks é um conjunto de <strong>blocos de conteúdo profissionais para "
+"criação de páginas</strong>, que pode ser usado com o editor de blocos "
+"Gutenberg do WordPress. Com nossos blocos altamente especializados, os "
+"desenvolvedores podem criar as mais belas e avançadas páginas no WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4348,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Trapaceando, hein?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Deixe uma avaliação"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s anos"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "um ano"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s semanas"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "uma semana"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s dias"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "um dia"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s horas"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "uma hora"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minutos"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "um minuto"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s segundos"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "um segundo"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Plug-in do WordPress %s"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Está gostando do %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Você já está usando o %1$s há %2$s. Quer aproveitar para deixar uma avaliação e dar sua opinião? Nós adoraríamos isso!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Deixe uma avaliação"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Você já está usando o %1$s há %2$s. Quer aproveitar para deixar uma "
+"avaliação e dar sua opinião? Nós adoraríamos isso!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Não, obrigado/já avaliei"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Agradecemos por usar o CoBlocks, o excelente criador de páginas para o novo editor de blocos do WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Agradecemos por usar o CoBlocks, o excelente criador de páginas para o novo "
+"editor de blocos do WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Você acabou de adicionar vários blocos úteis e um novo kit de ferramentas para criação de páginas ao editor do WordPress. O CoBlocks conta com recurso inovadores: %1$sdezenas de blocos%2$s, uma %1$s experiência única de criação de páginas%2$s e %1$scontroles de tipografia personalizados%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Você acabou de adicionar vários blocos úteis e um novo kit de ferramentas "
+"para criação de páginas ao editor do WordPress. O CoBlocks conta com recurso "
+"inovadores: %1$sdezenas de blocos%2$s, uma %1$s experiência única de criação "
+"de páginas%2$s e %1$scontroles de tipografia personalizados%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Veja alguns vídeos para começar:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Veja como criar sua primeira página com o %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Veja como criar sua primeira página"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Veja como usar os blocos de divisão de formas e linha"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Veja como usar o bloco de cartão de mídia"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Gostou do que viu? %1$sInscreva-se no nosso canal do YouTube%2$s para saber quando os novos tutoriais em vídeo são lançados."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Gostou do que viu? %1$sInscreva-se no nosso canal do YouTube%2$s para saber "
+"quando os novos tutoriais em vídeo são lançados."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Em caso de dúvidas ou comentários, fale conosco pelo %1$sTwitter%4$s ou nosso %2$sgrupo de Facebook%4$s. Além disso, %3$sinscreva-se no nosso boletim informativo%4$s para conhecer as novidades e os próximos recursos do CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Em caso de dúvidas ou comentários, fale conosco pelo %1$sTwitter%4$s ou "
+"nosso %2$sgrupo de Facebook%4$s. Além disso, %3$sinscreva-se no nosso "
+"boletim informativo%4$s para conhecer as novidades e os próximos recursos do "
+"CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Aproveite!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Saiba mais sobre o CoBlocks aqui:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4519,35 @@ msgstr "Habilitar ou desabilitar blocos"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "Chave de site do Google reCaptcha para proteção de formulários contra spam"
+msgstr ""
+"Chave de site do Google reCaptcha para proteção de formulários contra spam"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
-msgstr "Chave secreta do Google reCaptcha para proteção de formulários contra spam"
+msgstr ""
+"Chave secreta do Google reCaptcha para proteção de formulários contra spam"
+
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Nome"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Primeira"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Última"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Mensagem"
 
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Enviar"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Sua mensagem foi enviada:"
 
@@ -3490,3 +4562,87 @@ msgstr "Compartilhar no LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Tipo de alerta"
+
+#~ msgid "Edit image"
+#~ msgstr "Editar imagem"
+
+#~ msgid "Remove image"
+#~ msgstr "Remover imagem"
+
+#~ msgid "Heading..."
+#~ msgstr "Cabeçalho..."
+
+#~ msgid "Author Name"
+#~ msgstr "Nome do autor"
+
+#~ msgid "Write biography..."
+#~ msgstr "Escreva a biografia..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Adicione a biografia do autor."
+
+#~ msgid "%s Settings"
+#~ msgstr "%s Configurações"
+
+#~ msgid "Caption Color"
+#~ msgstr "Cor da legenda"
+
+#~ msgid "Highlight text."
+#~ msgstr "Texto de destaque."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Tabelas de %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Configurações da tabela de preços"
+
+#~ msgid "Tables"
+#~ msgstr "Tabelas"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Uma coluna no bloco da tabela de preços."
+
+#~ msgid "Sepia"
+#~ msgstr "Sépia"
+
+#~ msgid "Dim"
+#~ msgstr "Escurecimento"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Selecionar orientação"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "A margem superior foi removida neste bloco."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Selecione para remover as margens aplicadas à parte superior deste bloco."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "A margem inferior foi removida neste bloco."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Selecione para remover as margens aplicadas à parte inferior deste bloco."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Adicione a ação primária..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Adicione a ação secundária..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Saiba mais sobre o CoBlocks aqui:"

--- a/languages/coblocks-pt_PT.po
+++ b/languages/coblocks-pt_PT.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Apresentar aberto"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Adicionar título de acordeão..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Item de acordeão"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Adicione itens de acordeão colapsáveis aos acordeões."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "separadores"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "perguntas frequentes"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,39 @@ msgstr "O item do acordeão está aberto por predefinição."
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Alterne para definir este item de acordeão como aberto por predefinição."
+msgstr ""
+"Alterne para definir este item de acordeão como aberto por predefinição."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Definições dos itens de acordeão"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Apresentar aberto"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Definições de cor"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Cor de fundo"
@@ -103,14 +64,6 @@ msgstr "Cor de fundo"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Cor do texto do título"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Adicionar item de acordeão"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Acordeão"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +79,83 @@ msgstr "Compatibilidade com o Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Adicione compatibilidade com o Internet Explorer ao carregar um «polyfill» em JavaScript."
+msgstr ""
+"Adicione compatibilidade com o Internet Explorer ao carregar um «polyfill» "
+"em JavaScript."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Fornecendo compatibilidade com o Internet Explorer ao carregar um «polyfill» em JavaScript nesta página."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Fornecendo compatibilidade com o Internet Explorer ao carregar um «polyfill» "
+"em JavaScript nesta página."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Aviso"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Erro"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Tipo de alerta"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Predefinição"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Informações"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Sucesso"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Escrever título..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Escrever texto..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Alerta"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Forneça mensagens com comentários contextuais."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "aviso"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "mensagem"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Cor do texto"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Editar imagem"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Editar galeria"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Remover imagem"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Escrever legenda…"
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Largar para adicionar como avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Título..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Nome do autor"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Escrever biografia..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Definições de formulário"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Autor"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Adicione uma biografia do autor."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografia"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "perfil"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "Botões"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "Incentive os visitantes a agir com vários botões, lado a lado."
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "ligação"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "aàa"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Definições dos botões"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Empilhar em dispositivos móveis"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "Botões"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +173,25 @@ msgstr "Nome de utilizador do Twitter"
 msgid "Username"
 msgstr "Nome de utilizador"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Adicionar botão..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Adicionar uma citação ao tweet..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Clicar para tuitar"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Adicione uma citação para os leitores tuitarem."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "partilhar"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +199,18 @@ msgid "Text Settings"
 msgstr "Definições de texto"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Cor do botão"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "RH dinâmica"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Adicione um espaçador redimensionável entre outros blocos."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "espaçador"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Definições da RH dinâmica"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Altura em píxeis"
 
@@ -347,92 +222,71 @@ msgstr "Altura do elemento do separador dinâmico em píxeis."
 msgid "Color"
 msgstr "Cor"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Adicionar como fundo"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Funcionalidade"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
-msgstr "Uma coluna secundária individual num bloco de funcionalidades principais."
+msgstr ""
+"Uma coluna secundária individual num bloco de funcionalidades principais."
 
 #: src/blocks/features/feature/inspector.js:68
 msgid "Feature Settings"
 msgstr "Definições da funcionalidade"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Preenchimento"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Funcionalidades"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Adicione até três colunas de pequenas observações para o seu produto ou serviço."
+msgstr ""
+"Adicione até três colunas de pequenas observações para o seu produto ou "
+"serviço."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "serviços"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Margem"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Calha"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Espaço entre cada coluna."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Pequeno"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Médio"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +296,8 @@ msgstr "Grande"
 msgid "Features Settings"
 msgstr "Definições das funcionalidades"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Colunas"
 
@@ -455,76 +309,72 @@ msgstr "Adicionar secção de menu"
 msgid "Menu title..."
 msgstr "Título do menu..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Grelha"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Lista"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Largar imagem para substituir"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Remover imagem"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Adicionar título..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Picante"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Quente"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetariano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Sem glúten"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Piscitariano"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Vegan"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Adicionar descrição..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0,00 $"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Item de comida"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Um item de comida e bebida no bloco de Comida e bebida."
 
@@ -560,62 +410,46 @@ msgstr "Alterne para mostrar o preço deste item."
 msgid "Item Attributes"
 msgstr "Atributos do item"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Mais picante"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Definições da imagem"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Texto alternativo"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Descreva o objetivo da imagem"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Deixe em branco se a imagem for puramente decorativa."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Ponto de foco"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Comida e bebida"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Apresente um menu ou uma lista de preços."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restaurante"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menu"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Estilos"
@@ -648,134 +482,86 @@ msgstr "A mostrar o preço de cada item"
 msgid "Toggle to show the price of each item."
 msgstr "Alterne para mostrar o preço de cada item."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Email"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "email"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "correio"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "O campo de um endereço de Email."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Mensagem"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Área de texto"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Texto multilinhas"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Uma caixa de texto para respostas mais compridas."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s não é um endereço de Email válido."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s e %s não são endereços de Email válidos."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s não é um endereço de Email válido."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Endereço de Email"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "nome@exemplo.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Assunto"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Definições de formulário"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "reCAPTCHA da Google"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Adicione o site e as chaves secretas do reCAPTCHA para proteger o seu formulário contra spam."
+msgstr ""
+"Adicione o site e as chaves secretas do reCAPTCHA para proteger o seu "
+"formulário contra spam."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Gerar chaves"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "As minhas chaves"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Obter ajuda"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Chave do site"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Chave secreta"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "A guardar"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Guardar"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Remover"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Primeiro"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Último"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Nome"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Um campo de texto para nomes."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "O campo de um endereço de Email."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Adicionar etiqueta…"
 
@@ -783,41 +569,38 @@ msgstr "Adicionar etiqueta…"
 msgid "Required"
 msgstr "Obrigatório"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Definições do campo do nome"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Apelido"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "A mostrar os campos do nome próprio e do apelido."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Alterne para adicionar um campo de apelido."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Formulário"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Um campo de texto para nomes."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Uma caixa de texto para respostas mais compridas."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Adicione um formulário simples à sua página."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "email"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "sobre"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "contacto"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Assunto"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +610,219 @@ msgstr "Adicionar texto…"
 msgid "Button Text Color"
 msgstr "Cor do texto do botão"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Editar galeria"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Carrossel"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "imagem %1$d de %2$d na galeria"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Escrever legenda…"
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Carrossel"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Apresente várias imagens numa apelativa galeria em carrossel."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galeria"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "fotografias"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Definições de %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Altura da linha"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "A mostrar as setas de navegação por pontos."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Alterne para mostrar legendas nos itens multimédia."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Definições de cor"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Cantos arredondados"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Cor da legenda"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Aplicar"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Alvenaria"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Escrever descrição..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Apresente várias imagens numa galeria organizada em alvenaria."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Apresente várias imagens numa apelativa galeria em carrossel."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Tamanho da coluna"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Definições da imagem"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Adicione cantos arredondados aos itens da galeria."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Sombra"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Legendas"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Estilo da legenda"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "A mostrar legendas para cada item multimédia."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Alterne para mostrar legendas nos itens multimédia."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Alvenaria"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Apresente várias imagens numa galeria organizada em alvenaria."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Alterne para ativar as opções de controlo do mapa."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "‌‌Definições do mapa"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Tamanho da coluna"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Adicione cantos arredondados aos itens da galeria."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Ligeiro"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Empilhado"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Apresente várias imagens numa galeria empilhada numa única coluna."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Imagens com a largura total"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Imagem com a largura total"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Sombra da caixa"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "A opção de imagens com a largura total está ativada."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Alterne para preencher a área disponível da galeria com imagens com a largura total."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Alterne para preencher a área disponível da galeria com imagens com a "
+"largura total."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "‌‌Definições do item"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Imagens com a largura total"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Imagem com a largura total"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Remover gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Este gif tem um atributo «alt» vazio"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Procure o gif perfeito no Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Procurar gifs"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Escolha qualquer gif."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animado"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +848,11 @@ msgstr "Ficheiro do GitHub"
 msgid "File"
 msgstr "Ficheiro"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Ver este gist no GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL do gist"
 
@@ -1024,12 +865,9 @@ msgid "Loading Gist"
 msgstr "A carregar gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Incorpore gists do GitHub ao adicionar a respetiva ligação."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "código"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +890,159 @@ msgid "Gist Meta"
 msgstr "Metadados do gist"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Alterar esquema"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Adicionar fundo a %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Herói"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Uma área de apresentação de uma página acompanhada por uma pequena "
+"quantidade de texto e um apelo à ação."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Uma área de apresentação de uma página acompanhada por uma pequena quantidade de texto e um apelo à ação."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "botão"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "apelo à ação"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Largura do conteúdo em píxeis"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "‌‌Definições do herói"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Espaço dentro do contentor."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Canto superior esquerdo"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Centro superior"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Canto superior direito"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Centro à esquerda"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Centro"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Centro à direita"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Canto inferior esquerdo"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Centro inferior"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Canto inferior direito"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Adicionar texto realçado..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Realçar"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Realce o texto."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "texto"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "parágrafo"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Ícone"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Adicione um símbolo gráfico estilizado para comunicar algo mais."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "ícones"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Enorme"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Adicione um símbolo gráfico estilizado para comunicar algo mais."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Definições do ícone"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Desativar definições avançadas de %s"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Repor"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Tamanho de %s personalizado"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Definições avançadas de %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Personalizado"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Avançadas"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Raio"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Pesquisa de ícones"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Não foi encontrado nenhum resultado."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Definições da ligação"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL da ligação"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Rel da ligação"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "A abrir num novo separador"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Abrir num novo separador"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Cor do ícone"
 
@@ -1261,30 +1051,20 @@ msgid "Edit logos"
 msgstr "Editar logótipos"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logótipos e emblemas"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Arraste imagens, carregue imagens novas ou selecione ficheiros da sua biblioteca."
+msgstr ""
+"Arraste imagens, carregue imagens novas ou selecione ficheiros da sua "
+"biblioteca."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Adicione logótipos, emblemas ou certificações para estabelecer credibilidade."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "clientes"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "prova"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "testemunhos"
+msgstr ""
+"Adicione logótipos, emblemas ou certificações para estabelecer credibilidade."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1086,143 @@ msgstr "Editar localização"
 msgid "Map style"
 msgstr "Estilo do mapa"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Chave da API inválida ou demasiados pedidos"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Mapa da Google"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Introduza uma localização ou um endereço para colocar um pin num mapa da Google."
+msgstr ""
+"Introduza uma localização ou um endereço para colocar um pin num mapa da "
+"Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Procurar um local ou endereço…"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Aplicar"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Mapa"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Adicione um endereço e coloque um pin num mapa da Google."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "endereço"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "mapas"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Selecionar estilo do mapa"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "‌‌Definições do mapa"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Nível de zoom"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Altura do mapa em píxeis"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Nível de zoom"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Tamanho do marcador"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "As opções de controlo preciso estão ativadas."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Alterne para ativar as opções de controlo do mapa."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Controlos do mapa"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Tipo de mapa"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "A mudança entre a vista padrão e de satélite do mapa está ativada."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "Alterne para ativar a mudança entre o mapa padrão e de satélite."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Controlos de zoom"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "A mostrar os controlos de zoom do mapa."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Alterne para ativar o aumento e a redução do zoom no mapa com os controlos de zoom."
+msgstr ""
+"Alterne para ativar o aumento e a redução do zoom no mapa com os controlos "
+"de zoom."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Vista de rua"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "A mostrar o controlo do mapa da vista de rua."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Alterne para mostrar o controlo da vista de rua no canto inferior direito."
+msgstr ""
+"Alterne para mostrar o controlo da vista de rua no canto inferior direito."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Alternância de ecrã inteiro"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "A mostrar o controlo do mapa de ecrã inteiro."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Alterne para mostrar o controlo do mapa de ecrã inteiro."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Chave da API do Google Maps"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Adicione a sua chave da API do Google Maps. A atualização desta chave da API irá definir todos os seus mapas para utilizarem a nova chave."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Adicione a sua chave da API do Google Maps. A atualização desta chave da API "
+"irá definir todos os seus mapas para utilizarem a nova chave."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Obter a sua chave"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Precisa de ajuda?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Introduzir chave da API da Google…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Guardado"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Padrão"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Prata"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Escuro"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Noite"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Beringela"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1232,9 @@ msgstr "Conteúdo multimédia à direita"
 msgid "Media on left"
 msgstr "Conteúdo multimédia à esquerda"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Cartão multimédia"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Adicione uma imagem ou um vídeo com um cartão descentrado lado a lado."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "imagem"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "vídeo"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1248,18 @@ msgstr "A mostrar a sombra do cartão."
 msgid "Toggle to add a card shadow."
 msgstr "Alterne para adicionar uma sombra do cartão."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Sombra de %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "A mostrar sombra de %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Alterne para adicionar uma sombra de %s."
 
@@ -1545,40 +1283,171 @@ msgstr "Largar para substituir o conteúdo multimédia"
 msgid "Edit media"
 msgstr "Editar conteúdo multimédia"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Tabelas de %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL do gist"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Plano n.º %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Carrossel"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL do gist"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Definições de cor"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "A mostrar o preço deste item."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Alterne para mostrar os metadados do gist."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "A mostrar o botão de apelo à ação."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Alterne para mostrar os metadados do gist."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Definições da funcionalidade"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Conteúdo multimédia à esquerda"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Conteúdo multimédia à direita"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Tamanho da coluna"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Definições do gist"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Tabela de preços"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Tabela de preços"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Tabela de preços"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Tabela de preços"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Adicione tabelas de preços."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "início"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Plano n.º %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "comparação"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Definições da tabela de preços"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabelas"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1465,171 @@ msgstr "Plano A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Item da tabela de preços"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Uma coluna colocada no bloco da tabela de preços."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Adicionar fundo a %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Coluna"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Uma linha secundária imediata."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Largura"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Definições das colunas"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Espaço à volta do contentor."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Largura"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Alterar esquema"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "uma"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "duas"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "três"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "quatro"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Adicionar fundo a %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Uma coluna"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Duas colunas"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Três colunas"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Quatro colunas"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Esquema de linhas"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Linha"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Agora, selecione um esquema para esta linha com %s coluna(s)."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Selecione o número de colunas para esta linha."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Selecionar colunas da linha"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Selecionar esquema da linha"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Voltar para as colunas"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Adicione um invólucro estruturado para os blocos de colunas e, em seguida, adicione os blocos de conteúdo que pretender às colunas."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Adicione um invólucro estruturado para os blocos de colunas e, em seguida, "
+"adicione os blocos de conteúdo que pretender às colunas."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "linhas"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "colunas"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "esquemas"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Esquema"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Definições das linhas"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Nenhum"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1639,9 @@ msgstr "Quadrado"
 msgid "Circle"
 msgstr "Círculo"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Serviços"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Adicione até quatro colunas de serviços a apresentar."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "funcionalidades"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1663,7 @@ msgstr "A mostrar os botões de apelo à ação."
 msgid "Toggle to show call to action buttons."
 msgstr "Alterne para mostrar os botões de apelo à ação."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Serviço"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Um item de serviço individual num bloco de serviços."
 
@@ -1785,264 +1684,232 @@ msgid "Toggle to show a call to action button."
 msgstr "Alterne para mostrar um botão de apelo à ação."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Inverter horizontalmente"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Inverter verticalmente"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Divisor de formas"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Adicione um divisor de formas para distinguir visualmente as secções da página."
+msgstr ""
+"Adicione um divisor de formas para distinguir visualmente as secções da "
+"página."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "separador"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Cor da forma"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Definições do divisor"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Altura da forma em píxeis"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Altura do fundo em píxeis"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Orientação"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Cor da forma"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Partilhar no Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Partilhar no Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Partilhar no Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Partilhar no Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Partilhar no LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Partilhar através de Email"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Partilhar no Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Partilhar no Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Partilhar no Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Partilhar"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "social"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Adicione ligações de partilha nas redes sociais para obter mais gostos e partilhas."
+msgstr ""
+"Adicione ligações de partilha nas redes sociais para obter mais gostos e "
+"partilhas."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Cores das redes sociais"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Tamanho do ícone"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Tamanho do círculo"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Tamanho do botão"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Ícones"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "As cores dos botões de partilha estão ativadas."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Alterne para utilizar as cores oficiais de cada plataforma das redes sociais."
+msgstr ""
+"Alterne para utilizar as cores oficiais de cada plataforma das redes sociais."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Cores das redes sociais"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Adicionar perfil do Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Adicionar perfil do Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Adicionar perfil do Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Adicionar perfil do Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Adicionar perfil do Linkedln"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Adicionar perfil do YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Adicionar perfil do Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Adicionar perfil do Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Perfis nas redes sociais"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "ligações"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Apresente ligações para perfis nas redes sociais."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Ligações de perfil"
 
@@ -2057,18 +1924,6 @@ msgstr "Remover fundo"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Fundo"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Automático"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Capa"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Contém"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1981,6 @@ msgstr "Remover fundo"
 msgid "Remove "
 msgstr "Remover "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Não repetir"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Repetir horizontalmente"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Repetir verticalmente"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Mover imagem para trás"
@@ -2150,17 +1993,14 @@ msgstr "Mover imagem para a frente"
 msgid "Link To"
 msgstr "Ligação para"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Galeria de %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Carregar uma imagem"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Ligeiro"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2014,110 @@ msgstr "Página de anexos"
 msgid "Custom URL"
 msgstr "URL personalizado"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Píxel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Orientação"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Percentagem"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Repor"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Selecionar unidades"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "Unidades de %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Desativar definições avançadas de %s"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "Parte superior do(a) %s"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s direita"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "Parte inferior %s"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s esquerda"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Dessincronizar"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Sincronizar"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Sincronizar unidades"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Parte superior"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Direita"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Parte inferior"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Esquerda"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Definições avançadas de %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Avançadas"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Predefinição"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Esquema"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2136,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Alterne para ativar o modo de ecrã inteiro."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Título %d"
@@ -2263,43 +2145,16 @@ msgstr "Título %d"
 msgid "Custom color picker"
 msgstr "Selecionador de cor personalizada"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Original"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Escala de cinzentos"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sépia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Saturação"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Escuro"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Aplicar filtro"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Selecionar orientação"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Altura"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "%s para dispositivos móveis"
@@ -2333,7 +2188,8 @@ msgid "Five Seconds"
 msgstr "Cinco segundos"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Seis segundos"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2208,22 @@ msgstr "Nove segundos"
 msgid "Ten Seconds"
 msgstr "Dez segundos"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Navegação por setas"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Navegação por pontos"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "segundos"
@@ -2361,22 +2233,29 @@ msgid "second"
 msgstr "segundo"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "A avançar após %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Avance automaticamente para o próximo diapositivo."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
-msgstr "Arrastamento e folheação ativados em computadores e dispositivos móveis."
+#, fuzzy
+msgid "Dragging and flicking enabled."
+msgstr ""
+"Arrastamento e folheação ativados em computadores e dispositivos móveis."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Alterne para ativar a funcionalidade de arrastamento em computadores e dispositivos móveis."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Alterne para ativar a funcionalidade de arrastamento em computadores e "
+"dispositivos móveis."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2266,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Alterne para mostrar as setas de navegação lateral."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "A mostrar as setas de navegação por pontos."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Alterne para mostrar a navegação por pontos."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Espaço dentro do contentor."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Alterne para silenciar o vídeo."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Alterne para repetir o vídeo."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Definições do controlo deslizante"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Reprodução automática"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Velocidade de transição"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Arrastável"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Navegação por setas"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Navegação por pontos"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Aplicar maiúsculas"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2353,6 @@ msgstr "Nenhum espaçamento inferior"
 msgid "Change typography"
 msgstr "Alterar tipografia"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Negrito"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Maiúsculas"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Minúsculas"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Empilhar em dispositivos móveis"
@@ -2481,31 +2363,37 @@ msgstr "A capacidade de resposta está ativada."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Alterne para empilhar elementos uns em cima dos outros nas portas de visualização mais pequenas."
+msgstr ""
+"Alterne para empilhar elementos uns em cima dos outros nas portas de "
+"visualização mais pequenas."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Remover espaçamento superior"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "A margem superior está removida neste bloco."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Alterne para adicionar uma sombra do cartão."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Alterne para remover qualquer margem aplicada à parte superior deste bloco."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Alterne para mostrar a navegação por pontos."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Remover espaçamento inferior"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "A margem inferior está removida neste bloco."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Alterne para adicionar uma sombra do cartão."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Alterne para remover qualquer margem aplicada à parte inferior deste bloco."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Alterne para mostrar a navegação por pontos."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2407,14 @@ msgstr "A apresentar com a largura total."
 msgid "Toggle to display button as full width."
 msgstr "Alterne para apresentar o botão com a largura total."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Circular"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "‌‌Definições do herói"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Sombra"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Caixa de verificação"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Maiúsculas"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2434,800 @@ msgstr "Procurar um bloco"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Este bloco está adicionado à página e não pode atualmente ser desativado"
+msgstr ""
+"Este bloco está adicionado à página e não pode atualmente ser desativado"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Desativar tudo"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Nenhum bloco «%s» encontrado."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Galerias de %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Apresentar aberto"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Adicionar título de acordeão..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Item de acordeão"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "separadores"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "perguntas frequentes"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "aviso"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "mensagem"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografia"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "perfil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "ligação"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "aàa"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "partilhar"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "espaçador"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "serviços"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menu"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restaurante"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "email"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "correio"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Apelido"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Área de texto"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Texto multilinhas"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "email"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "sobre"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "contacto"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galeria"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "fotografias"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Noite"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animado"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "código"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "botão"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "apelo à ação"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "texto"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "parágrafo"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "ícones"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "clientes"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "prova"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "testemunhos"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "endereço"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "mapas"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "imagem"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "vídeo"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "endereço"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "início"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "comparação"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "linhas"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "colunas"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "esquemas"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "funcionalidades"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "separador"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "social"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "ligações"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Apresentar aberto"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Adicionar item de acordeão"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Acordeão"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Escrever texto..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Escrever título..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Alerta"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Autor"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Botões"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Clicar para tuitar"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "RH dinâmica"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Funcionalidade"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Funcionalidades"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Item de comida"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Comida e bebida"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Nome"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Mensagem"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Formulário"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Carrossel"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Alvenaria"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Empilhado"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL do gist"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Herói"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Realçar"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Ícone"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logótipos e emblemas"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Mapa"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Cartão multimédia"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Carrossel"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Tabela de preços"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Item da tabela de preços"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Coluna"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Linha"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Serviços"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Serviço"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Divisor de formas"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Partilhar"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Perfis nas redes sociais"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Informações"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Sucesso"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Aviso"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Erro"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Ponto"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Linha"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Largura total"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Grelha"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Lista"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Predefinição"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Camadas"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Contornado"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Preenchido"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Empilhado"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Repetir horizontalmente"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Ondulado"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Colinas"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Ondas"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Angular"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Inclinado"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Arredondado"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Triângulo"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Pontiagudo"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Máscara"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Ícone"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Texto"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Ícone e texto"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Circular"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Canto inferior esquerdo"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Canto superior esquerdo"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Largar para adicionar como avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Autor"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3247,34 @@ msgstr "Adicionar conteúdo da funcionalidade"
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Este é um bloco de funcionalidades que pode utilizar para destacar funcionalidades."
+msgstr ""
+"Este é um bloco de funcionalidades que pode utilizar para destacar "
+"funcionalidades."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Adicionar título de herói..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Adicionar título de herói..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Adicione conteúdo de herói, o qual consiste normalmente numa área de "
+"apresentação de uma página acompanhada por um apelo à ação ou dois."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Adicione conteúdo de herói, o qual consiste normalmente numa área de apresentação de uma página acompanhada por um apelo à ação ou dois."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Adicionar ação principal..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Adicionar ação secundária..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3293,126 @@ msgstr "Adicionar conteúdo..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Substitua este texto por uma descrição para acompanhar a imagem do cartão. Em seguida, adicione mais blocos a este cartão, tais como botões, listas ou imagens."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Substitua este texto por uma descrição para acompanhar a imagem do cartão. "
+"Em seguida, adicione mais blocos a este cartão, tais como botões, listas ou "
+"imagens."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Escrever título..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Escrever descrição..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Definições dos botões"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Personalizado"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Empilhar em dispositivos móveis"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Definições da RH dinâmica"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Pequeno"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Médio"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Grande"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Muito grande"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Pequeno"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Médio"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Grande"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3105,7 +3777,8 @@ msgstr "computador apple monitor dispositivo pc secretária escritório"
 #: src/blocks/icon/svgs.js:182
 msgctxt "tags"
 msgid "computer ipad surface apple montior device pc desk office"
-msgstr "computador ipad surface apple monitor dispositivo pc secretária escritório"
+msgstr ""
+"computador ipad surface apple monitor dispositivo pc secretária escritório"
 
 #: src/blocks/icon/svgs.js:187
 msgctxt "tags"
@@ -3160,7 +3833,8 @@ msgstr "mundo público global terra localização mapa"
 #: src/blocks/icon/svgs.js:258
 msgctxt "tags"
 msgid "location map public business corporation building town skyscraper"
-msgstr "localização mapa público empresa corporação edifício cidade arranha-céus"
+msgstr ""
+"localização mapa público empresa corporação edifício cidade arranha-céus"
 
 #: src/blocks/icon/svgs.js:263
 msgctxt "tags"
@@ -3259,23 +3933,31 @@ msgstr "música microfone canção intérprete criativo multimédia áudio"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "microfone podcast computador dispositivo música canção intérprete criativo multimédia áudio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"microfone podcast computador dispositivo música canção intérprete criativo "
+"multimédia áudio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
 msgid "photo photographer photography camera film creative media"
-msgstr "foto fotógrafo fotografia máquina fotográfica película criativo multimédia"
+msgstr ""
+"foto fotógrafo fotografia máquina fotográfica película criativo multimédia"
 
 #: src/blocks/icon/svgs.js:55
 msgctxt "tags"
 msgid "photo photographer photography camera aperture film creative media"
-msgstr "foto fotógrafo fotografia máquina fotográfica abertura película criativo multimédia"
+msgstr ""
+"foto fotógrafo fotografia máquina fotográfica abertura película criativo "
+"multimédia"
 
 #: src/blocks/icon/svgs.js:61
 msgctxt "tags"
 msgid "photo photos image media camera aperture collection"
-msgstr "fotografia fotografias imagem multimédia máquina fotográfica abertura coleção"
+msgstr ""
+"fotografia fotografias imagem multimédia máquina fotográfica abertura coleção"
 
 #: src/blocks/icon/svgs.js:67
 msgctxt "tags"
@@ -3284,8 +3966,12 @@ msgstr "filme videografia realizador produtor multimédia criativo"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "vídeo videografia realizador produtor multimédia criativo câmara fotógrafo fotografia abertura"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"vídeo videografia realizador produtor multimédia criativo câmara fotógrafo "
+"fotografia abertura"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3988,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "paleta conceção cores artista criativo multimédia tinta pincel"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Padrão"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Prata"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Escuro"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Noite"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Beringela"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Circular"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Sombra"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Predefinição"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Caixa de verificação"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Título do menu..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Pequeno"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Médio"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Grande"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Muito grande"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Automático"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Capa"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Contém"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Canto superior esquerdo"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Centro superior"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Canto superior direito"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Centro à esquerda"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Centro"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Centro à direita"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Canto inferior esquerdo"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Centro inferior"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Canto inferior direito"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Não repetir"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Repetir"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Repetir horizontalmente"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Repetir verticalmente"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Rel da ligação"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Escuro"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Ligeiro"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Nenhum"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Imagem"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Píxel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Percentagem"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Original"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Escala de cinzentos"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Ficheiro multimédia"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Saturação"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Filtro vintage"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Filtro vintage"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Aplicar maiúsculas"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Negrito"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Predefinição"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Maiúsculas"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Minúsculas"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4336,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "O CoBlocks é um conjunto de <strong>blocos de conteúdo para a criação de páginas</strong> profissionais para o editor de blocos Gutenberg do WordPress. Os nossos blocos estão extremamente focados em capacitar os criadores no sentido de criarem páginas complexas e apelativas no WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"O CoBlocks é um conjunto de <strong>blocos de conteúdo para a criação de "
+"páginas</strong> profissionais para o editor de blocos Gutenberg do "
+"WordPress. Os nossos blocos estão extremamente focados em capacitar os "
+"criadores no sentido de criarem páginas complexas e apelativas no WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4354,171 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Está a fazer batota?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Efetuar uma avaliação"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s anos"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "um ano"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s semanas"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "uma semana"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s dias"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "um dia"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s horas"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "uma hora"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minutos"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "um minuto"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s segundos"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "um segundo"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Suplemento %s do WordPress"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Está a desfrutar do %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Tem estado a utilizar o %1$s há %2$s. Importa-se de deixar um comentário para nos transmitir a sua opinião? Ficar-lhe-íamos muito gratos!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Efetuar uma avaliação"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Tem estado a utilizar o %1$s há %2$s. Importa-se de deixar um comentário "
+"para nos transmitir a sua opinião? Ficar-lhe-íamos muito gratos!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Não, obrigado / Já efetuei isto"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Obrigado por escolher o CoBlocks, o criador de páginas de eleição para o novo editor de blocos do WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Obrigado por escolher o CoBlocks, o criador de páginas de eleição para o "
+"novo editor de blocos do WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Acabou de adicionar muitos blocos úteis e um novo conjunto de ferramentas de criador de páginas ao editor do WordPress. O CoBlocks fornece-lhe um conjunto de funcionalidades totalmente inovador: %1$s dezenas de blocos%2$s, uma %1$s experiência de utilização de criador de páginas %2$s e %1$s controlos de tipografia personalizados%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Acabou de adicionar muitos blocos úteis e um novo conjunto de ferramentas de "
+"criador de páginas ao editor do WordPress. O CoBlocks fornece-lhe um "
+"conjunto de funcionalidades totalmente inovador: %1$s dezenas de blocos%2$s, "
+"uma %1$s experiência de utilização de criador de páginas %2$s e %1$s "
+"controlos de tipografia personalizados%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Seguem-se alguns vídeos para o ajudar a começar:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Veja como criar a sua primeira página com o %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Veja como criar a sua primeira página"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Veja como utilizar os blocos de Linha e Divisor de forma"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Veja como utilizar o bloco de Cartão multimédia"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Gosta do que está a ver? %1$sSubscreva o nosso canal do YouTube%2$s para o informarmos quando forem lançados novos vídeos de tutoriais."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Gosta do que está a ver? %1$sSubscreva o nosso canal do YouTube%2$s para o "
+"informarmos quando forem lançados novos vídeos de tutoriais."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Se pretender esclarecer alguma questão ou enviar comentários, contacte-nos através do %1$sTwitter%4$s ou do nosso %2$sgrupo no Facebook%4$s. Além disso, %3$ssubscreva o nosso boletim informativo%4$s se pretender manter-se a par das novidades e futuras iniciativas do CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Se pretender esclarecer alguma questão ou enviar comentários, contacte-nos "
+"através do %1$sTwitter%4$s ou do nosso %2$sgrupo no Facebook%4$s. Além "
+"disso, %3$ssubscreva o nosso boletim informativo%4$s se pretender manter-se "
+"a par das novidades e futuras iniciativas do CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Desfrute!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Comece a utilizar o CoBlocks aqui:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4526,37 @@ msgstr "Ativar ou desativar blocos"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "Chave do site do reCaptcha da Google para a proteção contra spam nos formulários"
+msgstr ""
+"Chave do site do reCaptcha da Google para a proteção contra spam nos "
+"formulários"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
-msgstr "Chave secreta do reCaptcha da Google para a proteção contra spam nos formulários"
+msgstr ""
+"Chave secreta do reCaptcha da Google para a proteção contra spam nos "
+"formulários"
+
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Nome"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Primeiro"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Último"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Mensagem"
 
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Enviar"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "A sua mensagem foi enviada:"
 
@@ -3490,3 +4571,89 @@ msgstr "Partilhar no LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Tipo de alerta"
+
+#~ msgid "Edit image"
+#~ msgstr "Editar imagem"
+
+#~ msgid "Remove image"
+#~ msgstr "Remover imagem"
+
+#~ msgid "Heading..."
+#~ msgstr "Título..."
+
+#~ msgid "Author Name"
+#~ msgstr "Nome do autor"
+
+#~ msgid "Write biography..."
+#~ msgstr "Escrever biografia..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Adicione uma biografia do autor."
+
+#~ msgid "%s Settings"
+#~ msgstr "Definições de %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Cor da legenda"
+
+#~ msgid "Highlight text."
+#~ msgstr "Realce o texto."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Tabelas de %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Definições da tabela de preços"
+
+#~ msgid "Tables"
+#~ msgstr "Tabelas"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Uma coluna colocada no bloco da tabela de preços."
+
+#~ msgid "Sepia"
+#~ msgstr "Sépia"
+
+#~ msgid "Dim"
+#~ msgstr "Escuro"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Selecionar orientação"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "A margem superior está removida neste bloco."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Alterne para remover qualquer margem aplicada à parte superior deste "
+#~ "bloco."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "A margem inferior está removida neste bloco."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Alterne para remover qualquer margem aplicada à parte inferior deste "
+#~ "bloco."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Adicionar ação principal..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Adicionar ação secundária..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Comece a utilizar o CoBlocks aqui:"

--- a/languages/coblocks-ru_RU.po
+++ b/languages/coblocks-ru_RU.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Отображать открытым"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Добавить название аккордеона..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Элемент аккордеона"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Добавить сворачиваемые элементы аккордеона к аккордеонам."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "вкладки"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "вопросы и ответы"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "Переключить для открытия этого элемент
 msgid "Accordion Item Settings"
 msgstr "Настройки элемента аккордеона"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Дисплей открыт"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "настройки сервера"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Цвет фона"
@@ -103,14 +63,6 @@ msgstr "Цвет фона"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Цвет основного текста"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Добавить элемент аккордеона"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Аккордеон"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +78,85 @@ msgstr "Поддержка Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Добавьте поддержку Internet Explorer путем загрузки полизаполнения JavaScript."
+msgstr ""
+"Добавьте поддержку Internet Explorer путем загрузки полизаполнения "
+"JavaScript."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Поддержка Internet Explorer путем загрузки полизаполнения JavaScript на этой странице."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Поддержка Internet Explorer путем загрузки полизаполнения JavaScript на этой "
+"странице."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Внимание"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Ошибка"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Тип предупреждения"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "По умолчанию"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Информация"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Успех"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Введите заголовок..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Введите текст..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Извещение"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Предоставьте контекстуальные отзывы."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "уведомление"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "сообщение"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Цвет текста"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Изменить изображение"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Редактировать галерею"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Удалить изображение"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Напишите подпись..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Добавьте аватар методом перетаскивания"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Заголовок..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Имя автора"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Напишите биографию"
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Настройки формы"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Автор"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Предложите посетителям выполнить действия с помощью нескольких кнопок, "
+"расположенных рядом."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Добавьте биографию автора"
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "биография"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "профиль"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Кнопки"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Предложите посетителям выполнить действия с помощью нескольких кнопок, расположенных рядом."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "ссылка"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Настройки кнопок"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Компоновка на мобильном устройстве"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -270,7 +164,8 @@ msgstr "Компоновка кнопок на мобильном устройс
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Toggle to stack buttons on mobile."
-msgstr "Используйте переключатель для компоновки кнопок на мобильном устройстве."
+msgstr ""
+"Используйте переключатель для компоновки кнопок на мобильном устройстве."
 
 #: src/blocks/click-to-tweet/controls.js:44
 msgid "Twitter Username"
@@ -280,31 +175,25 @@ msgstr "Имя пользователя Twitter"
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Добавить кнопку..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Добавить цитату в Twitter..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Щелкните, чтобы твитнуть"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Добавьте цитату для читателей в Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "поделиться"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "Twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +201,18 @@ msgid "Text Settings"
 msgstr "Настройки текста"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Цвет кнопки"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Динамический HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Добавьте разделитель с изменяемым размером между другими блоками."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "разделитель"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Настройки динамического HR"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Высота в пикселях"
 
@@ -347,17 +224,12 @@ msgstr "Высота элемента динамического раздели�
 msgid "Color"
 msgstr "Цвет"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Добавить как фон"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Функция"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "Отдельный дочерний столбец в блоке родительских функций."
 
@@ -366,73 +238,56 @@ msgid "Feature Settings"
 msgstr "Настройка функции"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Отступ"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Функции"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Можно добавить до трех столбцов или небольших заметок о вашем продукте или услуге."
+msgstr ""
+"Можно добавить до трех столбцов или небольших заметок о вашем продукте или "
+"услуге."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "услуги"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Поле"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Межстолбцовый промежуток"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Промежуток между столбцами"
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Малый"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Средний"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +297,8 @@ msgstr "Крупный"
 msgid "Features Settings"
 msgstr "Настройки функций"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -455,76 +310,72 @@ msgstr "Добавить раздел меню"
 msgid "Menu title..."
 msgstr "Заголовок меню..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Сетка"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Список"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Перетащите изображение для замены"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Удалить изображение"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Добавить заголовок..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Острое"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Горячее"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Вегетарианское"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Без глютена"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Вегетарианское с морепродуктами"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Веган"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Добавить описание..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0.00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Пищевой продукт"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Продукты питания и напитки в блоке \"Еда и напитки\"."
 
@@ -542,7 +393,8 @@ msgstr "Отображение изображения для этого элем
 
 #: src/blocks/food-and-drinks/food-item/inspector.js:25
 msgid "Toggle to show an image for this item."
-msgstr "Воспользуйтесь переключателем для отображения изображения для этого элемента."
+msgstr ""
+"Воспользуйтесь переключателем для отображения изображения для этого элемента."
 
 #: src/blocks/food-and-drinks/food-item/inspector.js:31
 msgid "Price"
@@ -560,62 +412,46 @@ msgstr "Воспользуйтесь переключателем для ото�
 msgid "Item Attributes"
 msgstr "Атрибуты элемента"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Пряный"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Настройки изображения"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Альтернативный текст"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Опишите назначение изображения"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Не заполняйте, если изображение используется только для украшения"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Фокусная точка"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Продукты и напитки"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Отображение меню или прайс-листа"
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "ресторан"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "меню"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Стили"
@@ -634,7 +470,9 @@ msgstr "Отображение изображений для каждого эл
 
 #: src/blocks/food-and-drinks/inspector.js:65
 msgid "Toggle to show images for each item."
-msgstr "Воспользуйтесь переключателем для отображения изображений для каждого элемента."
+msgstr ""
+"Воспользуйтесь переключателем для отображения изображений для каждого "
+"элемента."
 
 #: src/blocks/food-and-drinks/inspector.js:71
 msgid "Prices"
@@ -646,136 +484,89 @@ msgstr "Отображение цен для каждого элемента"
 
 #: src/blocks/food-and-drinks/inspector.js:75
 msgid "Toggle to show the price of each item."
-msgstr "Воспользуйтесь переключателем для отображения цен для каждого элемента."
+msgstr ""
+"Воспользуйтесь переключателем для отображения цен для каждого элемента."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Эл. почта"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "эл. почта"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "почта"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Поле адреса электронной почты."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Сообщение"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Текстовая область"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Многострочный текст"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Текстовое поле для длинных ответов."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "‌‌%s — недействительный адрес электронной почты."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s и %s — недействительные адреса электронной почты."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s — недействительный адрес электронной почты"
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Адрес эл. почты"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Тема"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Настройки формы"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "reCAPTCHA Google"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Добавьте ключ reCAPTCHA для сайта и секретный ключ, чтобы обеспечить защиту от спама."
+msgstr ""
+"Добавьте ключ reCAPTCHA для сайта и секретный ключ, чтобы обеспечить защиту "
+"от спама."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Создать ключи"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Мои ключи"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Получить помощь"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Ключ сайта"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Введите секретный ключ"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Сохранение"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Сохранить"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Удалить"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Первая"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Последняя"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Имя"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Текстовое поле для имен."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Поле адреса электронной почты."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Добавьте метку..."
 
@@ -783,41 +574,38 @@ msgstr "Добавьте метку..."
 msgid "Required"
 msgstr "Обязательно"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Настройки поля имени"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Фамилия"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Отображение полей имени и фамилии."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Воспользуйтесь переключателем для добавления поля \"Фамилия\"."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Форма"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Текстовое поле для имен."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Текстовое поле для длинных ответов."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Добавьте простую форму на вашу страницу."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "электронная почта"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "информация"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "контакт"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Тема"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +615,223 @@ msgstr "Добавить текст..."
 msgid "Button Text Color"
 msgstr "Цвет текста кнопки"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Редактировать галерею"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Карусель"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "изображение %1$d из %2$d в галерее"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Напишите подпись..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Карусель"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Покажите несколько изображений в красивой галерее \"Карусель\"."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "галерея"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "фотографии"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Настройки %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Высота линии"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Отображение навигационных стрелок точки."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr ""
+"Воспользуйтесь переключателем для отображения подписей к мультимедийным "
+"элементам."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "настройки сервера"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Размер"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Скругленные углы"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Цвет подписи"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Применить"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Кладка"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Введите описание…"
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Отображение нескольких изображений в упорядоченной галерее \"Кладка\"."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Покажите несколько изображений в красивой галерее \"Карусель\"."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Ширина столбца"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Настройки изображения"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Добавить скругленные углы к элементам галереи"
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Тень"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Подписи"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Стиль подписи"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Отображение подписей для каждого мультимедийного элемента."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
-msgstr "Воспользуйтесь переключателем для отображения подписей к мультимедийным элементам."
+msgstr ""
+"Воспользуйтесь переключателем для отображения подписей к мультимедийным "
+"элементам."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Кладка"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Отображение нескольких изображений в упорядоченной галерее \"Кладка\"."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Воспользуйтесь переключателем, чтобы включить опции управления картой."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Настройки карты"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Ширина столбца"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Добавить скругленные углы к элементам галереи"
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Свет"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Стек"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Отображение нескольких изображений в одной колонке галереи \"Стек\"."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Изображения с полной шириной"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Изображения с полной высотой"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Поле \"Тень\""
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Включен режим изображений с полной шириной"
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Воспользуйтесь переключателем, чтобы заполнить галерею изображениями с полной шириной."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы заполнить галерею изображениями с "
+"полной шириной."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Настройки элемента"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Изображения с полной шириной"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Изображения с полной высотой"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Удалить GIF"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Этот файл GIF имеет пустой атрибут alt"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Поиск совершенного файла gif в Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Поиск файлов GIF"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Выберите любой файл GIF."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "анимация"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +857,11 @@ msgstr "Файл GitHub"
 msgid "File"
 msgstr "Файл"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Просмотреть Gist на GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL-адрес Gist"
 
@@ -1024,12 +874,9 @@ msgid "Loading Gist"
 msgstr "Загрузка Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Встроить GitHub Gist путем добавления ссылки Gist."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "код"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +899,159 @@ msgid "Gist Meta"
 msgstr "Метаданные Gist"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Изменить макет"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Добавить фон для %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Герой"
-
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
 msgstr "Вводная область страницы с небольшим текстом и призывом к действию."
 
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "кнопка"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "призыв к действию"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Ширина содержимого в пикселях"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Настройки блока героев"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Пространство в контейнере."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Вверху слева"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Вверху по центру"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Вверху справа"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Слева по центру"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Точно в центре"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Справа по центру"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Внизу слева"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Внизу по центру"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Внизу справа"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Добавить выделенный текст..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Выделение"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Выделенный текст."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "текст"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "абзац"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Значок"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Добавьте стилизованный графический символ, чтобы сообщить дополнительную информацию."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "значки"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Огромные"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr ""
+"Добавьте стилизованный графический символ, чтобы сообщить дополнительную "
+"информацию."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Настройки значков"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Отключить расширенные настройки %s"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Сброс"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Пользовательский размер %s"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Дополнительные настройки %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Специальный"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Дополнительно"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Радиус"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Поиск значка"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Результаты не найдены."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Настройки ссылки"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL-адрес ссылки"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Связь ссылки"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Открытие в новой вкладке"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Открыть в новой вкладке"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Цвет значка"
 
@@ -1261,30 +1060,20 @@ msgid "Edit logos"
 msgstr "Изменить логотипы"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Логотипы и эмблемы"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Перетащите изображения, загрузите новые фотографии или выберите файлы из своей библиотеки."
+msgstr ""
+"Перетащите изображения, загрузите новые фотографии или выберите файлы из "
+"своей библиотеки."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Добавьте логотипы, эмблемы или сертификаты, чтобы улучшить свою репутацию"
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "клиенты"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "подтверждение"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "рекомендации"
+msgstr ""
+"Добавьте логотипы, эмблемы или сертификаты, чтобы улучшить свою репутацию"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1296,7 +1085,9 @@ msgstr "Черно-белое изображение"
 
 #: src/blocks/logos/inspector.js:16
 msgid "Toggle to add a black and white filter."
-msgstr "Воспользуйтесь переключателем, чтобы добавить фильтр черно-белого изображения."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы добавить фильтр черно-белого "
+"изображения."
 
 #: src/blocks/map/controls.js:30
 msgid "Edit Location"
@@ -1306,176 +1097,147 @@ msgstr "Изменить местоположение"
 msgid "Map style"
 msgstr "Стиль карты"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Недействительный ключ API или слишком много запросов"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Карта Google"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Введите местоположение или адрес, чтобы добавить метку на карту Google."
+msgstr ""
+"Введите местоположение или адрес, чтобы добавить метку на карту Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Поиск местоположения или адреса..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Применить"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Карта"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Добавьте местоположение, чтобы поместить метку на карту Google."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "адрес"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "карты"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "Google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Выберите стиль карты"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Настройки карты"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Уровень масштабирования"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Высота карты в пикселях"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Уровень масштабирования"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Размер маркера"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Опции точного управления включены"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Воспользуйтесь переключателем, чтобы включить опции управления картой."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Опции управления картой"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Тип карты"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "Переключатель стандартного и спутникового видов карты активирован."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Воспользуйтесь переключателем, чтобы выбрать стандартный или спутниковый вид карты."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы выбрать стандартный или спутниковый вид "
+"карты."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Управление масштабированием"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Отображение элементов управления масштабированием карты"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Воспользуйтесь переключателем, чтобы активировать элементы управления масштабированием карты."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы активировать элементы управления "
+"масштабированием карты."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Просмотр улиц"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Отображение элемента управления просмотром улиц на карте."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Воспользуйтесь переключателем, чтобы отобразить элемент управления просмотром улиц внизу справа."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы отобразить элемент управления "
+"просмотром улиц внизу справа."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Переключатель полного экрана"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Отображение переключателя полноэкранного режима карты."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
-msgstr "Воспользуйтесь переключателем, чтобы отобразить элемент управления полноэкранным режимом карты."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы отобразить элемент управления "
+"полноэкранным режимом карты."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Ключ API Карт Google"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Добавьте свой ключ API Карт Google. После обновления этого ключа API для всех ваших карт будет использоваться новый ключ."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Добавьте свой ключ API Карт Google. После обновления этого ключа API для "
+"всех ваших карт будет использоваться новый ключ."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Получить ключ"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Нужна помощь?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Введите ключ API Google…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Сохранено"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Стандарт"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Серебристый"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Ретро"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Темный"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Ночь"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Баклажан"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1247,9 @@ msgstr "Мультимедийный элемент справа"
 msgid "Media on left"
 msgstr "Мультимедийный элемент слева"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Медиакарта"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Добавьте изображение или видео рядом с картой."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "изображение"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "видео"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1263,18 @@ msgstr "Отображение тени карты."
 msgid "Toggle to add a card shadow."
 msgstr "Воспользуйтесь переключателем, чтобы добавить тень карты."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Тень %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Отображение тени %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Воспользуйтесь переключателем, чтобы добавить тень %s"
 
@@ -1545,40 +1298,171 @@ msgstr "Перетащите для замены мультимедийного 
 msgid "Edit media"
 msgstr "Изменить мультимедийный элемент"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Таблицы %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL-адрес Gist"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "План %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Карусель"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL-адрес Gist"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "настройки сервера"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Отображение цены для этого элемента."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Воспользуйтесь переключателем для отображения метаданных Gist."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Отображение кнопки призыва к действию."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Воспользуйтесь переключателем для отображения метаданных Gist."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Настройка функции"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Мультимедийный элемент слева"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Мультимедийный элемент справа"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Ширина столбца"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Настройки Gist"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Таблица цен"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Таблица цен"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Таблица цен"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Таблица цен"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Добавьте таблицы цен."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "целевая страница"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "План %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "сравнение"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Настройки таблиц цен"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Таблицы"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1480,171 @@ msgstr "План A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Элемент таблицы цен"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Столбец в блоке таблиц цен"
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Добавить фон для %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Столбец"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Непосредственный дочерний элемент строки."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Ширина"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Настройки столбца"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Пространство вокруг контейнера."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Ширина"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Изменить макет"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "один"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "два"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "три"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "четыре"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Добавить фон для %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Один столбец"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Два столбца"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Три столбца"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Четыре столбца"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Макет строки"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Строка"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Теперь выберите макет для этой строки столбца %s."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Выберите количество столбцов для этой строки."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Выберите столбцы строки"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Выберите макет строки"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Вернуться к столбцам"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Добавьте структурированную оболочку для блоков столбцов, а затем добавьте блоки контента в столбцы."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Добавьте структурированную оболочку для блоков столбцов, а затем добавьте "
+"блоки контента в столбцы."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "строки"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "столбцы"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "макеты"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Макет"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Настройки строки"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Нет"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1654,9 @@ msgstr "Квадрат"
 msgid "Circle"
 msgstr "Круг"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Услуги"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Добавьте до четырех столбцов для отображения услуг"
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "функции"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1758,13 +1676,10 @@ msgstr "Отображение кнопок призыва к действию."
 
 #: src/blocks/services/inspector.js:88
 msgid "Toggle to show call to action buttons."
-msgstr "Воспользуйтесь переключателем, чтобы отобразить кнопки призыва к действию."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы отобразить кнопки призыва к действию."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Услуга"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Один элемент в блоке услуг."
 
@@ -1782,267 +1697,233 @@ msgstr "Отображение кнопки призыва к действию."
 
 #: src/blocks/services/service/inspector.js:24
 msgid "Toggle to show a call to action button."
-msgstr "Воспользуйтесь переключателем, чтобы отобразить кнопку призыва к действию."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы отобразить кнопку призыва к действию."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Повернуть по горизонтали"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Повернуть по вертикали"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Разделитель форм"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "Добавьте разделитель форм, чтобы визуально различать разделы страницы."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "разделитель"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Цвет формы"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Настройки разделителя"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Высота формы в пикселях"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Высота фона в пикселях"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Ориентация"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Цвет формы"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Опубликовать в Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Опубликовать в Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Опубликовать в Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Опубликовать в Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Опубликовать в LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Поделиться по электронной почте"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Опубликовать в Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Опубликовать в Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Опубликовать в Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Поделиться"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "соцсети"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
 msgstr "Добавьте ссылки социальных сетей, чтобы получать лайки и публикации."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Цвета соцсетей"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Размер значка"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Размер круга"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Размер кнопки"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Значки"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Эл. почта"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Цвета кнопки \"Поделиться\" активированы."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Воспользуйтесь переключателем, чтобы использовать стандартные цвета каждой социальной платформы."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы использовать стандартные цвета каждой "
+"социальной платформы."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Цвета соцсетей"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Добавить профиль Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Добавить профиль Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Добавить профиль Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Добавить профиль Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Добавить профиль LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Добавить профиль YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Добавить профиль Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Добавить профиль Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Профили в социальных сетях"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "ссылки"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Отображение ссылок на профили в социальных сетях."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Ссылки на профили"
 
@@ -2057,18 +1938,6 @@ msgstr "Удалить фон"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Фон"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Автоматически"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Обложка"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Содержит"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1995,6 @@ msgstr "Удалить фон"
 msgid "Remove "
 msgstr "Удалить "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Без повтора"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Повтор по горизонтали"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Повтор по вертикали"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Переместить изображение назад"
@@ -2150,17 +2007,14 @@ msgstr "Переместить изображение вперед"
 msgid "Link To"
 msgstr "Ссылка на"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Галерея %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Загрузить изображение"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Свет"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2028,110 @@ msgstr "Страница приложений"
 msgid "Custom URL"
 msgstr "Пользовательский URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Пиксели"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "\"Эм\" (ширина самой широкой буквы данного шрифта)"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Ориентация"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Проценты"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Сброс"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Выбрать единицы"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "Единицы: %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Отключить расширенные настройки %s"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "Верх %s"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "Справа %s"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "Снизу %s"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "Слева %s"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Отменить синхронизацию"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Синхронизация"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Синхронизация единиц"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Верх"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Справа"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Снизу"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Слева"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Дополнительные настройки %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Дополнительно"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "По умолчанию"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Макет"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2150,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Воспользуйтесь переключателем, чтобы включить полноэкранный режим."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Заголовок %d"
@@ -2263,43 +2159,16 @@ msgstr "Заголовок %d"
 msgid "Custom color picker"
 msgstr "Пользовательская палитра"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Оригинал"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Оттенки серого"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Сепия"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Насыщенность"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Тускло"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Винтаж"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Применить фильтр"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Выберите ориентацию"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Высота"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Мобильный %s"
@@ -2333,7 +2202,8 @@ msgid "Five Seconds"
 msgstr "5 сек."
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "6 сек."
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2222,22 @@ msgstr "9 сек."
 msgid "Ten Seconds"
 msgstr "10 сек."
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Стрелки навигации"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Навигация точки"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "сек."
@@ -2361,22 +2247,28 @@ msgid "second"
 msgstr "сек."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Переход через %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Автоматически переходить к следующему слайду."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Перетаскивание включено на настольных и мобильных устройствах."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Воспользуйтесь переключателем, чтобы включить функцию перетаскивания на настольных и мобильных устройствах."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы включить функцию перетаскивания на "
+"настольных и мобильных устройствах."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2384,47 +2276,65 @@ msgstr "Отображение навигационных стрелок сла�
 
 #: src/components/slider-panel/index.js:35
 msgid "Toggle to show slide navigation arrows."
-msgstr "Воспользуйтесь переключателем, чтобы отобразить стрелки навигации слайдов."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы отобразить стрелки навигации слайдов."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Отображение навигационных стрелок точки."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
-msgstr "Воспользуйтесь переключателем, чтобы отобразить навигационные стрелки точки"
+msgstr ""
+"Воспользуйтесь переключателем, чтобы отобразить навигационные стрелки точки"
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Пространство в контейнере."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Воспользуйтесь переключателем, чтобы отключить звук видео"
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Воспользуйтесь переключателем, чтобы зациклить видео"
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Настройки ползунка"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Автовоспроизведение"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Скорость перехода"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Перетаскивание"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Стрелки навигации"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Навигация точки"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Прописные буквы"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Нормальный"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2368,6 @@ msgstr "Без нижнего интервала"
 msgid "Change typography"
 msgstr "Изменить типографику"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Полужирный"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Верхний регистр"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Нижний регистр"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Стек на мобильных устройствах"
@@ -2481,31 +2378,39 @@ msgstr "Обратная связь активирована."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Воспользуйтесь переключателем, чтобы расположить элементы друг над другом в малой области просмотра."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы расположить элементы друг над другом в "
+"малой области просмотра."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Удалить верхний интервал"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "В этом блоке удалено верхнее поле."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Воспользуйтесь переключателем, чтобы добавить тень карты."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Воспользуйтесь переключателем, чтобы удалить все поля, используемые в верхней части этого блока."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы отобразить навигационные стрелки точки"
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Удалить нижний интервал"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "В этом блоке удалено нижнее поле."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Воспользуйтесь переключателем, чтобы добавить тень карты."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Воспользуйтесь переключателем, чтобы удалить все поля, используемые в нижней части этого блока."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы отобразить навигационные стрелки точки"
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2517,23 +2422,17 @@ msgstr "Отображение в полную ширину."
 
 #: src/extensions/button-controls/index.js:74
 msgid "Toggle to display button as full width."
-msgstr "Воспользуйтесь переключателем, чтобы отобразить кнопку в полную ширину."
+msgstr ""
+"Воспользуйтесь переключателем, чтобы отобразить кнопку в полную ширину."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Круговой"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Настройки блока героев"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Тень"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Флажок"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Верхний регистр"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2553,114 +2452,800 @@ msgstr "Поиск блока"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:170
 msgid "This block is added to the page and cannot currently be disabled"
-msgstr "Этот блок добавлен на страницу и в настоящее время не может быть отключен"
+msgstr ""
+"Этот блок добавлен на страницу и в настоящее время не может быть отключен"
 
 #: src/sidebars/block-manager/components/options/disable-blocks.js:185
 msgid "Disable all"
 msgstr "Отключить все"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Блоки \"%s\" не найдены."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Галереи %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Отображать открытым"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Добавить название аккордеона..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Элемент аккордеона"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "вкладки"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "вопросы и ответы"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "уведомление"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "сообщение"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "биография"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "профиль"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "ссылка"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "поделиться"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "Twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "разделитель"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "услуги"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "меню"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "ресторан"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "эл. почта"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "почта"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Фамилия"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Текстовая область"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Многострочный текст"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "электронная почта"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "информация"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "контакт"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "галерея"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "фотографии"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Ночь"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "анимация"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "код"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "кнопка"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "призыв к действию"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "текст"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "абзац"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "значки"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "клиенты"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "подтверждение"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "рекомендации"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "адрес"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "карты"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "Google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "изображение"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "видео"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "адрес"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "целевая страница"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "сравнение"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "строки"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "столбцы"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "макеты"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "функции"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "разделитель"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "соцсети"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "ссылки"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Дисплей открыт"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Добавить элемент аккордеона"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Аккордеон"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Введите текст..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Введите заголовок..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Извещение"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Автор"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Кнопки"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Щелкните, чтобы твитнуть"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Динамический HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Функция"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Функции"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Пищевой продукт"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Продукты и напитки"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Эл. почта"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Имя"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Сообщение"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Форма"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Карусель"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Кладка"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Стек"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL-адрес Gist"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Герой"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Выделение"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Значок"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Логотипы и эмблемы"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Карта"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Медиакарта"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Карусель"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Таблица цен"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Элемент таблицы цен"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Столбец"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Строка"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Услуги"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Услуга"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Разделитель форм"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Поделиться"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Профили в социальных сетях"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Информация"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Успех"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Внимание"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Ошибка"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Точка"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Линия"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Полная ширина"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Сетка"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Список"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "По умолчанию"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Слои"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Контурный"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Заполненный"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Стек"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Повтор по горизонтали"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Волнистый"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Холмы"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Волны"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Угловой"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Наклонный"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Округленный"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Треугольник"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Заостренный"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Маска"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Значок"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Текст"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Значок и текст"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Круговой"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Внизу слева"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Вверху слева"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Добавьте аватар методом перетаскивания"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Автор"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3267,30 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "Этот функциональный блок вы можете использовать для выделения функций."
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "Добавить заголовок блока героев..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Добавьте контент блока героев, который обычно является вводным текстом страницы с одним или двумя призывами к действию."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Добавьте контент блока героев, который обычно является вводным текстом "
+"страницы с одним или двумя призывами к действию."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Добавьте основное действие..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Добавьте вспомогательное действие..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3309,125 @@ msgstr "Добавьте контент..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Замените этот текст описанием с изображением карты. Затем добавьте различные блоки на карту, такие как кнопки, списки или изображения."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Замените этот текст описанием с изображением карты. Затем добавьте различные "
+"блоки на карту, такие как кнопки, списки или изображения."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Введите заголовок..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Введите описание…"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Нормальный"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Настройки кнопок"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Специальный"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Компоновка на мобильном устройстве"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Настройки динамического HR"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Нет"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Нет"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Малый"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Средний"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Крупный"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Очень крупный"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Нет"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Малый"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Средний"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Крупный"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3105,7 +3792,8 @@ msgstr "компьютер Apple, монитор, устройство, наст
 #: src/blocks/icon/svgs.js:182
 msgctxt "tags"
 msgid "computer ipad surface apple montior device pc desk office"
-msgstr "компьютер, iPad, поверхность, Apple, монитор, устройство, настольный ПК, офис"
+msgstr ""
+"компьютер, iPad, поверхность, Apple, монитор, устройство, настольный ПК, офис"
 
 #: src/blocks/icon/svgs.js:187
 msgctxt "tags"
@@ -3125,7 +3813,8 @@ msgstr "USB-подключение, соцсеть, устройство, кон
 #: src/blocks/icon/svgs.js:20
 msgctxt "tags"
 msgid "music microphone podcast song artist creative media audio"
-msgstr "музыка, микрофон, подкаст, песня, исполнитель креатив, медиафайл, аудио"
+msgstr ""
+"музыка, микрофон, подкаст, песня, исполнитель креатив, медиафайл, аудио"
 
 #: src/blocks/icon/svgs.js:209
 msgctxt "tags"
@@ -3160,7 +3849,9 @@ msgstr "мир, общество, глобальная карта Земли"
 #: src/blocks/icon/svgs.js:258
 msgctxt "tags"
 msgid "location map public business corporation building town skyscraper"
-msgstr "схема проезда, государственная коммерческая корпорация, здание, город, небоскреб"
+msgstr ""
+"схема проезда, государственная коммерческая корпорация, здание, город, "
+"небоскреб"
 
 #: src/blocks/icon/svgs.js:263
 msgctxt "tags"
@@ -3180,7 +3871,9 @@ msgstr "веселье, вечеринка, счастливый праздни�
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "запах лепестка, приятный запах, расслабление, садоводство на открытом воздухе, природа, на улице"
+msgstr ""
+"запах лепестка, приятный запах, расслабление, садоводство на открытом "
+"воздухе, природа, на улице"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3259,8 +3952,12 @@ msgstr "музыка, микрофон, песня, исполнитель кр�
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "микрофон, подкаст, компьютер, устройство, песня, музыка, исполнитель креатив, медиафайл, аудио"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"микрофон, подкаст, компьютер, устройство, песня, музыка, исполнитель "
+"креатив, медиафайл, аудио"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3270,12 +3967,15 @@ msgstr "фото, фотограф, фотография, фотоаппарат
 #: src/blocks/icon/svgs.js:55
 msgctxt "tags"
 msgid "photo photographer photography camera aperture film creative media"
-msgstr "фото, фотограф, фотография, фотоаппарат, диафрагма, пленка, креатив, медиафайл"
+msgstr ""
+"фото, фотограф, фотография, фотоаппарат, диафрагма, пленка, креатив, "
+"медиафайл"
 
 #: src/blocks/icon/svgs.js:61
 msgctxt "tags"
 msgid "photo photos image media camera aperture collection"
-msgstr "фото, фотографии, изображения, медиафайлы, камера, диафрагма, коллекция"
+msgstr ""
+"фото, фотографии, изображения, медиафайлы, камера, диафрагма, коллекция"
 
 #: src/blocks/icon/svgs.js:67
 msgctxt "tags"
@@ -3284,8 +3984,12 @@ msgstr "режиссер фильма, продюсер, медиафайл, к�
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "видео, видеография, режиссер, продюсер, медиафайл, креатив, камера, фотограф, фотосъемка, диафрагма"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"видео, видеография, режиссер, продюсер, медиафайл, креатив, камера, "
+"фотограф, фотосъемка, диафрагма"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +4006,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "палитра, дизайн, цвета, художник, рисовать, креатив, медиафайл, кисть"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Стандарт"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Серебристый"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Ретро"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Темный"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Ночь"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Баклажан"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Круговой"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Тень"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "По умолчанию"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Нет"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Флажок"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Заголовок меню..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Малый"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Средний"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Крупный"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Очень крупный"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Автоматически"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Обложка"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Содержит"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Вверху слева"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Вверху по центру"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Вверху справа"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Слева по центру"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Точно в центре"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Справа по центру"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Внизу слева"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Внизу по центру"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Внизу справа"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Без повтора"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Повтор"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Повтор по горизонтали"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Повтор по вертикали"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Связь ссылки"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Темный"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Свет"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Нет"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Изображение"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Пиксели"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "\"Эм\" (ширина самой широкой буквы данного шрифта)"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Проценты"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Оригинал"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Оттенки серого"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Медиафайл"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Насыщенность"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Фильтр сайта"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Фильтр сайта"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Прописные буквы"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Нормальный"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Полужирный"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "По умолчанию"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Верхний регистр"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Нижний регистр"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4354,14 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks - это набор профессиональных <strong>блоков для создания страниц</strong> в редакторе WordPress Gutenberg Наши блоки позволяют разработчикам создавать прекрасные страницы в WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks - это набор профессиональных <strong>блоков для создания страниц</"
+"strong> в редакторе WordPress Gutenberg Наши блоки позволяют разработчикам "
+"создавать прекрасные страницы в WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4371,171 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Шутите?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Оставьте отзыв"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s г."
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "год"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s нед."
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "нед."
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s дн."
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "день"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s ч."
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "час"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s мин."
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "мин."
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s сек."
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "сек."
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Плагин WordPress %s"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Вам нравится %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Вы используете %1$s уже %2$s. Не могли бы вы оставить отзыв, чтобы поделиться своими идеями и пожеланиями? Мы будем очень признательны!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Оставьте отзыв"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Вы используете %1$s уже %2$s. Не могли бы вы оставить отзыв, чтобы "
+"поделиться своими идеями и пожеланиями? Мы будем очень признательны!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Нет, спасибо / у меня уже есть"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Спасибо за выбор CoBlocks, лучшего конструктора страниц для нового редактора блоков WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Спасибо за выбор CoBlocks, лучшего конструктора страниц для нового редактора "
+"блоков WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Вы только что добавили много полезных блоков и новые инструменты для компоновки страниц в редактор WordPress. CoBlocks предоставляет принципиально новый набор функций: %1$s десятки блоков%2$s, %1$s удобный конструктор страниц %2$s и %1$s пользовательские средства управления типографикой%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Вы только что добавили много полезных блоков и новые инструменты для "
+"компоновки страниц в редактор WordPress. CoBlocks предоставляет "
+"принципиально новый набор функций: %1$s десятки блоков%2$s, %1$s удобный "
+"конструктор страниц %2$s и %1$s пользовательские средства управления "
+"типографикой%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Вот несколько видеороликов, которые помогут вам начать работу:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Посмотрите, как создать свою первую страницу с %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Посмотрите, как создать свою первую страницу"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Посмотрите, как использовать блоки \"Строка\" и \"Разделитель форм\""
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Просмотрите, как использовать блок медиакарты"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Нравится то, что вы видите? %1$sПодпишитесь на канал YouTube%2$s, и мы будем уведомлять вас о выпуске новых учебных роликов."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Нравится то, что вы видите? %1$sПодпишитесь на канал YouTube%2$s, и мы будем "
+"уведомлять вас о выпуске новых учебных роликов."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Если у вас есть вопросы или комментарии, поделитесь ими в %1$sTwitter%4$s или в нашей группе %2$sFacebook %4$s. Кроме того, если вы хотите быть в курсе предстоящих событий на CoBlocks, %3$sподпишитесь на нашу новостную рассылку%4$s."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Если у вас есть вопросы или комментарии, поделитесь ими в %1$sTwitter%4$s "
+"или в нашей группе %2$sFacebook %4$s. Кроме того, если вы хотите быть в "
+"курсе предстоящих событий на CoBlocks, %3$sподпишитесь на нашу новостную "
+"рассылку%4$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Наслаждайтесь!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Начните работать с CoBlocks здесь:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4549,27 @@ msgstr "Ключ сайта reCAPTCHA Google для защиты от спама
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "Секретный ключ reCAPTCHA Google для защиты от спама"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Имя"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Первая"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Последняя"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Сообщение"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Отправить"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Ваше сообщение отправлено:"
 
@@ -3490,3 +4584,89 @@ msgstr "Опубликовать в LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "Тип предупреждения"
+
+#~ msgid "Edit image"
+#~ msgstr "Изменить изображение"
+
+#~ msgid "Remove image"
+#~ msgstr "Удалить изображение"
+
+#~ msgid "Heading..."
+#~ msgstr "Заголовок..."
+
+#~ msgid "Author Name"
+#~ msgstr "Имя автора"
+
+#~ msgid "Write biography..."
+#~ msgstr "Напишите биографию"
+
+#~ msgid "Add an author biography."
+#~ msgstr "Добавьте биографию автора"
+
+#~ msgid "%s Settings"
+#~ msgstr "Настройки %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Цвет подписи"
+
+#~ msgid "Highlight text."
+#~ msgstr "Выделенный текст."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Таблицы %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Настройки таблиц цен"
+
+#~ msgid "Tables"
+#~ msgstr "Таблицы"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Столбец в блоке таблиц цен"
+
+#~ msgid "Sepia"
+#~ msgstr "Сепия"
+
+#~ msgid "Dim"
+#~ msgstr "Тускло"
+
+#~ msgid "Vintage"
+#~ msgstr "Винтаж"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Выберите ориентацию"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "В этом блоке удалено верхнее поле."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Воспользуйтесь переключателем, чтобы удалить все поля, используемые в "
+#~ "верхней части этого блока."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "В этом блоке удалено нижнее поле."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Воспользуйтесь переключателем, чтобы удалить все поля, используемые в "
+#~ "нижней части этого блока."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Добавьте основное действие..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Добавьте вспомогательное действие..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Нормальный"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Начните работать с CoBlocks здесь:"

--- a/languages/coblocks-sv_SE.po
+++ b/languages/coblocks-sv_SE.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Visa öppen"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Lägg till titel för dragspel..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Dragspelsobjekt"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Lägg till komprimerade dragspelsobjekt till dragspel."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "flikar"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "vanliga frågor"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,39 @@ msgstr "Dragspelsobjekt är öppet som standard."
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Växla för att ange att det här dragspelsobjektet ska vara öppet som standard."
+msgstr ""
+"Växla för att ange att det här dragspelsobjektet ska vara öppet som standard."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Inställningar för dragspelsobjekt"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Visa Öppen"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Färginställningar"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Bakgrundsfärg"
@@ -103,14 +64,6 @@ msgstr "Bakgrundsfärg"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Textfärg för titel"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Lägg till dragspelsobjekt"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Accordion (dragspel)"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +79,83 @@ msgstr "Stöd för Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Lägg till stöd för Internet Explorer genom att läsa in ett JavaScript-polyfill."
+msgstr ""
+"Lägg till stöd för Internet Explorer genom att läsa in ett JavaScript-"
+"polyfill."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Få stöd för Internet Explorer genom att läsa in ett JavaScript-polyfill på den här sidan."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Få stöd för Internet Explorer genom att läsa in ett JavaScript-polyfill på "
+"den här sidan."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Varning"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Fel"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Varningstyp"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Standard"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Info"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Klart"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Skriv titel..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Skriv text..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Alert (varning)"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Ge kontextfeedback med meddelanden."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "avisering"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "meddelande"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Textfärger"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Redigera bild"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Redigera galleri"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Ta bort bild"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Skriv bildtext..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Släpp för att lägga till som avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Rubrik..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Författarens namn"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Skriv biografi..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Formulärinställningar"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Författare"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Lägg till en biografi över författare"
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biografi"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profil"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "Buttons (knappar)"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "Uppmana besökare att agera med flera knappar, sida vid sida."
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "länk"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Inställningar för knapp"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Stapla på mobilen"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "Buttons (knappar)"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +173,25 @@ msgstr "Twitter-användarnamn"
 msgid "Username"
 msgstr "Användarnamn"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Lägg till knapp..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Lägg till ett citattecken för att twittra..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Click to Tweet (klicka för att twittra)"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Lägg till ett citattecken så kan läsarna twittra på Twitter om det."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "dela"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +199,18 @@ msgid "Text Settings"
 msgstr "Textinställningar"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Knappfärg"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynamic HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Lägg till en reglerbar avståndskontroll mellan andra block."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "avståndskontroll"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Inställningar för Dynamic HR"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Höjd i pixlar"
 
@@ -347,17 +222,12 @@ msgstr "Höjd för dynamiskt avgränsningselement i pixlar."
 msgid "Color"
 msgstr "Färg"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Lägg till som bakgrund"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Funktion"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "En enskild underordnad kolumn inom ett överordnat block."
 
@@ -366,73 +236,56 @@ msgid "Feature Settings"
 msgstr "Funktionsinställningar"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Utfyllnad"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Features (funktioner)"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
-msgstr "Lägg till upp till tre kolumner med små anteckningar om din produkt eller tjänst."
+msgstr ""
+"Lägg till upp till tre kolumner med små anteckningar om din produkt eller "
+"tjänst."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "tjänster"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Marginal"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Fästmarginal"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Utrymme mellan respektive kolumn."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Litet"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Medium"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +295,8 @@ msgstr "Stort"
 msgid "Features Settings"
 msgstr "Funktionsinställningar"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Kolumner"
 
@@ -455,76 +308,72 @@ msgstr "Lägg till Meny-avsnitt"
 msgid "Menu title..."
 msgstr "Menyrubrik..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Skikt"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Lista"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Släpp bild för att ersätta"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Ta bort bild"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Lägg till titel..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Kryddstarkt"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Hett"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vegetariskt"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Glutenfritt"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Fisk"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Veganskt"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Lägg till beskrivning..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0,00 kr"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Maträtt"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Ett maträtts- och dryckesobjekt i blocket mat & dryck."
 
@@ -560,62 +409,46 @@ msgstr "Växla för att visa pris för den här artikeln."
 msgid "Item Attributes"
 msgstr "Artikelattribut"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Starkare"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Bildinställningar"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Alt Text (Alternativ text)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Beskriv syftet med bilden"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Lämna tom om bilden bara är dekoration."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Fokuspunkt"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Food & Drinks (mat & dryck)"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Visa en meny eller prislista."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restaurang"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "meny"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Stilar"
@@ -648,134 +481,86 @@ msgstr "Visar pris för vardera artikel"
 msgid "Toggle to show the price of each item."
 msgstr "Växla för att visa pris för vardera artikel."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "E-post"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "e-post"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "mail"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Fält för e-postadress."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Meddelande"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Textområde"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Flerradig text"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Textruta för längre svar."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s är ingen giltig e-postadress."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s och %s är inte giltiga e-postadresser."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s är inte giltiga e-postadresser."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "E-postadress"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Ämne"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Formulärinställningar"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Lägg till din reCAPTCHA och hemlig nyckel för att skydda formuläret från skräppost."
+msgstr ""
+"Lägg till din reCAPTCHA och hemlig nyckel för att skydda formuläret från "
+"skräppost."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Generera nycklar"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Mina nycklar"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Få hjälp"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Webbplatsnyckel"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Hemlig nyckel"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Sparar"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Spara"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "För"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Efter"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "namn"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Ett textfält för namn."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Fält för e-postadress."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Lägg till etikett..."
 
@@ -783,41 +568,38 @@ msgstr "Lägg till etikett..."
 msgid "Required"
 msgstr "Krävs"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Namnfältinställningar"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Efternamn"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Visar fält för både förnamn och efternamn."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Växla för att lägga till fält för efternamn."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Form (formulär)"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Ett textfält för namn."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Textruta för längre svar."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Lägg till ett enkelt formulär till din sida."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "e-post:"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "om"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "kontakt"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Ämne"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +609,219 @@ msgstr "Lägg till text..."
 msgid "Button Text Color"
 msgstr "Knapptextfärg"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Redigera galleri"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Carousel (karusell)"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "bild %1$d av %2$d i galleri"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Skriv bildtext..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Carousel (karusell)"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Visa flera bilder i ett snyggt karusellgalleri."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galleri"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "foton"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Inställningar för %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Radhöjd"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Visar navigeringspilar för punkter."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Växla för att visa mediebildtexter."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Färginställningar"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Storlek"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Runda hörn"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Bildtextfärg"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Tillämpa"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Masonry (murning)"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Skriv beskrivning..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Visa flera bilder i ett organiserat murningsgalleri."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Visa flera bilder i ett snyggt karusellgalleri."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Kolumnstorlek"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Bildinställningar"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Lägg till rundade hörn på galleriobjekt"
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Skugga"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Bildtexter"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Format på bildtexter"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Visar bildtexter för vardera medieobjekt."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Växla för att visa mediebildtexter."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Masonry (murning)"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Visa flera bilder i ett organiserat murningsgalleri."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Växla för att aktivera alternativ för kartkontroll."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Inställningar för karta"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Kolumnstorlek"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Lägg till rundade hörn på galleriobjekt"
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Ljus"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Stacked (staplad)"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Visa flera bilder i ett staplat galleri med en kolumn."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Bilder med fullständig bredd"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Bild med fullständig bredd"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Skugga på ruta"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Bilder med fullständig bredd är aktiverade."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Växla för att fylla tillgängligt galleriområde med bilder med fullständig bredd."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Växla för att fylla tillgängligt galleriområde med bilder med fullständig "
+"bredd."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Inställningar för artikel"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Bilder med fullständig bredd"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Bild med fullständig bredd"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Ta bort gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Denna gif har ett tomt attribut alt"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Sök efter en perfekt gif på Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Sök efter fler gif:ar"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Välj en gif, vilken gif som helst."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animerad"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +847,11 @@ msgstr "GitHub-fil"
 msgid "File"
 msgstr "Fil"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Visa denna gist på GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist-webbadress"
 
@@ -1024,12 +864,9 @@ msgid "Loading Gist"
 msgstr "Läser in gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Bädda in GitHub-gistar genom att lägga till gistlänken."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "kod"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +889,159 @@ msgid "Gist Meta"
 msgstr "Gistmeta"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Ändra layout"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Lägg till bakgrund till %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Herobanner"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Ett inledande stycke på en sida följt av ett litet textstycke och en "
+"uppmaning till handling."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Ett inledande stycke på en sida följt av ett litet textstycke och en uppmaning till handling."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "knapp"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "uppmaning till handling"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Innehållsbredd i pixlar"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Herobannerinställningar"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Utrymme i behållare"
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Högst upp till vänster"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Högst upp i mitten"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Högst upp till höger"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Mitten vänster"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Mitten mitten"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Mitten höger"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Längst ner till vänster"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Längst ner i mitten"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Längst ner till höger"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Lägg till markerad text..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Markera"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Markera text."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "text"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "stycke"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Icon (ikon)"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Lägg till en stiliserad grafisk symbol för att kommunicera något mer."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "ikoner"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Stor"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Lägg till en stiliserad grafisk symbol för att kommunicera något mer."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Ikoninställningar"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Stäng av avancerade inställningar för %s"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Återställ"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Anpassade storlek för %s"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Avancerade inställningar för %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Anpassad"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Avancerat"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Radius"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Ikonsökning"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Hittade inga resultat."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Länkinställningar"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "Länk-URL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Länkrelation"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Öppnar i ny flik"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Öppen i ny flik"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Ikonfärg"
 
@@ -1261,30 +1050,18 @@ msgid "Edit logos"
 msgstr "Redigera logotyper"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logos & Badges (logotyper och märken)"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr "Dra bilder, ladda upp nya eller välj filer från ditt bibliotek."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Lägg till logotyper, märken eller certifieringar för ökad trovärdighet."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "kunder"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "bevis"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "utlåtanden"
+msgstr ""
+"Lägg till logotyper, märken eller certifieringar för ökad trovärdighet."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1083,140 @@ msgstr "Redigera plats"
 msgid "Map style"
 msgstr "Kartformat"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Ogiltig API-nyckel eller för många förfrågningar"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Maps"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "Ange en plats eller adress för att fästa en nål på en Google-karta."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Sök efter en plats eller adress..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Tillämpa"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Map (karta)"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Lägg till en adress och fäst en nål på en Google-karta."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "adress"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "kartor"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Välj kartformat"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Inställningar för karta"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Inzoomningsnivå"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Höjd för karta i pixlar"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Inzoomningsnivå"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Storlek på markör"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Alternativ för finjustering är aktiverad."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Växla för att aktivera alternativ för kartkontroll."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Kartkontroller"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Karttyp"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "Växling mellan standard- och satellitkarta är aktiverad."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "Växla för att aktivera växling mellan standard- och satellitkartor."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Zoomkontroller"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Visar kontroller för kartzoomning"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Växla för att aktivera mellan att zooma in och ut på kartan med zoomkontroller."
+msgstr ""
+"Växla för att aktivera mellan att zooma in och ut på kartan med "
+"zoomkontroller."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Gatuvy"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Visar kontroll för gatuvykarta."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "Växla för att visa gatuvykontrollen längst ner till höger."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Helskärmsväxling"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Visar kontroll för helskärmskarta."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Växla för att visa kontroll för helskärmskarta"
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "API-nyckel för Google Maps"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Lägg till din API-nyckel för Google Maps. Om du uppdaterar den här API-nyckeln kommer den att användas till alla kartor."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Lägg till din API-nyckel för Google Maps. Om du uppdaterar den här API-"
+"nyckeln kommer den att användas till alla kartor."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Hämta din nyckel"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Behöver du hjälp?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Ange API-nyckel för Google..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Sparat"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standard"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Silver"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Mörk"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Natt"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Aubergine"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1226,9 @@ msgstr "Media på höger sida"
 msgid "Media on left"
 msgstr "Media på vänster sida"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Media Card (mediekort)"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Lägg till en bild eller video med ett förskjutet kort, sida vid sida."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "bild"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1242,18 @@ msgstr "Visar kortskugga"
 msgid "Toggle to add a card shadow."
 msgstr "Växla för att lägga till en kortskugga."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Skugga från %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Visar skugga från %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Växla för att lägga till en skugga från %s"
 
@@ -1545,40 +1277,171 @@ msgstr "Släpp för att ersätta media"
 msgid "Edit media"
 msgstr "Redigera media"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s-tabeller"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist-webbadress"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Paket %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Carousel (karusell)"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist-webbadress"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Färginställningar"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Visar priset för den här artikeln."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Växla för att visa gistmetadata."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Visar knappen med uppmaning till handling."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Växla för att visa gistmetadata."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Funktionsinställningar"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Media på vänster sida"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Media på höger sida"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Kolumnstorlek"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gistinställningar"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Pricing Table (prislistor)"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Pricing Table (prislistor)"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Pricing Table (prislistor)"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Pricing Table (prislistor)"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Lägg till prislistor."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "start"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Paket %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "jämförelse"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Inställningar för prislistor"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tabeller"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1459,171 @@ msgstr "Paket A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Objekt i prislista"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "En kolumn i blocket med prislista."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Lägg till bakgrund till %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Kolumn"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Ett direkt underordnat objekt till en rad."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Bredd"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Kolumninställningar"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Utrymme runt behållaren."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Bredd"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Ändra layout"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "ett"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "två"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "tre"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "fyra"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Lägg till bakgrund till %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "En kolumn"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Två kolumner"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Tre kolumner"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Fyra kolumner"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Radlayout"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Rad"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Välj nu en layout för den här %s-kolumnraden."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Välj antalet kolumner för den här raden."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Välj radkolumner"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Välj radlayout"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Tillbaka till kolumner"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Lägg till ett omslag med struktur för kolumnblock och lägg sedan till de innehållsblock du vill till kolumnerna."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Lägg till ett omslag med struktur för kolumnblock och lägg sedan till de "
+"innehållsblock du vill till kolumnerna."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "rader"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "kolumner"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "layouter"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Layout"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Radinställningar"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Ingen"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1633,9 @@ msgstr "Fyrkantig"
 msgid "Circle"
 msgstr "Cirkel"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Services (tjänster)"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Lägg till upp till fyra kolumner med tjänster att visa."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "funktioner"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1657,7 @@ msgstr "Visar knappar med uppmaning till handling."
 msgid "Toggle to show call to action buttons."
 msgstr "Växla till att visa knappar med uppmaning till handling."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Tjänst"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Ett tjänsteobjekt inom ett block med tjänster."
 
@@ -1785,264 +1678,231 @@ msgid "Toggle to show a call to action button."
 msgstr "Växla för att visa en knapp med uppmaning till handling."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Vänd horisontellt"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Vänd vertikalt"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Shape Divider (avdelare)"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "Lägg till en avdelare för att synligt skilja stycken på sidan åt."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "separator"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Formfärg"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Inställningar för avdelare"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Formhöjd i pixlar"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Bakgrundshöjd i pixlar"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Orientering"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Formfärg"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Dela på Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Dela på Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Dela på Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Dela på Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Dela på LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Dela via e-post"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Dela på Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Dela på Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Dela på Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Dela"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "socialt"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Lägg till länkar för delning på sociala medier som kan hjälpa dig att få delningar och gillanden."
+msgstr ""
+"Lägg till länkar för delning på sociala medier som kan hjälpa dig att få "
+"delningar och gillanden."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Sociala mediefärger"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Ikonstorlek"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Cirkelstorlek"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Knappstorlek"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Ikoner"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "E-post"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Delningsknappens färger är aktiverade."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Växla för att använda de officiella färgerna från de olika sociala medieplattformarna."
+msgstr ""
+"Växla för att använda de officiella färgerna från de olika sociala "
+"medieplattformarna."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Sociala mediefärger"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Lägg till Facebook-profil"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Lägg till Twitter-profil"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Lägg till Instagram-profil"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Lägg till Pinterest-profil"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Lägg till LinkedIn-profil"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Lägg till YouTube-profil"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Lägg till Yelp-profil"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Lägg till Houzz-profil"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Social Profiles (sociala profiler)"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "länkar"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Visa länkar till sociala medieprofiler."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Profillänkar"
 
@@ -2057,18 +1917,6 @@ msgstr "Ta bort bakgrund"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Bakgrund"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Bil"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Omslagsfoto"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Innehåller"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1974,6 @@ msgstr "Ta bort bakgrund"
 msgid "Remove "
 msgstr "Ta bort "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Ingen upprepning"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Upprepa horisontellt"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Upprepa vertikalt"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Flytta bild bakåt"
@@ -2150,17 +1986,14 @@ msgstr "Flytta bild framåt"
 msgid "Link To"
 msgstr "Länka till"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s-galleri"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Ladda upp en bild"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Ljus"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2007,110 @@ msgstr "Sida med bilaga"
 msgid "Custom URL"
 msgstr "Anpassad webbadress"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Orientering"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Procentsats"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Återställ"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Välj enheter"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s enheter"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Stäng av avancerade inställningar för %s"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s högst upp"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s höger"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s nederst"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s vänster"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Avsluta synkronisering"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Synkronisering"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Synkronisera enheter"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Överst"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Höger"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Nederst"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Vänster"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Avancerade inställningar för %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Avancerat"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Standard"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Layout"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2129,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Växla för att aktivera helskärmsläge."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Rubrik %d"
@@ -2263,43 +2138,16 @@ msgstr "Rubrik %d"
 msgid "Custom color picker"
 msgstr "Anpassad färgväljare"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Original"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Gråskala"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sepia"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Mättnad"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Nedtonad"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Vintage"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Tillämpa filter"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Välj orientering"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Höjd"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Mobil %s"
@@ -2333,7 +2181,8 @@ msgid "Five Seconds"
 msgstr "Fem sekunder"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Sex sekunder"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2201,22 @@ msgstr "Nio sekunder"
 msgid "Ten Seconds"
 msgstr "Tio sekunder"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Pilnavigering"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Punktnavigering"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "sekunder"
@@ -2361,21 +2226,25 @@ msgid "second"
 msgstr "sekund"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Går vidare efter %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Gå automatiskt vidare till nästa bild."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Att dra och svepa är aktiverat på dator och mobila enheter."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
 msgstr "Växla för att aktivera dragfunktionen på dator och mobila enheter."
 
 #: src/components/slider-panel/index.js:35
@@ -2387,44 +2256,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Växla för att visa navigeringspilar för bildspel."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Visar navigeringspilar för punkter."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Växla för att visa navigeringspilar för punkter."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Utrymme i behållare"
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Växla för att stänga av ljud på video."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Växla för att loopa videon."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Inställningar för skjutreglage"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Autospela"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Övergångshastighet"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Dragbar"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Pilnavigering"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Punktnavigering"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Börja med stor bokstav"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2343,6 @@ msgstr "Inget utrymme längst ner"
 msgid "Change typography"
 msgstr "Byt typografi"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Fet"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Versaler"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Gemener"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Stapla på mobilen"
@@ -2487,25 +2359,29 @@ msgstr "Växla för att stapla element på varandra på mindre visningsområden.
 msgid "Remove Top Spacing"
 msgstr "Ta bort utrymme högst upp"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Övre marginal är borttagen på det här blocket."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Växla för att lägga till en kortskugga."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Växla för att ta bort marginal upptill på det här blocket."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Växla för att visa navigeringspilar för punkter."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Ta bort utrymme längst ner"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Nedre marginal är borttagen på det här blocket."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Växla för att lägga till en kortskugga."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Växla för att ta bort marginal nedtill på det här blocket."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Växla för att visa navigeringspilar för punkter."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2395,14 @@ msgstr "Visas som fullständig bredd"
 msgid "Toggle to display button as full width."
 msgstr "Växla för att visa knapp med fullständig bredd."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Cirkelformad"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Herobannerinställningar"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Skugga"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Kryssruta"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Versaler"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2428,793 @@ msgstr "Det här blocket är tillagt på sidan och kan inte inaktiveras just nu.
 msgid "Disable all"
 msgstr "Inaktivera alla"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Inga \"%s\"-block hittade."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s-gallerier"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Visa öppen"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Lägg till titel för dragspel..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Dragspelsobjekt"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "flikar"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "vanliga frågor"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "avisering"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "meddelande"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biografi"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "länk"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "dela"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "avståndskontroll"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "tjänster"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "meny"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restaurang"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "e-post"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "mail"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Efternamn"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Textområde"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Flerradig text"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "e-post:"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "om"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "kontakt"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galleri"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "foton"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Natt"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animerad"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "kod"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "knapp"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "uppmaning till handling"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "text"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "stycke"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "ikoner"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "kunder"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "bevis"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "utlåtanden"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "adress"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "kartor"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "bild"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "adress"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "start"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "jämförelse"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "rader"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "kolumner"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "layouter"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "funktioner"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "separator"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "socialt"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "länkar"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Visa Öppen"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Lägg till dragspelsobjekt"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Accordion (dragspel)"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Skriv text..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Skriv titel..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Alert (varning)"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Författare"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Buttons (knappar)"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Click to Tweet (klicka för att twittra)"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynamic HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Funktion"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Features (funktioner)"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Maträtt"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Food & Drinks (mat & dryck)"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "E-post"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "namn"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Meddelande"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Form (formulär)"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Carousel (karusell)"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Masonry (murning)"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Stacked (staplad)"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist-webbadress"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Herobanner"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Markera"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Icon (ikon)"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logos & Badges (logotyper och märken)"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Map (karta)"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Media Card (mediekort)"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Carousel (karusell)"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Pricing Table (prislistor)"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Objekt i prislista"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Kolumn"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Rad"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Services (tjänster)"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Tjänst"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Shape Divider (avdelare)"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Dela"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Social Profiles (sociala profiler)"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Info"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Klart"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Varning"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Fel"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Punkt"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Linje"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Fullständig bredd"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Skikt"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Lista"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Standard"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Lager"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Kontur"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Fylld"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Stacked (staplad)"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Upprepa horisontellt"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Vågig"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Kullar"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Vågor"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Vinklad"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Lutande"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Rundad"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Triangelformad"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Spetsig"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Mask"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Icon (ikon)"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Text"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Ikon och text"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Cirkelformad"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Längst ner till vänster"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Högst upp till vänster"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Släpp för att lägga till som avatar"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Författare"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3234,33 @@ msgstr "Lägg till funktionsinnehåll"
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Det här är ett funktionsblock som du kan använda för att markera funktioner."
+msgstr ""
+"Det här är ett funktionsblock som du kan använda för att markera funktioner."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Lägg till herobannerrubrik..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Lägg till herobannerrubrik..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Lägg till herobannerinnehåll, som brukar vara ett introduktionsområde på en "
+"sida, följt av en uppmaning till handling eller två."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Lägg till herobannerinnehåll, som brukar vara ett introduktionsområde på en sida, följt av en uppmaning till handling eller två."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Lägg till primär åtgärd..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Lägg till sekundär åtgärd..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3279,126 @@ msgstr "Lägg till innehåll..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Ersätt den här texten med beskrivande text som passar med kortbilden. Sedan kan du lägga till fler block till det här kortet, som knappar, listor och bilder."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Ersätt den här texten med beskrivande text som passar med kortbilden. Sedan "
+"kan du lägga till fler block till det här kortet, som knappar, listor och "
+"bilder."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Skriv titel..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Skriv beskrivning..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Inställningar för knapp"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Anpassad"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Stapla på mobilen"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Inställningar för Dynamic HR"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Ingen"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Ingen"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Litet"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Stort"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Extra stor"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Ingen"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Litet"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Stort"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,7 +3917,9 @@ msgstr "musik mikrofon låt artist kreativ media ljud"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
 msgstr "mikrofon podcast dator enhet ljud"
 
 #: src/blocks/icon/svgs.js:49
@@ -3284,8 +3944,12 @@ msgstr "film videografi regissör producent media kreativ"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "video videografi regissör producent media kreativ kamera fotografi fotograf bländare"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"video videografi regissör producent media kreativ kamera fotografi fotograf "
+"bländare"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3966,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "palett design färger artist konstnär kreativ media måla pensel"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standard"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Silver"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Mörk"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Natt"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Aubergine"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Cirkelformad"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Skugga"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Standard"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Ingen"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Kryssruta"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Menyrubrik..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Litet"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Medium"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Stort"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Extra stor"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Bil"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Omslagsfoto"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Innehåller"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Högst upp till vänster"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Högst upp i mitten"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Högst upp till höger"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Mitten vänster"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Mitten mitten"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Mitten höger"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Längst ner till vänster"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Längst ner i mitten"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Längst ner till höger"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Ingen upprepning"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Upprepa"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Upprepa horisontellt"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Upprepa vertikalt"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Länkrelation"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Mörk"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Ljus"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Ingen"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Bild"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Pixel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Procentsats"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Original"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Gråskala"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Mediefil"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Mättnad"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Vintagefilter"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Vintagefilter"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Börja med stor bokstav"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Fet"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Standard"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Versaler"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Gemener"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4314,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks är en svit professionella <strong>block för sidbygge</strong> för blockredigeraren Gutenberg i WordPress. Våra block är hyperfokuserade på att ge användarna alla möjligheter att skapa snygga och innehållsrika sidor i WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks är en svit professionella <strong>block för sidbygge</strong> för "
+"blockredigeraren Gutenberg i WordPress. Våra block är hyperfokuserade på att "
+"ge användarna alla möjligheter att skapa snygga och innehållsrika sidor i "
+"WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4332,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Fusk, va?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Skriv en recension"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s år"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "ett år"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s veckor"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "en vecka"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s dagar"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "en dag"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s timmar"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "en timme"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s minuter"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "en minut"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s sekunder"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "en sekund"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPress-plugin"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Tycker du om %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Du har använt %1$s i %2$s nu. Kan du tänka dig att skriva en recension och berätta vad du tycker? Det skulle vara toppen!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Skriv en recension"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Du har använt %1$s i %2$s nu. Kan du tänka dig att skriva en recension och "
+"berätta vad du tycker? Det skulle vara toppen!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Nej tack / Det har jag redan gjort"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Tack för att du väljer CoBlocks, den högklassiga sidbyggaren för den nya WordPress-blockredigeraren."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Tack för att du väljer CoBlocks, den högklassiga sidbyggaren för den nya "
+"WordPress-blockredigeraren."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Du har precis lag till massor av användbara block och ett nytt verktygskit för sidbygge i WordPress-redigeraren. CoBlocks ger dig revolutionerande funktioner: %1$s tiotalet olika block%2$s, en %1$s sidbyggarupplevelse %2$s och %1$s anpassade typografikontroller%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Du har precis lag till massor av användbara block och ett nytt verktygskit "
+"för sidbygge i WordPress-redigeraren. CoBlocks ger dig revolutionerande "
+"funktioner: %1$s tiotalet olika block%2$s, en %1$s sidbyggarupplevelse %2$s "
+"och %1$s anpassade typografikontroller%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Här är några videoklipp som kan hjälpa dig att komma igång:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Se hur du skapar din första sidan med %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Se hur du skapar din första sida"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Se hur du kan använda blocken rad och avdelare"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Titta på hur man använder mediekortsblocket"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Tycker du om det du ser? %1$sPrenumerera på vår YouTube-kanal%2$s så meddelar vi när nya videohandledningar släpps."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Tycker du om det du ser? %1$sPrenumerera på vår YouTube-kanal%2$s så "
+"meddelar vi när nya videohandledningar släpps."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Om du har några frågor eller kommentarer kan du bara kontakta oss på %1$sTwitter%4$s eller i vår %2$sFacebook-grupp %4$s. Du kan också %3$sprenumerera på vårt nyhetsbrev%4$s om du vill få besked om det senaste inom CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Om du har några frågor eller kommentarer kan du bara kontakta oss på "
+"%1$sTwitter%4$s eller i vår %2$sFacebook-grupp %4$s. Du kan också "
+"%3$sprenumerera på vårt nyhetsbrev%4$s om du vill få besked om det senaste "
+"inom CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Mycket nöje!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Kom igång med CoBlocks här:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4509,27 @@ msgstr "Google reCaptcha-platsnyckel för skräppostskydd för formulär"
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "Google reCaptcha hemlig nyckel för skräppostskydd för formulär"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "namn"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "För"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Efter"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Meddelande"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Skicka"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Ditt meddelande skickades:"
 
@@ -3490,3 +4544,85 @@ msgstr "Dela på LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Varningstyp"
+
+#~ msgid "Edit image"
+#~ msgstr "Redigera bild"
+
+#~ msgid "Remove image"
+#~ msgstr "Ta bort bild"
+
+#~ msgid "Heading..."
+#~ msgstr "Rubrik..."
+
+#~ msgid "Author Name"
+#~ msgstr "Författarens namn"
+
+#~ msgid "Write biography..."
+#~ msgstr "Skriv biografi..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Lägg till en biografi över författare"
+
+#~ msgid "%s Settings"
+#~ msgstr "Inställningar för %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Bildtextfärg"
+
+#~ msgid "Highlight text."
+#~ msgstr "Markera text."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s-tabeller"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Inställningar för prislistor"
+
+#~ msgid "Tables"
+#~ msgstr "Tabeller"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "En kolumn i blocket med prislista."
+
+#~ msgid "Sepia"
+#~ msgstr "Sepia"
+
+#~ msgid "Dim"
+#~ msgstr "Nedtonad"
+
+#~ msgid "Vintage"
+#~ msgstr "Vintage"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Välj orientering"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Övre marginal är borttagen på det här blocket."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "Växla för att ta bort marginal upptill på det här blocket."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Nedre marginal är borttagen på det här blocket."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "Växla för att ta bort marginal nedtill på det här blocket."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Lägg till primär åtgärd..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Lägg till sekundär åtgärd..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Kom igång med CoBlocks här:"

--- a/languages/coblocks-th.po
+++ b/languages/coblocks-th.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "เปิดให้แสดงผล"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "เพิ่มชื่อแอคคอร์เดียน..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "รายการแอคคอร์เดียน"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "เพิ่มรายการแอคคอร์เดียนที่ยุบได้ลงในชุดแอคคอร์เดียน"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "แท็บ"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "คำถามที่ถามบ่อย"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "เปลี่ยนเพื่อตั้งค่ารายกา
 msgid "Accordion Item Settings"
 msgstr "การตั้งค่ารายการแอคคอร์เดียน"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "เปิดให้แสดงผล"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "การตั้งค่าสี"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "สีพื้นหลัง"
@@ -103,14 +63,6 @@ msgstr "สีพื้นหลัง"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "สีตัวอักษรชื่อเรื่อง"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "เพิ่มรายการแอคคอร์เดียน"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "แอคคอร์เดียน"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -129,140 +81,76 @@ msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
 msgstr "เพิ่มการรองรับ Internet Explorer โดยโหลดโพลีฟิลล์ของ JavaScript"
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
 msgstr "การทำให้รองรับ Internet Explorer โดยโหลดโพลีฟิลล์ของ JavaScript ในหน้านี้"
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "คำเตือน"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "เกิดข้อผิดพลาด"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "ประเภทการแจ้งเตือน"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "ค่าเริ่มต้น"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "ข้อมูล"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "สำเร็จ"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "เขียนชื่อเรื่อง..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "เขียนข้อความ..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "การแจ้งเตือน"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "ระบุข้อความเสนอแนะตามสถานการณ์"
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "การแจ้งให้ทราบ"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "ข้อความ"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "สีข้อความ"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "แก้ไขรูปภาพ"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "แก้ไขแกลเลอรี"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "ลบรูปภาพ"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "เขียนคำบรรยาย:"
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "วางเพื่อเพิ่มเป็นรูปประจำตัว"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "หัวเรื่อง..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "ชื่อผู้เขียน"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "เขียนชีวประวัติ..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "การตั้งค่าแบบฟอร์ม"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "ผู้เขียน"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "เพิ่มชีวประวัติผู้เขียน"
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "ชีวประวัติ"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "โปรไฟล์"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "ปุ่ม"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "แจ้งให้ผู้เข้าชมดำเนินการกับหลากหลายปุ่มที่เรียงข้างกัน"
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "ลิงก์"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "CTA"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "การตั้งค่าปุ่ม"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "เรียงซ้อนบนมือถือ"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "ปุ่ม"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +168,25 @@ msgstr "ชื่อผู้ใช้ Twitter"
 msgid "Username"
 msgstr "ชื่อผู้ใช้"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "เพิ่มปุ่ม..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "เพิ่มคำพูดอ้างอิงที่จะทวีต..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "คลิกเพื่อทวีต"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "เพิ่มคำพูดอ้างอิงสำหรับผู้อ่านที่จะทวีต Twitter"
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "แชร์"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "Twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +194,18 @@ msgid "Text Settings"
 msgstr "การตั้งค่าข้อความ"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "สีปุ่ม"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "ระยะแนวนอนแบบไดนามิก"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "เพิ่มช่องไฟที่ปรับขนาดได้ระหว่างบล็อคอื่นๆ"
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "ช่องไฟ"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "การตั้งค่าระยะแนวนอนแบบไดนามิก"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "ความสูงเป็นพิกเซล"
 
@@ -347,17 +217,12 @@ msgstr "ความสูงสำหรับองค์ประกอบต
 msgid "Color"
 msgstr "สี"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "เพิ่มเป็นพื้นหลัง"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "คุณลักษณะ"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "คอลัมน์ย่อยเดี่ยวภายในบล็อคคุณลักษณะหลัก"
 
@@ -366,73 +231,54 @@ msgid "Feature Settings"
 msgstr "การตั้งค่าคุณลักษณะ"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "ส่วนเสริมขนาด"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "ฟีเจอร์"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "เพิ่มบันทึกขนาดเล็กเป็นสามคอลัมน์สำหรับผลิตภัณฑ์หรือบริการของคุณ"
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "บริการ"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "ขอบ"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "ขอบนอก"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "ช่องว่างระหว่างแต่ละคอลัมน์"
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "เล็ก"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "กลาง"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +288,8 @@ msgstr "ใหญ่"
 msgid "Features Settings"
 msgstr "การตั้งค่าคุณลักษณะ"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "คอลัมน์"
 
@@ -455,76 +301,72 @@ msgstr "เพิ่มส่วนของเมนู"
 msgid "Menu title..."
 msgstr "ชื่อเมนู..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "กริด"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "รายการ"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "วางรูปภาพแทนที่"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "ลบรูปภาพ"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "เพิ่มชื่อเรื่อง..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "เผ็ดร้อน"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "สุดยอด"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "มังสวิรัติ"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "ปราศจากกลูเต็น"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "งดเนื้อสัตว์ยกเว้นอาหารทะเล"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "อาหารที่ไม่มีผลิตภัณฑ์จากสัตว์"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "เพิ่มคำอธิบาย..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0.00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "รายการอาหาร"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "รายการอาหารและเครื่องดื่มในบล็อคอาหารและเครื่องดื่ม"
 
@@ -560,62 +402,46 @@ msgstr "เปลี่ยนให้แสดงราคาสำหรับ
 msgid "Item Attributes"
 msgstr "แอตทริบิวต์รายการ"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "เผ็ดร้อนยิ่งกว่า"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "การตั้งค่ารูปภาพ"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Alt Text (ข้อความสำรอง)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "บรรยายจุดประสงค์ของภาพ"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "ปล่อยว่างไว้หากรูปภาพเป็นการตกแต่งเท่านั้น"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "จุดโฟกัส"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "อาหารและเครื่องดื่ม"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "แสดงเมนูหรือรายการราคา"
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "ร้านอาหาร"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "เมนู"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "สไตล์"
@@ -648,134 +474,84 @@ msgstr "การแสดงราคาสำหรับแต่ละรา
 msgid "Toggle to show the price of each item."
 msgstr "เปลี่ยนให้แสดงราคาสำหรับแต่ละรายการ"
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "อีเมล"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "อีเมล"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "เมล"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "ช่องที่อยู่อีเมล"
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "ข้อความ"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "พื้นที่ข้อความ"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "ข้อความหลายบรรทัด"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "กล่องข้อความสำหรับการตอบที่ยาวขึ้น"
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s ไม่ใช่ที่อยู่อีเมลที่ถูกต้อง"
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s และ %s ไม่ใช่ที่อยู่อีเมลที่ถูกต้อง"
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s ไม่ใช่ที่อยู่อีเมลที่ถูกต้อง"
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "ที่อยู่อีเมล"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "เรื่อง"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "การตั้งค่าแบบฟอร์ม"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
 msgstr "เพิ่มเว็บไซต์ reCAPTCHA และคีย์ลับของคุณเพื่อปกป้องแบบฟอร์มของคุณจากสแปม"
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "สร้างคีย์"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "คีย์ของฉัน"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "รับความช่วยเหลือ"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "คีย์เว็บไซต์"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "คีย์ลับ"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "การบันทึก"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "บันทึก"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "นำออก"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "แรก"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "สุดท้าย"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "ชื่อ"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "ช่องข้อความสำหรับใส่ชื่อ"
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "ช่องที่อยู่อีเมล"
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "เพิ่มป้ายชื่อ..."
 
@@ -783,41 +559,38 @@ msgstr "เพิ่มป้ายชื่อ..."
 msgid "Required"
 msgstr "ต้องระบุ"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "การตั้งค่าช่องใส่ชื่อ"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "นามสกุล"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "การแสดงทั้งช่องใส่ชื่อและนามสกุล"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "เปลี่ยนให้เพิ่มช่องนามสกุล"
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "แบบฟอร์ม"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "ช่องข้อความสำหรับใส่ชื่อ"
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "กล่องข้อความสำหรับการตอบที่ยาวขึ้น"
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "เพิ่มแบบฟอร์มธรรมดาในหน้าของคุณ"
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "อีเมล"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "เกี่ยวกับ"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "ข้อมูลติดต่อ"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "เรื่อง"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +600,217 @@ msgstr "เพิ่มข้อความ…"
 msgid "Button Text Color"
 msgstr "สีข้อความบนปุ่ม"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "แก้ไขแกลเลอรี"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "แถบหมุน"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "ภาพ %1$d จาก %2$d ในแกลเลอรี"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "เขียนคำบรรยาย:"
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "แถบหมุน"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "แสดงหลายภาพในแกลเลอรีแบบแถบหมุนอย่างสวยงาม"
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "แกลเลอรี"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "ภาพถ่าย"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "การตั้งค่ า%s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "ความสูงของเส้น"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "การแสดงลูกศรนำทางด้วยจุด"
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "เปลี่ยนให้แสดงคำบรรยายสื่อ"
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "การตั้งค่าสี"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "ขนาด"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "มุมโค้งมน"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "สีคำบรรยาย"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "นำไปใช้"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "แบบเรียงอิฐ"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "เขียนคำอธิบาย..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "แสดงหลายภาพในแกลเลอรีแบบเรียงอิฐอย่างเป็นระเบียบ"
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "แสดงหลายภาพในแกลเลอรีแบบแถบหมุนอย่างสวยงาม"
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "ขนาดคอลัมน์"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "การตั้งค่ารูปภาพ"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "เพิ่มมุมโค้งมนให้กับรายการแกลเลอรี"
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "เงา"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "คำบรรยาย"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "สไตล์คำบรรยาย"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "แสดงคำบรรยายสำหรับสื่อแต่ละรายการ"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "เปลี่ยนให้แสดงคำบรรยายสื่อ"
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "แบบเรียงอิฐ"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "แสดงหลายภาพในแกลเลอรีแบบเรียงอิฐอย่างเป็นระเบียบ"
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "เปลี่ยนให้เปิดใช้งานตัวเลือกการควบคุมโดยละเอียด"
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "การตั้งค่าแผนที่"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "ขนาดคอลัมน์"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "เพิ่มมุมโค้งมนให้กับรายการแกลเลอรี"
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "อ่อน"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "เรียงซ้อน"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "แสดงหลายภาพในแกลเลอรีแบบเรียงซ้อนแนวตั้งเป็นแถวเดียว"
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "ภาพเต็มความกว้าง"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "ภาพเต็มความกว้าง"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "เงากล่อง"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "เปิดใช้งานภาพเต็มความกว้าง"
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
 msgstr "เปลี่ยนให้ใส่ภาพเต็มความกว้างทั้งหมดในพื้นที่แกลเลอรีที่มีอยู่"
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "‌‌การตั้งค่ารายการ"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "ภาพเต็มความกว้าง"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "ภาพเต็มความกว้าง"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "ลบ gif ออก"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "gif นี้มีแอตทริบิวต์ข้อความสำรองที่ว่างอยู่"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "ค้นหา gif ที่ตรงใจบน Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "ค้นหา gif"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "เลือกมาหนึ่ง gif จะเป็น gif ใดก็ได้"
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "ภาพเคลื่อนไหว"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +836,11 @@ msgstr "ไฟล์ GitHub"
 msgid "File"
 msgstr "ไฟล์"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "ดูกิสต์นี้บน GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL ของกิสต์"
 
@@ -1024,12 +853,9 @@ msgid "Loading Gist"
 msgstr "กำลังโหลดกิสต์"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "ฝังกิสต์ของ GitHub โดยเพิ่มลิงก์ของกิสต์"
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "โค้ด"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +878,157 @@ msgid "Gist Meta"
 msgstr "ข้อมูลเมตาของกิสต์"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "เปลี่ยนเค้าโครง"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "เพิ่มพื้นหลังให้ %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "ฮีโร่"
-
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
 msgstr "พื้นที่แนะนำของเพจที่มาพร้อมข้อความเล็กน้อยและการกระตุ้นให้ดำเนินการ"
 
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "ปุ่ม"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "กระตุ้นให้ดำเนินการ"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "ความกว้างของเนื้อหาในพิกเซล"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "‌‌การตั้งค่าฮีโร่"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "ช่องว่างภายในพื้นที่บรรจุ"
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "ซ้ายบน"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "กลางบน"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "ขวาบน"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "ซ้ายกลาง"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "ตรงกลาง"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "ขวากลาง"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "ซ้ายล่าง"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "กลางล่าง"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "ขวาล่าง"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "เพิ่มข้อความที่เน้น..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "เน้น"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "ข้อความที่เน้น"
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "ข้อความ"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "ย่อหน้า"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "ไอคอน"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "เพิ่มสัญลักษณ์กราฟิกอย่างมีสไตล์เพื่อสื่อสารให้มากขึ้น"
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "ไอคอน"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "ใหญ่มาก"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "เพิ่มสัญลักษณ์กราฟิกอย่างมีสไตล์เพื่อสื่อสารให้มากขึ้น"
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "การตั้งค่าไอคอน"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "ปิดการตั้งค่า %s ขั้นสูง"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "รีเซ็ต"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "ขนาด %s ที่กำหนดเอง"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "การตั้งค่า %s ขั้นสูง"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "กำหนดเอง"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "ขั้นสูง"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "รัศมี"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "ค้นหาไอคอน"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "ไม่พบผลลัพธ์"
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "‌‌การตั้งค่าลิงก์"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL ลิงก์"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Link Rel"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "การเปิดในแท็บใหม่"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "เปิดในแท็บใหม่"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "สีไอคอน"
 
@@ -1261,30 +1037,17 @@ msgid "Edit logos"
 msgstr "แก้ไขโลโก้"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "โลโก้และป้าย"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr "ลากรูปภาพ อัปโหลดภาพใหม่ หรือเลือกไฟล์จากไลบรารีของคุณ"
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "เพิ่มโลโก้ ป้าย หรือเครื่องหมายรับรองเพื่อสร้างความน่าเชื่อถือ"
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "ลูกค้า"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "การพิสูจน์"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "คำนิยม"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1069,137 @@ msgstr "แก้ไขตำแหน่งที่ตั้ง"
 msgid "Map style"
 msgstr "สไตล์แผนที่"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "คีย์ API ไม่ถูกต้องหรือจำนวนคำขอมากเกินไป"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Map"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "ใส่ตำแหน่งหรือที่อยู่เพื่อปักหมุดบน Google Map"
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "ค้นหาสถานที่หรือที่อยู่…"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "นำไปใช้"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "แผนที่"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "เพิ่มที่อยู่และปักหมุดบน Google Map"
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "ที่อยู่"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "แผนที่"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "Google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "เลือกสไตล์แผนที่"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "การตั้งค่าแผนที่"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "ระดับการย่อ/ขยาย"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "ความสูงสำหรับแผนที่เป็นพิกเซล"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "ระดับการย่อ/ขยาย"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "ขนาดของเครื่องหมาย"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "เปิดใช้งานตัวเลือกการควบคุมโดยละเอียดแล้ว"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "เปลี่ยนให้เปิดใช้งานตัวเลือกการควบคุมโดยละเอียด"
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "ระบบควบคุมแผนที่"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "ประเภทของแผนที่"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "เปิดใช้งานการสลับระหว่างมุมมองแผนที่มาตรฐานและแบบดาวเทียมแล้ว"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "เปลี่ยนให้เปิดใช้งานการสลับระหว่างมุมมองแผนที่มาตรฐานและแบบดาวเทียม"
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "ระบบควบคุมการย่อ/ขยาย"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "การแสดงระบบควบคุมการย่อ/ขยายแผนที่"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "เปลี่ยนให้เปิดใช้งานการย่อและขยายบนแผนที่ด้วยระบบควบคุมการย่อ/ขยาย"
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "มุมมองถนน"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "การแสดงระบบควบคุมแผนที่มุมมองถนน"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "เปิดให้แสดงระบบควบคุมแผนที่มุมมองถนนที่มุมขวาล่าง"
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "เปลี่ยนให้เป็นภาพเต็มจอ"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "การแสดงระบบควบคุมแผนที่แบบเต็มจอ"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "เปลี่ยนให้แสดงระบบควบคุมแผนที่แบบเต็มจอ"
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "คีย์ API ของ Google Maps"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "เพิ่มคีย์ API ของ Google Maps ของคุณ การอัปเดตคีย์ API นี้จะตั้งค่าแผนที่ทั้งหมดของคุณให้ใช้คีย์ใหม่"
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"เพิ่มคีย์ API ของ Google Maps ของคุณ การอัปเดตคีย์ API นี้จะตั้งค่าแผนที่ทั้งหมดของคุณให้ใช้คีย์ใหม่"
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "เรียกคีย์ของคุณ"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "ต้องการความช่วยเหลือใช่หรือไม่"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "ใส่คีย์ API ของ Google…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "บันทึกแล้ว"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "มาตรฐาน"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "สีเงิน"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "เรโทร"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "มืด"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "กลางคืน"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "โทนม่วง"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1209,9 @@ msgstr "สื่ออยู่ทางขวา"
 msgid "Media on left"
 msgstr "สื่ออยู่ทางซ้าย"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "การ์ดสื่อ"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "เพิ่มรูปภาพหรือวิดีโอพร้อมมีการ์ดวางข้างๆ"
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "รูปภาพ"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "วิดีโอ"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1225,18 @@ msgstr "การแสดงเงาการ์ด"
 msgid "Toggle to add a card shadow."
 msgstr "เปลี่ยนให้เพิ่มเงาการ์ด"
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " เงา %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "การแสดงเงา %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "เปลี่ยนให้เพิ่มเงา %s"
 
@@ -1545,40 +1260,171 @@ msgstr "วางเพื่อแทนที่สื่อ"
 msgid "Edit media"
 msgstr "แก้ไขสื่อ"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "ตาราง %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL ของกิสต์"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "แผน %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "แถบหมุน"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL ของกิสต์"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "การตั้งค่าสี"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "การแสดงราคาสำหรับรายการนี้"
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "เปลี่ยนให้แสดงข้อมูลเมตาของกิสต์"
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "การแสดงปุ่มกระตุ้นให้ดำเนินการ"
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "เปลี่ยนให้แสดงข้อมูลเมตาของกิสต์"
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "การตั้งค่าคุณลักษณะ"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "สื่ออยู่ทางซ้าย"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "สื่ออยู่ทางขวา"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "ขนาดคอลัมน์"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "‌‌การตั้งค่ากิสต์"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "ตารางราคา"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "ตารางราคา"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "ตารางราคา"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "ตารางราคา"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "เพิ่มตารางราคา"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "หน้าเริ่มต้น"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "แผน %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "การเปรียบเทียบ"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "กาตตั้งค่าตารางราคา"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "ตาราง"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1442,170 @@ msgstr "แผน A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "รายการตารางราคา"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "คอลัมน์ที่วางในบล็อคตารางราคา"
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "เพิ่มพื้นหลังให้ %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "คอลัมน์"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "แถวย่อยที่อยู่ติดกัน"
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "ความกว้าง"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "การตั้งค่าคอลัมน์"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "ช่องว่างรอบพื้นที่บรรจุ"
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "ความกว้าง"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "เปลี่ยนเค้าโครง"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "หนึ่ง"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "สอง"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "สาม"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "สี่"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "เพิ่มพื้นหลังให้ %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "หนึ่งคอลัมน์"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "สองคอลัมน์"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "สามคอลัมน์"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "สี่คอลัมน์"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "เค้าโครงแถว"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "แถว"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "ทีนี้ก็เลือกเค้าโครงสำหรับแถว %s คอลัมน์นี้"
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "เลือกจำนวนคอลัมน์สำหรับแถวนี้"
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "เลือกคอลัมน์ในแถว"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "เลือกเค้าโครงแถว"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "กลับไปที่คอลัมน์"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "เพิ่มส่วนห่อหุ้มที่จัดโครงสร้างไว้สำหรับบล็อคคอลัมน์ แล้วเพิ่มบล็อคเนื้อหาที่คุณต้องการลงในคอลัมน์"
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"เพิ่มส่วนห่อหุ้มที่จัดโครงสร้างไว้สำหรับบล็อคคอลัมน์ แล้วเพิ่มบล็อคเนื้อหาที่คุณต้องการลงในคอลัมน์"
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "แถว"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "คอลัมน์"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "เค้าโครง"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "เค้าโครง"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "‌‌การตั้งค่าแถว"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "ไม่มี"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1615,9 @@ msgstr "สี่เหลี่ยม"
 msgid "Circle"
 msgstr "วงกลม"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "บริการ"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "เพิ่มบริการได้สูงสุดสี่คอลัมน์ในการแสดงผล"
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "คุณลักษณะ"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1639,7 @@ msgstr "การแสดงปุ่มกระตุ้นให้ดำเ
 msgid "Toggle to show call to action buttons."
 msgstr "เปลี่ยนให้แสดงปุ่มกระตุ้นให้ดำเนินการ"
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "บริการ"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "หนึ่งรายการบริการภายในบล็อคบริการ"
 
@@ -1785,264 +1660,227 @@ msgid "Toggle to show a call to action button."
 msgstr "เปลี่ยนให้แสดงปุ่มกระตุ้นให้ดำเนินการ"
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "พลิกกลับแนวนอน"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "พลิกกลับแนวตั้ง"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "ตัวแบ่งหน้าจอแบบรูปร่าง"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "เพิ่มตัวแบ่งหน้าจอแบบรูปร่างเพื่อแยกแต่ละส่วนในหน้านั้นออกจากกันอย่างชัดเจน"
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "ตัวคั่น"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "สีรูปร่าง"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "การตั้งค่าตัวแบ่งหน้าจอ"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "ความสูงของรูปร่างเป็นพิกเซล"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "ความสูงพื้นหลังเป็นพิกเซล"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "การวางแนว"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "สีรูปร่าง"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "แชร์ใน Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "แชร์ใน Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "แชร์ใน Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "แชร์ใน Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "แชร์ใน LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "แชร์ทางอีเมล"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "แชร์ใน Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "แชร์ใน Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "แชร์ใน Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "แชร์"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "โซเชียล"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
 msgstr "เพิ่มลิงก์สำหรับแชร์ในโซเชียลเพื่อช่วยให้คุณได้แชร์และมีคนกดถูกใจ"
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "สีโซเชียล"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "ขนาดไอคอน"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "ขนาดวงกลม"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "ขนาดปุ่ม"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "ไอคอน"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "อีเมล"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "เปิดใช้งานสีปุ่มแชร์แล้ว"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
 msgstr "เปลี่ยนไปใช้สีทางการจากแต่ละโซเชียลมีเดีย"
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "สีโซเชียล"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "เพิ่มโปรไฟล์ Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "เพิ่มโปรไฟล์ Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "เพิ่มโปรไฟล์ Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "เพิ่มโปรไฟล์ Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "เพิ่มโปรไฟล์ LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "เพิ่มโปรไฟล์ YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "เพิ่มโปรไฟล์ Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "เพิ่มโปรไฟล์ Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "โพรไฟล์บนสังคมออนไลน์"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "ลิงก์"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "แสดงลิงก์ไปยังโปรไฟล์ของโซเชียลมีเดีย"
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "ลิงก์โปรไฟล์"
 
@@ -2057,18 +1895,6 @@ msgstr "เอาพื้นหลังออก"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "พื้นหลัง"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "รถยนต์"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "ภาพปก"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "บรรจุ"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1952,6 @@ msgstr "เอาพื้นหลังออก"
 msgid "Remove "
 msgstr "นำออก "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "ไม่ซ้ำ"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "ซ้ำแนวนอน"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "ซ้ำแนวตั้ง"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "ย้ายรูปภาพไปข้างหลัง"
@@ -2150,17 +1964,14 @@ msgstr "ย้ายรูปภาพมาข้างหน้า"
 msgid "Link To"
 msgstr "ลิงก์ไปยัง"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "แกลเลอรี %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "อัปโหลดรูปภาพ"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "อ่อน"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +1985,110 @@ msgstr "หน้าสิ่งที่แนบ"
 msgid "Custom URL"
 msgstr "URL ที่กำหนดเอง"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "พิกเซล"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "อีเอ็ม"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "การวางแนว"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "ร้อยละ"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "รีเซ็ต"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "เลือกหน่วย"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s หน่วย"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "ปิดการตั้งค่า %s ขั้นสูง"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "ด้านบน %s"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "ด้านขวา %s"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "ด้านล่าง %s"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "ด้านซ้าย %s"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "ยกเลิกการซิงค์"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "ซิงค์"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "ซิงค์หน่วยให้ตรงกัน"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "ด้านบน"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "ด้านขวา"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "ด้านล่าง"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "ด้านซ้าย"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "การตั้งค่า %s ขั้นสูง"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "ขั้นสูง"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "ค่าเริ่มต้น"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "เค้าโครง"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2107,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "เปลี่ยนให้เปิดใช้งานโหมดเต็มจอ"
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "หัวเรื่อง %d"
@@ -2263,43 +2116,16 @@ msgstr "หัวเรื่อง %d"
 msgid "Custom color picker"
 msgstr "ตัวเลือกสีที่กำหนดเอง"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "ดั้งเดิม"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "สีขาวดำ"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "ซีเปีย"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "ความอิ่มตัว"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "หม่น"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "วินเทจ"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "ใช้ตัวกรอง"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "เลือกแนว"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "ความสูง"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "%s เคลื่อนที่"
@@ -2333,7 +2159,8 @@ msgid "Five Seconds"
 msgstr "ห้าวินาที"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "หกวินาที"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2179,22 @@ msgstr "เก้าวินาที"
 msgid "Ten Seconds"
 msgstr "สิบวินาที"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "การนำทางด้วยลูกศร"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "การนำทางด้วยจุด"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "วินาที"
@@ -2361,21 +2204,25 @@ msgid "second"
 msgstr "วินาที"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "ไปต่อหลังจาก %1$d %2$s"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "ไปที่ภาพนิ่งต่อไปโดยอัตโนมัติ"
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "เปิดใช้งานการลากและสะบัดบนอุปกรณ์เดสก์ท็อปและมือถือ"
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
 msgstr "เปลี่ยนให้เปิดใช้งานการลากบนอุปกรณ์เดสก์ท็อปและมือถือ"
 
 #: src/components/slider-panel/index.js:35
@@ -2387,44 +2234,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "เปลี่ยนให้แสดงลูกศรนำทางภาพนิ่ง"
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "การแสดงลูกศรนำทางด้วยจุด"
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "เปลี่ยนให้แสดงการนำทางด้วยจุด"
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "ช่องว่างภายในพื้นที่บรรจุ"
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "เปลี่ยนให้ปิดเสียงวิดีโอ"
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "เปลี่ยนให้วนซ้ำวิดีโอ"
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "การตั้งค่าตัวเลื่อน"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "เล่นอัตโนมัติ"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "ความเร็วในการเปลี่ยน"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "ลากได้"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "การนำทางด้วยลูกศร"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "การนำทางด้วยจุด"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "เปลี่ยนเป็นตัวพิมพ์ใหญ่"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "ปกติ"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2321,6 @@ msgstr "ไม่มีช่องว่างด้านล่าง"
 msgid "Change typography"
 msgstr "เปลี่ยนการออกแบบตัวอักษร"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "ตัวหนา"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "ตัวพิมพ์ใหญ่"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "ตัวพิมพ์เล็ก"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "เรียงซ้อนบนมือถือ"
@@ -2487,25 +2337,29 @@ msgstr "เปลี่ยนให้เรียงองค์ประกอ
 msgid "Remove Top Spacing"
 msgstr "เอาช่องว่างด้านบนออก"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "เอาขอบด้านบนของบล็อคนี้ออกแล้ว"
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "เปลี่ยนให้เพิ่มเงาการ์ด"
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "เปลี่ยนให้เอาขอบใดๆ ที่ใช้กับด้านบนของบล็อคนี้ออก"
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "เปลี่ยนให้แสดงการนำทางด้วยจุด"
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "เอาช่องว่างด้านล่างออก"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "เอาขอบด้านล่างของบล็อคนี้ออกแล้ว"
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "เปลี่ยนให้เพิ่มเงาการ์ด"
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "เปลี่ยนให้เอาขอบใดๆ ที่ใช้กับด้านล่างของบล็อคนี้ออก"
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "เปลี่ยนให้แสดงการนำทางด้วยจุด"
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2373,14 @@ msgstr "การแสดงให้เต็มความกว้าง"
 msgid "Toggle to display button as full width."
 msgstr "เปลี่ยนให้แสดงปุ่มเต็มความกว้าง"
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "วงแหวน"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "‌‌การตั้งค่าฮีโร่"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "สามมิติ"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "เงา"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "ช่องทำเครื่องหมาย"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "ตัวพิมพ์ใหญ่"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2406,793 @@ msgstr "เพิ่มบล็อคนี้ในเพจแล้วแล
 msgid "Disable all"
 msgstr "ปิดใช้งานทั้งหมด"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "ไม่พบบล็อค \"%s\""
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "แกลเลอรี %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "เปิดให้แสดงผล"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "เพิ่มชื่อแอคคอร์เดียน..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "รายการแอคคอร์เดียน"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "แท็บ"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "คำถามที่ถามบ่อย"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "การแจ้งให้ทราบ"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "ข้อความ"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "ชีวประวัติ"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "โปรไฟล์"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "ลิงก์"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "CTA"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "แชร์"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "Twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "ช่องไฟ"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "บริการ"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "เมนู"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "ร้านอาหาร"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "อีเมล"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "เมล"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "นามสกุล"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "พื้นที่ข้อความ"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "ข้อความหลายบรรทัด"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "อีเมล"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "เกี่ยวกับ"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "ข้อมูลติดต่อ"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "แกลเลอรี"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "ภาพถ่าย"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "กลางคืน"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "ภาพเคลื่อนไหว"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "โค้ด"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "ปุ่ม"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "กระตุ้นให้ดำเนินการ"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "ข้อความ"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "ย่อหน้า"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "ไอคอน"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "ลูกค้า"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "การพิสูจน์"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "คำนิยม"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "ที่อยู่"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "แผนที่"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "Google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "รูปภาพ"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "วิดีโอ"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "ที่อยู่"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "หน้าเริ่มต้น"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "การเปรียบเทียบ"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "แถว"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "คอลัมน์"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "เค้าโครง"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "คุณลักษณะ"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "ตัวคั่น"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "โซเชียล"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "ลิงก์"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "เปิดให้แสดงผล"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "เพิ่มรายการแอคคอร์เดียน"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "แอคคอร์เดียน"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "เขียนข้อความ..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "เขียนชื่อเรื่อง..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "การแจ้งเตือน"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "ผู้เขียน"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "ปุ่ม"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "คลิกเพื่อทวีต"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "ระยะแนวนอนแบบไดนามิก"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "คุณลักษณะ"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "ฟีเจอร์"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "รายการอาหาร"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "อาหารและเครื่องดื่ม"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "อีเมล"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "ชื่อ"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "ข้อความ"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "แบบฟอร์ม"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "แถบหมุน"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "แบบเรียงอิฐ"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "เรียงซ้อน"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL ของกิสต์"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "ฮีโร่"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "เน้น"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "ไอคอน"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "โลโก้และป้าย"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "แผนที่"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "การ์ดสื่อ"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "แถบหมุน"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "ตารางราคา"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "รายการตารางราคา"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "คอลัมน์"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "แถว"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "บริการ"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "บริการ"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "ตัวแบ่งหน้าจอแบบรูปร่าง"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "แชร์"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "โพรไฟล์บนสังคมออนไลน์"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "ข้อมูล"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "สำเร็จ"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "คำเตือน"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "เกิดข้อผิดพลาด"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "จุด"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "เส้น"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "เต็มความกว้าง"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "กริด"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "รายการ"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "ค่าเริ่มต้น"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "เลเยอร์"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "มีเส้นขอบ"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "ทึบ"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "เรียงซ้อน"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "ซ้ำแนวนอน"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "เป็นคลื่น"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "เนิน"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "คลื่น"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "เหลี่ยมมุม"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "ลาดชัน"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "กลม"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "สามเหลี่ยม"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "แหลม"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "หน้ากาก"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "ไอคอน"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "ข้อความ"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "ไอคอนและข้อความ"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "วงแหวน"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "ซ้ายล่าง"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "ซ้ายบน"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "วางเพื่อเพิ่มเป็นรูปประจำตัว"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "ผู้เขียน"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3214,29 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "นี่เป็นบล็อคคุณลักษณะที่คุณสามารถใช้เพื่อเน้นคุณลักษณะได้"
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "เพิ่มหัวเรื่องแบบฮีโร่..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "เพิ่มเนื้อหาแบบฮีโร่ ซึ่งปกติจะเป็นพื้นที่แนะนำหน้าหรือสองหน้าที่มาพร้อมกับการกระตุ้นให้ดำเนินการ"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"เพิ่มเนื้อหาแบบฮีโร่ ซึ่งปกติจะเป็นพื้นที่แนะนำหน้าหรือสองหน้าที่มาพร้อมกับการกระตุ้นให้ดำเนินการ"
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "เพิ่มการดำเนินการหลัก..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "เพิ่มการดำเนินการรอง..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3255,125 @@ msgstr "เพิ่มเนื้อหา..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "แทนที่ข้อความนี้ด้วยคำบรรยายที่เข้ากับภาพในการ์ด จากนั้นเพิ่มบล็อคลงในการ์ดนี้ เช่น ปุ่ม รายชื่อ หรือรูปภาพ"
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"แทนที่ข้อความนี้ด้วยคำบรรยายที่เข้ากับภาพในการ์ด จากนั้นเพิ่มบล็อคลงในการ์ดนี้ เช่น ปุ่ม รายชื่อ "
+"หรือรูปภาพ"
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "เขียนชื่อเรื่อง..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "เขียนคำอธิบาย..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "ปกติ"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "การตั้งค่าปุ่ม"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "กำหนดเอง"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "เรียงซ้อนบนมือถือ"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "การตั้งค่าระยะแนวนอนแบบไดนามิก"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "ไม่มี"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "ไม่มี"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "เล็ก"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "กลาง"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "ใหญ่"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "ใหญ่เป็นพิเศษ"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "ไม่มี"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "เล็ก"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "กลาง"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "ใหญ่"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,7 +3892,9 @@ msgstr "ดนตรี ไมโครโฟน เพลง ศิลปิน
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
 msgstr "ไมโครโฟน พ็อดแคสต์ คอมพิวเตอร์ อุปกรณ์ ดนตรี เพลง ศิลปิน สร้างสรรค์ สื่อ เสียง"
 
 #: src/blocks/icon/svgs.js:49
@@ -3284,7 +3919,9 @@ msgstr "ฟิล์ม การถ่ายวิดีโอ ผู้กำ�
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
 msgstr "วิดีโอ ถ่ายวิดีโอ ผู้กำกับ ผู้ผลิต สื่อ สร้างสรรค์ กล้อง ช่างภาพ ถ่ายภาพ รูรับแสง"
 
 #: src/blocks/icon/svgs.js:85
@@ -3302,12 +3939,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "เมนูสี ออกแบบ สี ศิลปิน สร้างสรรค์ สื่อ ระบายสี แปรงทาสี"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "มาตรฐาน"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "สีเงิน"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "เรโทร"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "มืด"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "กลางคืน"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "โทนม่วง"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "วงแหวน"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "สามมิติ"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "เงา"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "ค่าเริ่มต้น"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "ไม่มี"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "ช่องทำเครื่องหมาย"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "ชื่อเมนู..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "เล็ก"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "กลาง"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "ใหญ่"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "ใหญ่เป็นพิเศษ"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "รถยนต์"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "ภาพปก"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "บรรจุ"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "ซ้ายบน"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "กลางบน"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "ขวาบน"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "ซ้ายกลาง"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "ตรงกลาง"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "ขวากลาง"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "ซ้ายล่าง"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "กลางล่าง"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "ขวาล่าง"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "ไม่ซ้ำ"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "ซ้ำ"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "ซ้ำแนวนอน"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "ซ้ำแนวตั้ง"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Link Rel"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "มืด"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "อ่อน"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "ไม่มี"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "รูปภาพ"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "พิกเซล"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "อีเอ็ม"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "ร้อยละ"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "ดั้งเดิม"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "สีขาวดำ"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "ไฟล์สื่อ"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "ความอิ่มตัว"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "ตัวกรองวินเทจ"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "ตัวกรองวินเทจ"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "เปลี่ยนเป็นตัวพิมพ์ใหญ่"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "ปกติ"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "ตัวหนา"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "ค่าเริ่มต้น"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "ตัวพิมพ์ใหญ่"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "ตัวพิมพ์เล็ก"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4287,14 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks เป็นชุด <strong>บล็อคเนื้อหาสำหรับสร้างเพจ</strong> ระดับมืออาชีพสำหรับโปรแกรมแก้ไขบล็อค WordPress Gutenberg บล็อคของเราเน้นให้ผู้สร้างมีความสามารถที่จะสร้างเพจที่สวยงามสมบูรณ์ได้ใน WordPress"
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks เป็นชุด <strong>บล็อคเนื้อหาสำหรับสร้างเพจ</strong> "
+"ระดับมืออาชีพสำหรับโปรแกรมแก้ไขบล็อค WordPress Gutenberg "
+"บล็อคของเราเน้นให้ผู้สร้างมีความสามารถที่จะสร้างเพจที่สวยงามสมบูรณ์ได้ใน WordPress"
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4304,167 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "โกงหรือ"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "แสดงความคิดเห็น"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s ปี"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "หนึ่งปี"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s สัปดาห์"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "หนึ่งสัปดาห์"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s วัน"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "หนึ่งวัน"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s ชั่วโมง"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "หนึ่งชั่วโมง"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s นาที"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "หนึ่งนาที"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s วินาที"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "หนึ่งวินาที"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "ปลั๊กอิน %s ของ WordPress"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "คุณพอใจกับ %s หรือไม่"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "คุณใช้งาน %1$s เป็นเวลา %2$s แล้ว ขัดข้องไหมที่จะแสดงความคิดเห็นให้เราทราบว่าคุณคิดอย่างไร เราจะขอบคุณเป็นอย่างยิ่ง!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "แสดงความคิดเห็น"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"คุณใช้งาน %1$s เป็นเวลา %2$s แล้ว ขัดข้องไหมที่จะแสดงความคิดเห็นให้เราทราบว่าคุณคิดอย่างไร "
+"เราจะขอบคุณเป็นอย่างยิ่ง!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "ไม่ ขอบคุณ / ฉันแสดงความคิดเห็นไปแล้ว"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "ขอขอบคุณที่เลือก CoBlocks โปรแกรมสร้างเพจที่ดีที่สุดสำหรับตัวแก้ไขบล็อคใหม่ของ WordPress"
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"ขอขอบคุณที่เลือก CoBlocks โปรแกรมสร้างเพจที่ดีที่สุดสำหรับตัวแก้ไขบล็อคใหม่ของ WordPress"
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "คุณได้เพิ่มบล็อคที่เป็นประโยชน์มากมายและชุดอุปกรณ์สร้างเพจใหม่ในตัวแก้ไข WordPress CoBlocks มอบคุณลักษณะที่จะเปลี่ยนเกมให้คุณ: %1$s บล็อคหลายสิบบล็อค %2$s %1$s ประสบการณ์ในการสร้างเพจ %2$s และ %1$s ระบบควบคุมการออกแบบตัวอักษรที่กำหนดเอง%2$s"
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"คุณได้เพิ่มบล็อคที่เป็นประโยชน์มากมายและชุดอุปกรณ์สร้างเพจใหม่ในตัวแก้ไข WordPress CoBlocks "
+"มอบคุณลักษณะที่จะเปลี่ยนเกมให้คุณ: %1$s บล็อคหลายสิบบล็อค %2$s %1$s "
+"ประสบการณ์ในการสร้างเพจ %2$s และ %1$s ระบบควบคุมการออกแบบตัวอักษรที่กำหนดเอง%2$s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "ต่อไปนี้เป็นวิดีโอที่จะช่วยคุณในการเริ่มใช้งาน:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "ลองชมดูว่าจะสร้างหน้าแรกของคุณด้วย %s ได้อย่างไร"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "ลองชมดูว่าจะสร้างหน้าแรกของคุณได้อย่างไร"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "ลองชมดูว่าจะใช้บล็อคแถวและบล็อคตัวแบ่งหน้าจอแบบรูปร่างอย่างไร"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "ดูวิธีใช้บล็อคแบบการ์ดสื่อ"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "ชอบสิ่งที่คุณเห็นไหม %1$sสมัครสมาชิกช่อง YouTube ของเรา%2$s แล้วเราจะแจ้งให้คุณทราบเมื่อออกวิดีโอสาธิตใหม่"
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"ชอบสิ่งที่คุณเห็นไหม %1$sสมัครสมาชิกช่อง YouTube ของเรา%2$s "
+"แล้วเราจะแจ้งให้คุณทราบเมื่อออกวิดีโอสาธิตใหม่"
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "หากคุณมีข้อสงสัยหรือข้อเสนอแนะใดๆ บอกให้เรารู้ได้ที่ %1$sTwitter%4$s หรือ %2$sกลุ่ม Facebook%4$s ของเรา นอกจากนี้ %3$sสมัครรับจดหมายข่าวของเรา%4$s หากคุณไม่ต้องการพลาดข่าวสารว่ามีอะไรใหม่ที่กำลังจะเกิดขึ้นที่ CoBlocks"
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"หากคุณมีข้อสงสัยหรือข้อเสนอแนะใดๆ บอกให้เรารู้ได้ที่ %1$sTwitter%4$s หรือ %2$sกลุ่ม Facebook"
+"%4$s ของเรา นอกจากนี้ %3$sสมัครรับจดหมายข่าวของเรา%4$s "
+"หากคุณไม่ต้องการพลาดข่าวสารว่ามีอะไรใหม่ที่กำลังจะเกิดขึ้นที่ CoBlocks"
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "ใช้งานได้เต็มที่เลย!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "เริ่มต้นใช้งาน CoBlocks ที่นี่:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4478,27 @@ msgstr "คีย์เว็บไซต์ Google reCaptcha เพื่อป
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "คีย์ลับ Google reCaptcha เพื่อป้องกันการสแปมแบบฟอร์ม"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "ชื่อ"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "แรก"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "สุดท้าย"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "ข้อความ"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "ส่ง"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "ส่งข้อความของคุณแล้ว:"
 
@@ -3490,3 +4513,85 @@ msgstr "แชร์ทาง LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "ประเภทการแจ้งเตือน"
+
+#~ msgid "Edit image"
+#~ msgstr "แก้ไขรูปภาพ"
+
+#~ msgid "Remove image"
+#~ msgstr "ลบรูปภาพ"
+
+#~ msgid "Heading..."
+#~ msgstr "หัวเรื่อง..."
+
+#~ msgid "Author Name"
+#~ msgstr "ชื่อผู้เขียน"
+
+#~ msgid "Write biography..."
+#~ msgstr "เขียนชีวประวัติ..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "เพิ่มชีวประวัติผู้เขียน"
+
+#~ msgid "%s Settings"
+#~ msgstr "การตั้งค่ า%s"
+
+#~ msgid "Caption Color"
+#~ msgstr "สีคำบรรยาย"
+
+#~ msgid "Highlight text."
+#~ msgstr "ข้อความที่เน้น"
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "ตาราง %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "กาตตั้งค่าตารางราคา"
+
+#~ msgid "Tables"
+#~ msgstr "ตาราง"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "คอลัมน์ที่วางในบล็อคตารางราคา"
+
+#~ msgid "Sepia"
+#~ msgstr "ซีเปีย"
+
+#~ msgid "Dim"
+#~ msgstr "หม่น"
+
+#~ msgid "Vintage"
+#~ msgstr "วินเทจ"
+
+#~ msgid "Select Orientation"
+#~ msgstr "เลือกแนว"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "เอาขอบด้านบนของบล็อคนี้ออกแล้ว"
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "เปลี่ยนให้เอาขอบใดๆ ที่ใช้กับด้านบนของบล็อคนี้ออก"
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "เอาขอบด้านล่างของบล็อคนี้ออกแล้ว"
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "เปลี่ยนให้เอาขอบใดๆ ที่ใช้กับด้านล่างของบล็อคนี้ออก"
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "เพิ่มการดำเนินการหลัก..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "เพิ่มการดำเนินการรอง..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "ปกติ"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "เริ่มต้นใช้งาน CoBlocks ที่นี่:"

--- a/languages/coblocks-tr_TR.po
+++ b/languages/coblocks-tr_TR.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Görüntüleme açık"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Akordeon başlık ekleyin..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Akordeon Öğe"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Akordeonlara daraltılabilir akordeon öğeler ekleyin."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "sekmeler"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "sss"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,39 @@ msgstr "Akordeon öğe varsayılan olarak açıktır."
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Bu akordeon öğeyi varsayılan olarak açık ayarlamak için düğmeyi tıklayın."
+msgstr ""
+"Bu akordeon öğeyi varsayılan olarak açık ayarlamak için düğmeyi tıklayın."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Akordeon Öğe Ayarları"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Görüntüleme Açık"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Renk Ayarları"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Arkaplan Rengi"
@@ -103,14 +64,6 @@ msgstr "Arkaplan Rengi"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Başlık Metin Rengi"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Akordeon Öğe Ekleyin"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Akordeon"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +79,84 @@ msgstr "Internet Explorer Desteği"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Bir JavaScript polyfill’i yükleyerek Internet Explorer desteği ekleyin."
+msgstr ""
+"Bir JavaScript polyfill’i yükleyerek Internet Explorer desteği ekleyin."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Bu sayfaya bir JavaScript polyfill’i yükleyerek Internet Explorer’ı desteklemek."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Bu sayfaya bir JavaScript polyfill’i yükleyerek Internet Explorer’ı "
+"desteklemek."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Uyarı"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Hata"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Uyarı Türü"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Varsayılan"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Bilgi"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Başarılı"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Başlık yazın..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Metin yazın..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Bildirim"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "İçeriksel geri bildirim mesajları sağlayın."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "uyarı"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "mesaj"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Metin Rengi"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Görseli düzenle"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Galeriyi düzenleyin"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Görseli kaldır"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Resim yazısı yazın..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Avatar olarak eklemek için bırakın"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Başlık..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Yazar Adı"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Biyografi yazın..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Form Ayarları"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Yazar"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Yan yana yerleştireceğiniz düğmeler aracılığıyla ziyaretçilerinizi işlem "
+"yapmaya yönlendirin."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Yazar biyografisi ekleyin."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "biyografi"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "profil"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Düğmeler"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Yan yana yerleştireceğiniz düğmeler aracılığıyla ziyaretçilerinizi işlem yapmaya yönlendirin."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "bağlantı"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Düğme Ayarları"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Mobilde gruplandırma"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +174,25 @@ msgstr "Twitter Kullanıcı Adı"
 msgid "Username"
 msgstr "Kullanıcı adı"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Düğme ekleyin..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Tweet’lenecek bir alıntı ekleyin..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Tweet Göndermek için Tıklayın"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Kullanıcılarınızın Twitter’da paylaşabileceği bir alıntı ekleyin."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "paylaş"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +200,18 @@ msgid "Text Settings"
 msgstr "Metin Ayarları"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Düğme Rengi"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Dynamic HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Diğer bloklar arasına yeniden boyutlandırılabilir bir ayırıcı ekleyin."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "ayırıcı"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Dynamic HR Ayarları"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Piksel cinsinden yükseklik"
 
@@ -347,17 +223,12 @@ msgstr "Dinamik ayıraç öğesi için piksel cinsinden yükseklik."
 msgid "Color"
 msgstr "Renk"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Arkaplan olarak ekleyin"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Özellik"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "Üst özellik blokunun içinde yer alan tekil alt sütun."
 
@@ -366,73 +237,54 @@ msgid "Feature Settings"
 msgstr "Özellik Ayarları"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Doldurma"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Özellikler"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "Ürün veya hizmetinize üç sütuna kadar küçük notlar ekleyebilirsiniz."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "hizmetler"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Kenar boşluğu"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Cilt payı"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Her sütunun arasındaki boşluk."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Küçük"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Orta"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +294,8 @@ msgstr "Büyük"
 msgid "Features Settings"
 msgstr "Özellik Ayarları"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Sütunlar"
 
@@ -455,76 +307,72 @@ msgstr "Menü Bölümü Ekleyin"
 msgid "Menu title..."
 msgstr "Menü başlığı..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Dağıtımlı"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Liste"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Yenilemek için görseli bırakın"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Görseli kaldır"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Başlık ekleyin..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Baharatlı"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Öne Çıkanlar"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Vejetaryen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Glutensiz"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Pesketaryen"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Vegan"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Açıklama ekleyin..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0,00 USD"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Yemek Ürünü"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Yiyecek ve İçecek blokunda yer alan bir yiyecek veya içecek ürünü."
 
@@ -560,62 +408,46 @@ msgstr "Bu ürünün fiyatını göstermek için düğmeyi tıklayın."
 msgid "Item Attributes"
 msgstr "Ürün Nitelikleri"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Daha Baharatlı"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Görüntü Ayarları"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Alt. Metin (Alternatif Metin)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Görselin amacını açıklayın"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Görseli sadece dekoratif amaçlı kullanıyorsanız bu kısmı boş bırakın."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Odak Noktası"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Yiyecek ve İçecekler"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Menü veya fiyat listesi sergileyin."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "restoran"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menü"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Stiller"
@@ -648,134 +480,86 @@ msgstr "Her ürünün fiyatını gösterme"
 msgid "Toggle to show the price of each item."
 msgstr "Her ürünün fiyatını göstermek için düğmeyi tıklayın."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "E-posta"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "e-posta"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "posta"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Bir e-posta adresi alanı."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Mesaj"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Metinalanı"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Çok satırlı metin"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Daha uzun yanıtlar için metin kutusu."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s geçersiz bir e-posta adresidir."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s ve %s geçersiz e-posta adresleridir."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s geçersiz e-posta adresleridir."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "E-posta adresi"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "ad@ornek.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Konu"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Form Ayarları"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Formunuzu istenmeyen e-postalara karşı korumak için reCAPTCHA site ve gizli anahtarlarını ekleyin."
+msgstr ""
+"Formunuzu istenmeyen e-postalara karşı korumak için reCAPTCHA site ve gizli "
+"anahtarlarını ekleyin."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Anahtarlar oluşturun"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Anahtarlarım"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Yardım alın"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Site Anahtarı"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Gizli Anahtar"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Kaydediliyor"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Kaydet"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Kaldır"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "İlk"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Son"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Ad"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Adlar için bir metin alanı."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Bir e-posta adresi alanı."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Etiket ekleyin..."
 
@@ -783,41 +567,38 @@ msgstr "Etiket ekleyin..."
 msgid "Required"
 msgstr "Zorunlu"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Ad Alanı Ayarları"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Soyadı"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Hem ad hem de soyadı alanlarını göstermek."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Soyadı alanı eklemek düğmeyi tıklayın."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Form"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Adlar için bir metin alanı."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Daha uzun yanıtlar için metin kutusu."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Sayfanıza basit bir form ekleyin."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "e-posta"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "hakkında"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "irtibat kişisi"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Konu"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +608,219 @@ msgstr "Metin ekleyin..."
 msgid "Button Text Color"
 msgstr "Düğme Metin Rengi"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Galeriyi düzenleyin"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Döngü Görünümü"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "Galerideki %1$d %2$d sıralı görsel"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Resim yazısı yazın..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Döngü Görünümü"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Döngü görünümlü galeride birden fazla görseli sergileyin."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "galeri"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "fotoğraflar"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s Ayarları"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Satır Yüksekliği"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Nokta gezinti oklarını gösterme."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Resim yazılarını göstermek için düğmeyi tıklayın."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Renk Ayarları"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Boyut"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Yuvarlatılmış Köşeler"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Resim Yazısı Rengi"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Uygula"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Duvar Yapımı"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Açıklama yazın..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Düzenli bir duvar yapımı galerisinde birden fazla görseli sergileyin."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Döngü görünümlü galeride birden fazla görseli sergileyin."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Sütun Boyutu"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Görüntü Ayarları"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Galeri öğelerine yuvarlatılmış köşeler ekleyin."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Gölge"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Resim Yazıları"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Resim Yazısı Stili"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Her medya öğesi için resim yazısı göstermek."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Resim yazılarını göstermek için düğmeyi tıklayın."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Duvar Yapımı"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Düzenli bir duvar yapımı galerisinde birden fazla görseli sergileyin."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Harita kontrol seçeneklerini etkinleştirmek için düğmeyi tıklayın."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Harita Ayarları"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Sütun Boyutu"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Galeri öğelerine yuvarlatılmış köşeler ekleyin."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Açık"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Yığın"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Tek sütunluk yığın galerisinde birden fazla görseli sergileyin."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Tam Genişlikli Görseller"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Tam Genişlikli Görsel"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Kutu Gölgesi"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Tam genişlikli görseller etkinleştirildi."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Uygun galeri alanını bütünüyle tam genişlikli görsellerle doldurmak için düğmeyi tıklayın."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Uygun galeri alanını bütünüyle tam genişlikli görsellerle doldurmak için "
+"düğmeyi tıklayın."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Ürün Ayarları"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Tam Genişlikli Görseller"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Tam Genişlikli Görsel"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "GIF dosyasını kaldır"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Bu GIF dosyasının ALT özniteliği boş"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Aklınızdaki o mükemmel GIF dosyasını bulmak için Giphy’de arama yapın"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "GIF dosyası arayın"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Dilediğiniz GIF dosyasını seçin, herhangi biri olur."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "animasyonlu"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +846,11 @@ msgstr "GitHub Dosyası"
 msgid "File"
 msgstr "Dosya"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Bu özeti GitHub’da görüntüleyin"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Özet URL’si"
 
@@ -1024,12 +863,9 @@ msgid "Loading Gist"
 msgstr "Özet Yükleme"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Özet bağlantısını ekleyerek GitHub özetlerini gömülü olarak ekleyin."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "kod"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +888,158 @@ msgid "Gist Meta"
 msgstr "Özet Meta Verisi"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Sayfa düzenini değiştir"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "%s sayfasına arkaplan ekle"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Ana Site"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Sayfanın küçük bir metin ve eylem çağrısıyla ile beraber tanıtıcı bölümü."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Sayfanın küçük bir metin ve eylem çağrısıyla ile beraber tanıtıcı bölümü."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "düğme"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "eylem çağrısı"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Piksel cinsinden içerik genişliği"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "‌‌Ana Site Ayarları"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Kapsayıcı içindeki alan."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Sol Üst"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Orta Üst"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Sağ Üst"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Orta Sol"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Orta Orta"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Orta Sağ"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Sol Alt"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Orta Alt"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Sağ Alt"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Vurgulanan metni ekleyin..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Vurgula"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Metni vurgulayın."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "metin"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "paragraf"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Simge"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Daha fazla şey anlatmak için biçimlendirilmiş grafik sembol ekleyin."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "simgeler"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Çok Büyük"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Daha fazla şey anlatmak için biçimlendirilmiş grafik sembol ekleyin."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Simge Ayarları"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Gelişmiş %s ayarlarını kapatın"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Kişiselleştirilmiş %s boyutu"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Gelişmiş %s ayarları"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Özel"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Gelişmiş"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Yarıçap"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Simge Araması"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Bir sonuç bulunamadı."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Bağlantı Ayarları"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "Bağlantı URL'si"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "Göreli Oran"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Yeni Sekmede Açmak"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Yeni Sekmede Aç"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Simge Rengi"
 
@@ -1261,30 +1048,18 @@ msgid "Edit logos"
 msgstr "Logoları düzenle"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logolar ve Rozetler"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Görselleri sürükleyin, yenilerini yükleyin veya kütüphanenizden dosya seçin."
+msgstr ""
+"Görselleri sürükleyin, yenilerini yükleyin veya kütüphanenizden dosya seçin."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "Güven kazanmak için logo, rozet veya sertifika ekleyin."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "istemciler"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "kanıt"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "referanslar"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1081,146 @@ msgstr "Konumu Düzenle"
 msgid "Map style"
 msgstr "Harita stili"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "API anahtarı geçersiz veya çok sayıda istek var"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Haritalar"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "Google haritası üzerinde raptiye bırakmak için konum veya adres girin."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Yer veya adres arayın..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Uygula"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Harita"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Bir adres ekleyin ve Google haritası üzerinde raptiye bırakın."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "adres"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "haritalar"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Harita Stilini Seçin"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Harita Ayarları"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Yakınlaştırma Düzeyi"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Piksel cinsinden harita için yükseklik"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Yakınlaştırma Düzeyi"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "İşaretçi Boyutu"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "İnce kontrol seçenekleri etkinleştirildi."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Harita kontrol seçeneklerini etkinleştirmek için düğmeyi tıklayın."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Harita Kontrolleri"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Harita Türü"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
-msgstr "Standart ve uydu harita görüntüleri arasında geçiş yapma özelliği etkinleştirildi."
+msgstr ""
+"Standart ve uydu harita görüntüleri arasında geçiş yapma özelliği "
+"etkinleştirildi."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Standart ve uydu harita görüntüleri arasında geçiş yapma özelliğini etkinleştirmek için düğmeyi tıklayın."
+msgstr ""
+"Standart ve uydu harita görüntüleri arasında geçiş yapma özelliğini "
+"etkinleştirmek için düğmeyi tıklayın."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Yakınlaştırma Kontrolleri"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Harita yakınlaştırma kontrollerini gösterme."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Harita üzerinde yakınlaştırma kontrollerini kullanarak yakınlaştırma ve uzaklaştırmayı etkinleştirmek için düğmeyi tıklayın."
+msgstr ""
+"Harita üzerinde yakınlaştırma kontrollerini kullanarak yakınlaştırma ve "
+"uzaklaştırmayı etkinleştirmek için düğmeyi tıklayın."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Sokak Görünümü"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Sokak görünümü için harita kontrolünü göstermek."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Sağ alt kısımda sokak görünümü harita kontrolünü göstermek için düğmeyi tıklayın."
+msgstr ""
+"Sağ alt kısımda sokak görünümü harita kontrolünü göstermek için düğmeyi "
+"tıklayın."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Tam Ekran Açma/Kapama"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Tam ekran harita kontrolünü gösterme."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Tam ekran harita kontrolünü göstermek için düğmeyi tıklayın."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google Haritalar API Anahtarı"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Google Haritalar API anahtarınızı ekleyin. Bu API anahtarını güncellediğinizde tüm haritalarınız yeni anahtarı kullanır."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Google Haritalar API anahtarınızı ekleyin. Bu API anahtarını "
+"güncellediğinizde tüm haritalarınız yeni anahtarı kullanır."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Anahtarınızı alın"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Yardıma mı ihtiyacınız var?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Google API anahtarını girin..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Kaydedildi"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Standart"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Gümüş"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Retro"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Koyu"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Gece"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Patlıcan Moru"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1230,9 @@ msgstr "Sağdaki medya"
 msgid "Media on left"
 msgstr "Soldaki medya"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Medya Kartı"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Ofset kart ile yan yana bir görsel veya video ekleyin"
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "görsel"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1246,18 @@ msgstr "Kart gölgesini gösterme."
 msgid "Toggle to add a card shadow."
 msgstr "Kart gölgesi eklemek için düğmeyi tıklayın."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s Gölgesi"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "%s gölgesini gösterme."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "%s gölgesi eklemek için düğmeyi tıklayın."
 
@@ -1545,40 +1281,171 @@ msgstr "Yenilemek için medyayı bırakın"
 msgid "Edit media"
 msgstr "Medyayı düzenleyin"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s Tabloları"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Özet URL’si"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Plan %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Döngü Görünümü"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Özet URL’si"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Renk Ayarları"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Bu ürünün fiyatını göstermek."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Özet meta verisini göstermek için düğmeyi tıklayın."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Eylem çağrısı düğmesini gösterme."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Özet meta verisini göstermek için düğmeyi tıklayın."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Özellik Ayarları"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Soldaki medya"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Sağdaki medya"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Sütun Boyutu"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Özet Ayarları"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Fiyatlandırma Tablosu"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Fiyatlandırma Tablosu"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Fiyatlandırma Tablosu"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Fiyatlandırma Tablosu"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Fiyatlandırma tabloları ekleyin."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "giriş sayfası"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Plan %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "karşılaştırma"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Fiyatlandırma Tablosu Ayarları"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Tablolar"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1463,171 @@ msgstr "A Planı"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Fiyatlandırma Tablosu Öğesi"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Fiyatlandırma tablosu blokuna yerleştirilmiş bir sütun."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "%s sayfasına arkaplan ekle"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Sütun"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Satırın bir alt satırı."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Genişlik"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Sütun Ayarları"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Kapsayıcının etrafındaki alan."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Genişlik"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Sayfa düzenini değiştir"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "bir"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "iki"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "üç"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "dört"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "%s sayfasına arkaplan ekle"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Bir Sütun"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "İki Sütun"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Üç Sütun"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Dört Sütun"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Satır Düzeni"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Satır"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Şimdi bu %s sütun satırı için bir düzen seçin."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Bu satır için sütun sayısını belirleyin."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Satır Sütunlarını Seçin"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Satır Düzenini Seçin"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Sütunlara Geri Dönün"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Sütun bloklarına yapılandırılmış bir sarmalayıcı ekledikten sonra sütunlara istediğiniz içerik bloklarını ekleyin."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Sütun bloklarına yapılandırılmış bir sarmalayıcı ekledikten sonra sütunlara "
+"istediğiniz içerik bloklarını ekleyin."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "satırlar"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "sütunlar"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "sayfa düzenleri"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Sayfa Düzeni"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Satır Ayarları"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Yok"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1637,9 @@ msgstr "Kare"
 msgid "Circle"
 msgstr "Daire"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Hizmetler"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Görüntülemek için en fazla dört sütun ekleyin."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "özellikler"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1661,7 @@ msgstr "Eylem çağrısı düğmelerini gösterme."
 msgid "Toggle to show call to action buttons."
 msgstr "Eylem çağrısı düğmelerini göstermek için düğmeyi tıklayın."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Hizmet"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Hizmetler blokundaki tek bir hizmet öğesi."
 
@@ -1785,264 +1682,233 @@ msgid "Toggle to show a call to action button."
 msgstr "Eylem çağrısı düğmesini göstermek için düğmeyi tıklayın."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Yatay çevir"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Dikey çevir"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Şekil Bölücü"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Sayfanın bölümlerini gözle görülür bir şekilde birbirinden ayırmak için bir şekil bölücü ekleyin."
+msgstr ""
+"Sayfanın bölümlerini gözle görülür bir şekilde birbirinden ayırmak için bir "
+"şekil bölücü ekleyin."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "ayırıcı"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Şekil Rengi"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Bölücü Ayarları"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Piksel cinsinden Şekil Yüksekliği"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Piksel Cinsinden Arkaplan Yüksekliği"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Yönlendirme"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Şekil Rengi"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Twitter'da Paylaş"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Facebook’ta Paylaş"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Twitter'da Paylaş"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Pinterest'te Paylaş"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "LinkedIn’de Paylaş"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "E-posta ile paylaş"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Tumblr’da Paylaş"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Google’da Paylaş"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Reddit’te Paylaş"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Paylaş"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "sosyal"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Gönderilerinizin beğenilmesine ve paylaşılmasına yardımcı olacak sosyal paylaşım bağlantıları ekleyin."
+msgstr ""
+"Gönderilerinizin beğenilmesine ve paylaşılmasına yardımcı olacak sosyal "
+"paylaşım bağlantıları ekleyin."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Sosyal Medya Renkleri"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Simge Boyutu"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Daire Boyutu"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Düğme Boyutu"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Simgeler"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "E-posta"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Paylaş düğmesi renkleri etkinleştirildi."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Her sosyal medya platformunun kendisine ait resmi renklerini kullanmak için düğmeyi tıklayın."
+msgstr ""
+"Her sosyal medya platformunun kendisine ait resmi renklerini kullanmak için "
+"düğmeyi tıklayın."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Sosyal Medya Renkleri"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Facebook Profili Ekleyin"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Twitter Profili Ekleyin"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Instagram Profili Ekleyin"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Pinterest Profili Ekleyin"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "LinkedIn Profili Ekleyin"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "YouTube Profili Ekleyin"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Yelp Profili Ekleyin"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Houzz Profili Ekleyin"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Sosyal Profiller"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "bağlantılar"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Sosyal medya profillerinin bağlantılarını görüntüleyin."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Profil Bağlantıları"
 
@@ -2057,18 +1923,6 @@ msgstr "Arkaplanı Kaldırın"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Arkaplan"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Otomotiv"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Kapak Resmi"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Şunu İçeren:"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1980,6 @@ msgstr "Arkaplanı kaldırın"
 msgid "Remove "
 msgstr "Kaldır "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Tekrarlama Yok"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Yatay Olarak Tekrarla"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Dikey Olarak Tekrarla"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Görseli Geri Taşı"
@@ -2150,17 +1992,14 @@ msgstr "Görseli İleri Taşı"
 msgid "Link To"
 msgstr "Şuraya Bağlantı:"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s Galerisi"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Bir görsel yükle"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Açık"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2013,110 @@ msgstr "Ek Sayfası"
 msgid "Custom URL"
 msgstr "Özelleştirilmiş URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Piksel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Yönlendirme"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Yüzde"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Sıfırla"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Birim Seçin"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s Birim"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Gelişmiş %s ayarlarını kapatın"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s Üst"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s Sağ"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s Aşağı"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s Sol"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Eşitlemeyi Kaldır"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Senkronize Et"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Birimleri Eşitle"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Yukarı"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Sağ"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Aşağı"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Sol"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Gelişmiş %s ayarları"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Gelişmiş"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Varsayılan"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Sayfa Düzeni"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2135,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Tam ekran modunu etkinleştirmek için düğmeyi tıklayın."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Başlık %d"
@@ -2263,43 +2144,16 @@ msgstr "Başlık %d"
 msgid "Custom color picker"
 msgstr "Kişiselleştirilmiş renk seçici"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Orijinal"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Gri ton"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Sepya"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Doygunluk"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Solma"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Klasik"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Filtreyi uygula"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Yönlendirme Seçin"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Yükseklik"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Mobil %s"
@@ -2333,7 +2187,8 @@ msgid "Five Seconds"
 msgstr "Beş Saniye"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Altı Saniye"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2207,22 @@ msgstr "Dokuz Saniye"
 msgid "Ten Seconds"
 msgstr "On Saniye"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Oklu Gezinti"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Noktalı Gezinti"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "saniye"
@@ -2361,22 +2232,30 @@ msgid "second"
 msgstr "saniye"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "%1$d %2$s sonrasında ilerleme."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Otomatik olarak sonraki slayda geçer."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
-msgstr "Masaüstü ve mobil cihazlarda sürükleme ve hızlı kaydırma özellikleri etkinleştirildi."
+#, fuzzy
+msgid "Dragging and flicking enabled."
+msgstr ""
+"Masaüstü ve mobil cihazlarda sürükleme ve hızlı kaydırma özellikleri "
+"etkinleştirildi."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Sürükleme fonksiyonunu masaüstü ve mobil cihazlarda etkinleştirmek için düğmeyi tıklayın."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Sürükleme fonksiyonunu masaüstü ve mobil cihazlarda etkinleştirmek için "
+"düğmeyi tıklayın."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2266,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Slayt gezinti oklarını göstermek için düğmeyi tıklayın."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Nokta gezinti oklarını gösterme."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Nokta ile gezintiyi göstermek için düğmeyi tıklayın."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Kapsayıcı içindeki alan."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Videonun sesini kapatmak için düğmeyi tıklayın."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Videoyu döngüye sokmak için düğmeyi tıklayın."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Kaydırıcı Ayarları"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Otomatik Oynatma"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Geçiş Hızı"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Sürüklenebilir"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Oklu Gezinti"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Noktalı Gezinti"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Büyük Harf Yap"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Normal"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2353,6 @@ msgstr "Alt Boşluk Yok"
 msgid "Change typography"
 msgstr "Tipografiyi değiştir"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Kalın"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Büyük Harf"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Küçük Harf"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Mobilde Gruplandırma"
@@ -2481,31 +2363,37 @@ msgstr "Duyarlılık etkinleştirildi."
 
 #: src/extensions/advanced-controls/index.js:117
 msgid "Toggle to stack elements on top of each other on smaller viewports."
-msgstr "Öğeleri daha küçük görünüm pencerelerinde üst üste yığmak için düğmeyi tıklayın."
+msgstr ""
+"Öğeleri daha küçük görünüm pencerelerinde üst üste yığmak için düğmeyi "
+"tıklayın."
 
 #: src/extensions/advanced-controls/index.js:125
 msgid "Remove Top Spacing"
 msgstr "Üst Boşluğu Kaldır"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Bu bloktaki üst kenar boşluğu kaldırıldı."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Kart gölgesi eklemek için düğmeyi tıklayın."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Bu blokun üstüne uygulanan herhangi bir kenar boşluğunu kaldırmak için düğmeyi tıklayın."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Nokta ile gezintiyi göstermek için düğmeyi tıklayın."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Alt Boşluğu Kaldır"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Bu bloktaki alt kenar boşluğu kaldırıldı."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Kart gölgesi eklemek için düğmeyi tıklayın."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Bu blokun altına uygulanan herhangi bir kenar boşluğunu kaldırmak için düğmeyi tıklayın."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Nokta ile gezintiyi göstermek için düğmeyi tıklayın."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2407,14 @@ msgstr "Tam genişlikli olarak görüntüleniyor."
 msgid "Toggle to display button as full width."
 msgstr "Düğmeyi tam genişlikli olarak görüntülemek için düğmeyi tıklayın."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Dairesel"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "‌‌Ana Site Ayarları"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Gölge"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Onay kutusu"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Büyük Harf"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2440,793 @@ msgstr "Bu blok sayfaya eklenmiş olup şu anda devre dışı bırakılamaz"
 msgid "Disable all"
 msgstr "Tümünü devre dışı bırakın"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "\"%s\" bloku bulunamadı."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s Galerileri"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Görüntüleme açık"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Akordeon başlık ekleyin..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Akordeon Öğe"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "sekmeler"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "sss"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "uyarı"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "mesaj"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "biyografi"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "profil"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "bağlantı"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "paylaş"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "ayırıcı"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "hizmetler"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menü"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "restoran"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "e-posta"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "posta"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Soyadı"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Metinalanı"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Çok satırlı metin"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "e-posta"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "hakkında"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "irtibat kişisi"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "galeri"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "fotoğraflar"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Gece"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "animasyonlu"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "kod"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "düğme"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "eylem çağrısı"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "metin"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "paragraf"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "simgeler"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "istemciler"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "kanıt"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "referanslar"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "adres"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "haritalar"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "görsel"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "adres"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "giriş sayfası"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "karşılaştırma"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "satırlar"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "sütunlar"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "sayfa düzenleri"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "özellikler"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "ayırıcı"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "sosyal"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "bağlantılar"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Görüntüleme Açık"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Akordeon Öğe Ekleyin"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Akordeon"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Metin yazın..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Başlık yazın..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Bildirim"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Yazar"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Düğmeler"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Tweet Göndermek için Tıklayın"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Dynamic HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Özellik"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Özellikler"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Yemek Ürünü"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Yiyecek ve İçecekler"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "E-posta"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Ad"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Mesaj"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Form"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Döngü Görünümü"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Duvar Yapımı"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Yığın"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Özet URL’si"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Ana Site"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Vurgula"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Simge"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logolar ve Rozetler"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Harita"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Medya Kartı"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Döngü Görünümü"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Fiyatlandırma Tablosu"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Fiyatlandırma Tablosu Öğesi"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Sütun"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Satır"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Hizmetler"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Hizmet"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Şekil Bölücü"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Paylaş"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Sosyal Profiller"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Bilgi"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Başarılı"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Uyarı"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Hata"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Nokta"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Satır"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Tam Genişlikli"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Dağıtımlı"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Liste"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Varsayılan"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Katmanlar"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Ana Hatlı"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Dolgulu"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Yığın"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Yatay Olarak Tekrarla"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Dalgalı"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Tepeler"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Dalgalar"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Açılı"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Eğimli"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Yuvarlatılmış"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Üçgen"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Köşeli"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Maske"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Simge"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Metin"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Simge ve Metin"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Dairesel"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Sol Alt"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Sol Üst"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Avatar olarak eklemek için bırakın"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Yazar"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3246,33 @@ msgstr "Özellik içeriği ekleyin..."
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Bu blok, özellikleri vurgulamak için kullanabileceğiniz bir özellik blokudur."
+msgstr ""
+"Bu blok, özellikleri vurgulamak için kullanabileceğiniz bir özellik blokudur."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Ana site başlığı ekleyin..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Ana site başlığı ekleyin..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Genellikle bir veya iki eylem çağrısıyla birlikte sayfanın giriş kısmını "
+"oluşturan ana site içeriğini ekleyin."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Genellikle bir veya iki eylem çağrısıyla birlikte sayfanın giriş kısmını oluşturan ana site içeriğini ekleyin."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Birincil eylem ekleyin..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "İkincil eylem ekleyin..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3291,126 @@ msgstr "İçerik ekleyin..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Bu metnin yerine karttaki görselin yanında yer alacak açıklayıcı bir metin koyun. Ardından bu karta düğme, liste veya görsel gibi daha fazla blok ekleyin."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Bu metnin yerine karttaki görselin yanında yer alacak açıklayıcı bir metin "
+"koyun. Ardından bu karta düğme, liste veya görsel gibi daha fazla blok "
+"ekleyin."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Başlık yazın..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Açıklama yazın..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Normal"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Düğme Ayarları"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Özel"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Mobilde gruplandırma"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Dynamic HR Ayarları"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Yok"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Yok"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Küçük"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Orta"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Büyük"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Çok Büyük"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Yok"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Küçük"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Orta"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Büyük"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,8 +3929,12 @@ msgstr "müzik mikrofon şarkı sanatçı yaratıcı medya ses"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "mikrofon podcast bilgisayar cihaz müzik mikrofon şarkı sanatçı yaratıcı medya ses"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"mikrofon podcast bilgisayar cihaz müzik mikrofon şarkı sanatçı yaratıcı "
+"medya ses"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3270,7 +3944,9 @@ msgstr "fotoğraf fotoğrafçı kamera film yaratıcı medya"
 #: src/blocks/icon/svgs.js:55
 msgctxt "tags"
 msgid "photo photographer photography camera aperture film creative media"
-msgstr "fotoğraf fotoğrafçı fotoğrafçılık kamera diyafram açıklığı film yaratıcı medya"
+msgstr ""
+"fotoğraf fotoğrafçı fotoğrafçılık kamera diyafram açıklığı film yaratıcı "
+"medya"
 
 #: src/blocks/icon/svgs.js:61
 msgctxt "tags"
@@ -3284,8 +3960,12 @@ msgstr "film videografi yönetmen yapımcı medya yaratıcı"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "video videografi yönetmen yapımcı medya yaratıcı kamera fotoğrafçı fotoğrafçılık diyafram açıklığı"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"video videografi yönetmen yapımcı medya yaratıcı kamera fotoğrafçı "
+"fotoğrafçılık diyafram açıklığı"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3982,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "palet tasarım renkler sanatçı yaratıcı medya boya boya fırçası"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Standart"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Gümüş"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Retro"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Koyu"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Gece"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Patlıcan Moru"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Dairesel"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Gölge"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Varsayılan"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Yok"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Onay kutusu"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Menü başlığı..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Küçük"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Orta"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Büyük"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Çok Büyük"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Otomotiv"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Kapak Resmi"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Şunu İçeren:"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Sol Üst"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Orta Üst"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Sağ Üst"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Orta Sol"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Orta Orta"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Orta Sağ"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Sol Alt"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Orta Alt"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Sağ Alt"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Tekrarlama Yok"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Yinele"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Yatay Olarak Tekrarla"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Dikey Olarak Tekrarla"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "Göreli Oran"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Koyu"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Açık"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Yok"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Görüntü"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Piksel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Yüzde"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Orijinal"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Gri ton"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Medya Dosyası"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Doygunluk"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Klasik Filtre"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Klasik Filtre"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Büyük Harf Yap"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Kalın"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Varsayılan"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Büyük Harf"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Küçük Harf"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4330,15 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks, WordPress Gutenberg blok düzenleyici için profesyonel <strong>sayfa oluşturan içerik blokları</strong> paketidir. Bloklarımız, tamamen site yaratıcılarının WordPress’te güzel ve zengin içerikli sayfalar oluşturmasına yardımcı olmak üzere tasarlanmıştır."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks, WordPress Gutenberg blok düzenleyici için profesyonel "
+"<strong>sayfa oluşturan içerik blokları</strong> paketidir. Bloklarımız, "
+"tamamen site yaratıcılarının WordPress’te güzel ve zengin içerikli sayfalar "
+"oluşturmasına yardımcı olmak üzere tasarlanmıştır."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4348,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Hile mi yapıyorsunuz?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Yorum Paylaşın"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s yıl"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "bir yıl"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s hafta"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "bir hafta"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s gün"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "bir gün"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s saat"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "bir saat"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s dakika"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "bir dakika"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s saniye"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "bir saniye"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPress Eklentisi"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "%s kullanımından memnun musunuz?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "%2$s boyunca %1$s kullanıyorsunuz. Düşüncelerinizi bizimle paylaşmak için bir inceleme yazısı bırakmak ister misiniz? Çok memnun oluruz!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Yorum Paylaşın"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"%2$s boyunca %1$s kullanıyorsunuz. Düşüncelerinizi bizimle paylaşmak için "
+"bir inceleme yazısı bırakmak ister misiniz? Çok memnun oluruz!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Hayır teşekkürler / Zaten yaptım"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Yeni WordPress blok düzenleyicisinin kullandığı üst düzey sayfa oluşturucu CoBlocks’u tercih ettiğiniz için teşekkür ederiz."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Yeni WordPress blok düzenleyicisinin kullandığı üst düzey sayfa oluşturucu "
+"CoBlocks’u tercih ettiğiniz için teşekkür ederiz."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "WordPress düzenleyicisine bir sürü yararlı blok ve yeni bir sayfa oluşturucu eklediniz. CoBlocks size oyunun kurallarını değiştiren bir dizi özellik sunar: %1$s onlarca blok%2$s, bir %1$s sayfa oluşturucu deneyimi %2$s ve %1$s özelleştirilmiş tipografi kontrolleri%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"WordPress düzenleyicisine bir sürü yararlı blok ve yeni bir sayfa oluşturucu "
+"eklediniz. CoBlocks size oyunun kurallarını değiştiren bir dizi özellik "
+"sunar: %1$s onlarca blok%2$s, bir %1$s sayfa oluşturucu deneyimi %2$s ve "
+"%1$s özelleştirilmiş tipografi kontrolleri%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Başlarken size yardımcı olacak birkaç video:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "%s ile ilk sayfanızı nasıl oluşturacağınızı izleyin"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "İlk sayfanızı nasıl oluşturacağınızı izleyin"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Satır ve Şekil Ayırıcı blokları nasıl kullanacağınızı izleyin"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Medya Kartı blokunu nasıl kullanacağınızı izleyin"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Gördüklerinizi beğendiniz mi? %1$sYouTube kanalımıza abone olun%2$s ve yeni eğitici videolar çıktığında sizi bilgilendirelim."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Gördüklerinizi beğendiniz mi? %1$sYouTube kanalımıza abone olun%2$s ve yeni "
+"eğitici videolar çıktığında sizi bilgilendirelim."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Herhangi bir sorunuz veya bildirmek istediğiniz bir görüşünüz varsa, lütfen bunu %1$sTwitter’da%4$s veya %2$sFacebook grubumuzda%4$s bizimle paylaşın. Ayrıca, CoBlocks’taki yeniliklerden ve gelişmelerden haberdar olmak için %3$sbültenimize abone olabilirsiniz%4$s."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Herhangi bir sorunuz veya bildirmek istediğiniz bir görüşünüz varsa, lütfen "
+"bunu %1$sTwitter’da%4$s veya %2$sFacebook grubumuzda%4$s bizimle paylaşın. "
+"Ayrıca, CoBlocks’taki yeniliklerden ve gelişmelerden haberdar olmak için "
+"%3$sbültenimize abone olabilirsiniz%4$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Keyfini çıkarın!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "CoBlocks’u kullanmaya başlayın:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3465,17 +4519,35 @@ msgstr "Blokları etkinleştirin veya devre dışı bırakın"
 
 #: includes/class-coblocks-form.php:67
 msgid "Google reCaptcha site key for form spam protection"
-msgstr "Form kaynaklı istenmeyen posta koruması için Google reCaptcha site anahtarı"
+msgstr ""
+"Form kaynaklı istenmeyen posta koruması için Google reCaptcha site anahtarı"
 
 #: includes/class-coblocks-form.php:79
 msgid "Google reCaptcha secret key for form spam protection"
-msgstr "Form kaynaklı istenmeyen posta koruması için Google reCaptcha gizli anahtarı"
+msgstr ""
+"Form kaynaklı istenmeyen posta koruması için Google reCaptcha gizli anahtarı"
+
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Ad"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "İlk"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Son"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Mesaj"
 
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Gönder"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Mesajınız gönderildi:"
 
@@ -3490,3 +4562,89 @@ msgstr "Linkedin'de Paylaş"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "Uyarı Türü"
+
+#~ msgid "Edit image"
+#~ msgstr "Görseli düzenle"
+
+#~ msgid "Remove image"
+#~ msgstr "Görseli kaldır"
+
+#~ msgid "Heading..."
+#~ msgstr "Başlık..."
+
+#~ msgid "Author Name"
+#~ msgstr "Yazar Adı"
+
+#~ msgid "Write biography..."
+#~ msgstr "Biyografi yazın..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Yazar biyografisi ekleyin."
+
+#~ msgid "%s Settings"
+#~ msgstr "%s Ayarları"
+
+#~ msgid "Caption Color"
+#~ msgstr "Resim Yazısı Rengi"
+
+#~ msgid "Highlight text."
+#~ msgstr "Metni vurgulayın."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s Tabloları"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Fiyatlandırma Tablosu Ayarları"
+
+#~ msgid "Tables"
+#~ msgstr "Tablolar"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Fiyatlandırma tablosu blokuna yerleştirilmiş bir sütun."
+
+#~ msgid "Sepia"
+#~ msgstr "Sepya"
+
+#~ msgid "Dim"
+#~ msgstr "Solma"
+
+#~ msgid "Vintage"
+#~ msgstr "Klasik"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Yönlendirme Seçin"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Bu bloktaki üst kenar boşluğu kaldırıldı."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr ""
+#~ "Bu blokun üstüne uygulanan herhangi bir kenar boşluğunu kaldırmak için "
+#~ "düğmeyi tıklayın."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Bu bloktaki alt kenar boşluğu kaldırıldı."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr ""
+#~ "Bu blokun altına uygulanan herhangi bir kenar boşluğunu kaldırmak için "
+#~ "düğmeyi tıklayın."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Birincil eylem ekleyin..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "İkincil eylem ekleyin..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Normal"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "CoBlocks’u kullanmaya başlayın:"

--- a/languages/coblocks-uk.po
+++ b/languages/coblocks-uk.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Показувати у відкритому стані"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Додати заголовок гармошки..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Елемент гармошки"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Додавання до гармошок елементів, які можуть згортатися."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "вкладки"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "запитання й відповіді"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "Перемикання цього елемента гармошки у �
 msgid "Accordion Item Settings"
 msgstr "Настройки елемента гармошки"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Показувати у відкритому стані"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Настройки кольорів"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Колір тла"
@@ -104,17 +64,11 @@ msgstr "Колір тла"
 msgid "Title Text Color"
 msgstr "Колір тексту заголовка"
 
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Додати елемент гармошки"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Гармошка"
-
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
-msgstr "Систематизуйте вміст у вигляді елементів гармошки, які можуть згортатися й розгортатися."
+msgstr ""
+"Систематизуйте вміст у вигляді елементів гармошки, які можуть згортатися й "
+"розгортатися."
 
 #: src/blocks/accordion/inspector.js:27
 msgid "Accordion Settings"
@@ -126,143 +80,85 @@ msgstr "Підтримка Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Додайте підтримку для Internet Explorer, завантаживши полізаповнення JavaScript."
+msgstr ""
+"Додайте підтримку для Internet Explorer, завантаживши полізаповнення "
+"JavaScript."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Щоб забезпечити підтримку для Internet Explorer, завантажте полізаповнення JavaScript на цій сторінці."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Щоб забезпечити підтримку для Internet Explorer, завантажте полізаповнення "
+"JavaScript на цій сторінці."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Попередження"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Помилка"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Тип оповіщення"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "За промовчанням"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Інформація"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Успішно"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Напишіть заголовок..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Напишіть текст..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Сповіщення"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Надання повідомлень-відгуків з урахуванням контексту."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "нотатка"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "повідомлення"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Колір тексту"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Змінити зображення"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Редагувати галерею"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Видалити зображення"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Напишіть підпис..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Перетягніть зображення для аватару"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Заголовок..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Ім'я автора"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Напишіть біографію..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Настройки форми"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Автор"
+#: src/blocks/buttons/index.js:29
+msgid "Prompt visitors to take action with multiple buttons, side by side."
+msgstr ""
+"Запропонуйте відвідувачам можливі дії за допомогою кнопок, розташованих "
+"поруч."
 
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Додайте біографію автора."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "біографія"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "профіль"
-
-#: src/blocks/buttons/index.js:30
 #: src/blocks/buttons/inspector.js:30
 msgid "Buttons"
 msgstr "Кнопки"
-
-#: src/blocks/buttons/index.js:31
-msgid "Prompt visitors to take action with multiple buttons, side by side."
-msgstr "Запропонуйте відвідувачам можливі дії за допомогою кнопок, розташованих поруч."
-
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "посилання"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "заклик до дії"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Настройки кнопок"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Стос на мобільному"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +176,25 @@ msgstr "Ім’я користувача Twitter"
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Додати кнопку..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Додати коментар для твіту..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Клацніть, щоб зробити твіт"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Додайте коментар для читачів через Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "поширення"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +202,18 @@ msgid "Text Settings"
 msgstr "Настройки тексту"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Колір кнопки"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "Динамічний HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Додайте роздільник між іншими блоками з регульованим розміром."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "роздільник"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Настройки динамічного HR"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Висота в пікселах"
 
@@ -347,17 +225,12 @@ msgstr "Висота динамічного розділового елемен�
 msgid "Color"
 msgstr "Колір"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Додати як тло"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Функція"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "Одиничний дочірній стовпець у батьківському блоці особливостей"
 
@@ -366,73 +239,54 @@ msgid "Feature Settings"
 msgstr "Настройки особливості"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Заповнення"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Особливості"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "Додайте один-три стовпці стислих нотаток про ваш товар або послугу."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "послуги"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Поле"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Корінець"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Проміжок між стовпцями."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Малий"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Cередній"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +296,8 @@ msgstr "Великий"
 msgid "Features Settings"
 msgstr "Настройки особливостей"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Стовпці"
 
@@ -455,76 +309,72 @@ msgstr "Додати розділ меню"
 msgid "Menu title..."
 msgstr "Заголовок меню..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Таблиця"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Список"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Перетягніть зображення на заміну"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Вилучити зображення"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Додати заголовок..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Гостра"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Гаряча"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Вегетаріанська"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Без глютену"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Пескатаріанська"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Веганська"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Додати опис..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0,00 грн."
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Страва"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Страва або напій у блоці «Їжа та напої»"
 
@@ -560,62 +410,46 @@ msgstr "Перемкніть, щоб показувати ціну для цьо
 msgid "Item Attributes"
 msgstr "Атрибути елемента"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Гостріша"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Настройки зображення"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Текст заміщення (альтернативний текст"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Опишіть мету цього зображення"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Залиште поле пустим, якщо це лише прикраса."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Точка уваги"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Їжа та напої"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Відображення меню або прайсу."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "ресторан"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "меню"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Стилі"
@@ -648,134 +482,86 @@ msgstr "Показ ціни для кожного елемента"
 msgid "Toggle to show the price of each item."
 msgstr "Перемкніть, щоб показувати ціну для кожного елемента."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Електронна пошта"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "електронна пошта"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "пошта"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Поле адреси електронної пошти."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Повідомлення"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Текстова область"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Багаторядковий текст"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Блок тексту для довших відповідей."
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s не є правильною адресою електронної пошти."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s і %s не є правильними адресами електронної пошти."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s не є правильними адресами електронної пошти."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Адреса електронної пошти"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Тема"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Настройки форми"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Додайте ключ сайту та секретний ключ eCAPTCHA , щоб захистити вашу форму від спаму."
+msgstr ""
+"Додайте ключ сайту та секретний ключ eCAPTCHA , щоб захистити вашу форму від "
+"спаму."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Створити ключі"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Мої ключі"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Отримати довідку"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Ключ сайту"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Секретний ключ"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Збереження"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Зберегти"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Видалити"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Перша"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Остання"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Ім'я"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Текстове поле для імен."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Поле адреси електронної пошти."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Додати мітку..."
 
@@ -783,41 +569,38 @@ msgstr "Додати мітку..."
 msgid "Required"
 msgstr "Обов'язково"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Настройки поля імені"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Прізвище"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Показ полів для імені та для прізвища."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Перемкніть, щоб додати поле для прізвища."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Форма"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Текстове поле для імен."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Блок тексту для довших відповідей."
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Додайте на сторінку просту форму."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "ел. пошта"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "інформація"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "контакт"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Тема"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +610,223 @@ msgstr "Додати текст..."
 msgid "Button Text Color"
 msgstr "Колір тексту кнопки"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Редагувати галерею"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "Карусель"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "зображення %1$d з %2$d у галереї"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Напишіть підпис..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "Карусель"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
-msgstr "Показ кількох зображень у привабливій галереї, яка діє за принципом каруселі."
+msgstr ""
+"Показ кількох зображень у привабливій галереї, яка діє за принципом каруселі."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "галерея"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "фотографії"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Настройки %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Висота ліній"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Показ стрілок навігації крапками."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Перемкніть, щоб показувати підписи до мультимедіа."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Настройки кольорів"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Розмір"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Заокруглені кути"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Колір підпису"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Застосувати"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Кам'яна кладка"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Напишіть опис..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Показ кількох зображень у впорядкованій галереї, яка має вигляд кам’яної кладки."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr ""
+"Показ кількох зображень у привабливій галереї, яка діє за принципом каруселі."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Розмір стовпця"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Настройки зображення"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Заокруглення кутів елементів галереї."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Тінь"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Підписи"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Стиль підпису"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Показ підписів для кожного мультимедійного елемента."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Перемкніть, щоб показувати підписи до мультимедіа."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Кам'яна кладка"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr ""
+"Показ кількох зображень у впорядкованій галереї, яка має вигляд кам’яної "
+"кладки."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Перемкніть, щоб увімкнути параметри керування мапою."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "‌‌Настройки мапи"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Розмір стовпця"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Заокруглення кутів елементів галереї."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Світлий"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Один на одному"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Показ кількох зображень в одностовпцевій галереї."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Повноширинні зображення"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Повноширинне зображення"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Тінь поля"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Дозволено показ повноширинних зображень."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
-msgstr "Перемкніть, щоб заповнити доступну площину галереї повністю повношириними зображеннями."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+"Перемкніть, щоб заповнити доступну площину галереї повністю повношириними "
+"зображеннями."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "‌‌Настройки елемента"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Повноширинні зображення"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Повноширинне зображення"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Видалити gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Це gif-зображення має пустий атрибут alt"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Знайдіть чудовий gif-малюнок на сайті Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Пошук gif"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Візьміть будь-яке gif-зображення."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "анімоване"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +852,11 @@ msgstr "Файл GitHub"
 msgid "File"
 msgstr "Файл"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Переглянути цей Gist-фрагмент на GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist URL"
 
@@ -1024,12 +869,9 @@ msgid "Loading Gist"
 msgstr "Завантаження Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Вбудуйте gist-фрагменти з GitHub, додавши посилання на них."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "код"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +894,160 @@ msgid "Gist Meta"
 msgstr "Метадані Gist"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Змінити макет"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Додати тло до %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Hero"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Вступна частина сторінки, яка супроводжується невеликим текстом і закликом "
+"до дії."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Вступна частина сторінки, яка супроводжується невеликим текстом і закликом до дії."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "кнопка"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "заклик до дії"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Ширина вмісту в пікселах"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "‌‌Настройки Hero"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Проміжок у контейнері"
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Вгорі зліва"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Вгорі по центру"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Вгорі справа"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Посередині зліва"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Посередині по центру"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Посередині справа"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Внизу зліва"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Внизу по центру"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Внизу справа"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Додати виділений текст..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Виділення"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Виділіть текст."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "текст"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "абзац"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Значок"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Додайте стилізований графічний символ, який додатково про щось сповіщає."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "значки"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Великий"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr ""
+"Додайте стилізований графічний символ, який додатково про щось сповіщає."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Настройки значка"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Увімкнути додаткові настройки %s"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Перезавантажити"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Довільний розмір %s"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Додаткові настройки %s"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Довільний"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Додатково"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Радіус"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Пошук значка"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Пошук не дав результатів."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "‌‌Настройки посилання"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL посилання"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "REL посилання"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Відкриття на новій вкладці"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Відкрити на новій вкладці"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Колір значка"
 
@@ -1261,30 +1056,19 @@ msgid "Edit logos"
 msgstr "Редагувати емблеми"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Логотипи та емблеми"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
-msgstr "Перетягніть зображення, завантажте нові або виберіть файли в бібліотеці"
+msgstr ""
+"Перетягніть зображення, завантажте нові або виберіть файли в бібліотеці"
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr "Додайте логотипи, емблеми та сертифікати, щоб зміцнити довіру відвідувачів."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "клієнти"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "доказ"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "відгуки"
+msgstr ""
+"Додайте логотипи, емблеми та сертифікати, щоб зміцнити довіру відвідувачів."
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1090,145 @@ msgstr "Змінити розташування"
 msgid "Map style"
 msgstr "Стиль мапи"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Неправильний ключ API або надто багато запитів"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google Map"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
-msgstr "Введіть розташування або адресу, щоб поставити позначку на мапі Google."
+msgstr ""
+"Введіть розташування або адресу, щоб поставити позначку на мапі Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Пошук місця або адреси..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Застосувати"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Мапа"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Додайте адресу та поставте позначку на мапі Google."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "адреса"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "мапи"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Виберіть стиль мапи"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "‌‌Настройки мапи"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Масштаб"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Висота мапи в пікселах"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Масштаб"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Розмір маркера"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Увімкнуто параметри точного керування."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Перемкніть, щоб увімкнути параметри керування мапою."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Елементи керування мапою"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Тип мапи"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "Дозволено перемикання між стандартним і супутниковим поданнями мапи."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
-msgstr "Перемкніть, щоб дозволити перемикання між стандартною та супутниковою мапою."
+msgstr ""
+"Перемкніть, щоб дозволити перемикання між стандартною та супутниковою мапою."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Елементи керування масштабом"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Показ елементів керування масштабом мапи."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Перемкніть, щоб дозволити збільшення та зменшення масштабу мапи за допомогою елементів керування."
+msgstr ""
+"Перемкніть, щоб дозволити збільшення та зменшення масштабу мапи за допомогою "
+"елементів керування."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Вигляд з вулиць"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Показ елемента керування виглядом з вулиць."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
-msgstr "Перемкніть, щоб внизу справа відображався елемент керування виглядом з вулиць."
+msgstr ""
+"Перемкніть, щоб внизу справа відображався елемент керування виглядом з "
+"вулиць."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Перемикач повноекранного режиму"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Показ елемента керування повноекранним режимом мапи."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
-msgstr "Перемкніть, щоб показувати елемент керування повноекранним режимом мапи."
+msgstr ""
+"Перемкніть, щоб показувати елемент керування повноекранним режимом мапи."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Ключ Google Maps API"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Додайте ключ Google Maps API. У разі оновлення цього ключа API всі ваші мапи будуть використовувати новий ключ."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Додайте ключ Google Maps API. У разі оновлення цього ключа API всі ваші мапи "
+"будуть використовувати новий ключ."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Отримайте ваш ключ"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Потрібна допомога?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Введіть ключ Google API…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Збережено"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Стандартний"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Сріблистий"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Ретро"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Темний"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Ніч"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Баклажан"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1238,9 @@ msgstr "Мультимедіа праворуч"
 msgid "Media on left"
 msgstr "Мультимедіа ліворуч"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Картка мультимедіа"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Додайте зображення або відео за допомогою картки зі зсувом."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "зображення"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "відео"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1254,18 @@ msgstr "Показ тіні картки."
 msgid "Toggle to add a card shadow."
 msgstr "Перемкніть, щоб додати тінь картки."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Тінь %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Показ тіні %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Перемкніть, щоб додати тінь %s."
 
@@ -1545,40 +1289,171 @@ msgstr "Перетягніть, щоб замінити мультимедіа"
 msgid "Edit media"
 msgstr "Редагувати мультимедіа"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Таблиці: %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "План %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "Карусель"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Настройки кольорів"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Показ ціни для цього елемента."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Перемкніть, щоб показувати метадані gist-фрагменту."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Показ кнопки заклику до дії."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Перемкніть, щоб показувати метадані gist-фрагменту."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Настройки особливості"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Мультимедіа ліворуч"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Мультимедіа праворуч"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Розмір стовпця"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Настройки Gist"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Таблиця цін"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Таблиця цін"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Таблиця цін"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Таблиця цін"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Додайте таблиці цін."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "цільова"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "План %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "порівняння"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Настройки таблиці цін"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Таблиці"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1471,171 @@ msgstr "План A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Елемент таблиці цін"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Стовпець, розташований у блоці таблиці цін."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Додати тло до %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Стовпець"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Безпосередній дочірній елемент рядка."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Ширина"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Настройки стовпців"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Проміжок навколо контейнера."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Ширина"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Змінити макет"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "1"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "2"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "3"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "4"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Додати тло до %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Один стовпець"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Два стовпці"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Три стовпці"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Чотири стовпці"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Макет рядка"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Рядок"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Тепер виберіть макет для цього %s-стовпцевого рядка."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Виберіть кількість стовпців у цьому рядку."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Виберіть стовпці рядка"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Виберіть макет рядка"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Повернутися до стовпців"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Додайте структуровану обгортку для блоків стовпців, потім додайте бажані блоки вмісту для стовпців."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Додайте структуровану обгортку для блоків стовпців, потім додайте бажані "
+"блоки вмісту для стовпців."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "рядки"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "стовпці"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "макети"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Макет"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Настройки рядка"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Немає"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1645,9 @@ msgstr "Квадрат"
 msgid "Circle"
 msgstr "Коло"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Послуги"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Додайте один-чотири стовпці для показу послуг."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "особливості"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1669,7 @@ msgstr "Показ кнопок заклику до дій."
 msgid "Toggle to show call to action buttons."
 msgstr "Перемкніть, щоб показувати кнопки заклику до дій."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Послуга"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Один елемент послуги у блоці послуг."
 
@@ -1785,264 +1690,232 @@ msgid "Toggle to show a call to action button."
 msgstr "Перемкніть, щоб показувати кнопку заклику до дії."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Перевернути по горизонталі"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Перевернути по вертикалі"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Фігурний роздільник"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
-msgstr "Додайте фігурний роздільник, який допомагає візуально розрізняти розділи сторінки."
+msgstr ""
+"Додайте фігурний роздільник, який допомагає візуально розрізняти розділи "
+"сторінки."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "роздільник"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Колір фігури"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Настройки роздільника"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Висота фігури в пікселах"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Висота тла в пікселах"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Oрієнтація"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Колір фігури"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Опублікувати у Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Опублікувати в Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Опублікувати у Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Опублікувати в Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Опублікувати в LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Поділитися через електронну пошту"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Опублікувати в Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Опублікувати в Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Опублікувати в Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Поширити"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "спільнота"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Додайте посилання в соціальних мережах, щоб отримати більше «лайків» і сприяти поширенню."
+msgstr ""
+"Додайте посилання в соціальних мережах, щоб отримати більше «лайків» і "
+"сприяти поширенню."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Кольори соціальних мереж"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Розмір значка"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Розмір кола"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Розмір кнопки"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Значки"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Електронна пошта"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Дозволено кольори кнопок поширення."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
-msgstr "Перемкніть, щоб використовувати офіційні кольори кожної соціальної мережі"
+msgstr ""
+"Перемкніть, щоб використовувати офіційні кольори кожної соціальної мережі"
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Кольори соціальних мереж"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Додати профіль Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Додати профіль Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Додати профіль Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Додати профіль Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Додати профіль LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Додати профіль YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Додати профіль Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Додати профіль Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Профілі в соціальних мережах"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "посилання"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Показувати посилання на профілі в соціальних мережах"
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Посилання на профілі"
 
@@ -2057,18 +1930,6 @@ msgstr "Видалити тло"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Тло"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Авто"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Обкладинка"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Містять"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1987,6 @@ msgstr "Видалити тло"
 msgid "Remove "
 msgstr "Видалити "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Не повторювати"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Повторювати по горизонталі"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Повторювати по вертикалі"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Перемістити зображення назад"
@@ -2150,17 +1999,14 @@ msgstr "Перемістити зображення вперед"
 msgid "Link To"
 msgstr "Посилання на"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Галерея - %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Передати зображення"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Світлий"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +2020,110 @@ msgstr "Сторінка вкладення"
 msgid "Custom URL"
 msgstr "Користувацька URL-адреса"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Піксел"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Oрієнтація"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Відсоток"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Перезавантажити"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Виберіть одиниці вимірювання"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "Одиниці: %s"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Увімкнути додаткові настройки %s"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s вгорі"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s справа"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s внизу"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s зліва"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Розсинхронізувати"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Синхронізувати"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Синхронізувати одиниці"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Вгорі"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Справа"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Знизу"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Зліва"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Додаткові настройки %s"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Додатково"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "За промовчанням"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Макет"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2142,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Перемкніть, щоб увімкнути повноекранний режим."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Заголовок %d"
@@ -2263,43 +2151,16 @@ msgstr "Заголовок %d"
 msgid "Custom color picker"
 msgstr "Вибір довільного кольору"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Оригінал"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Відтінки сірого"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Сепія"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Насичення"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Тьмяний"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Вінтаж"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Застосувати фільтр"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Виберіть орієнтацію"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Висота"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Мобільний %s"
@@ -2333,7 +2194,8 @@ msgid "Five Seconds"
 msgstr "П’ять секунд"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Шість секунд"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2214,22 @@ msgstr "Дев’ять секунд"
 msgid "Ten Seconds"
 msgstr "Десять секунд"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Навігація стрілками"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Навігація крапками"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "секунд"
@@ -2361,22 +2239,30 @@ msgid "second"
 msgstr "секунда"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Перехід за %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Автоматично переходити до наступного слайда."
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
-msgstr "Дозволено перетягування та струшування на екрані комп’ютера та мобільного пристрою."
+#, fuzzy
+msgid "Dragging and flicking enabled."
+msgstr ""
+"Дозволено перетягування та струшування на екрані комп’ютера та мобільного "
+"пристрою."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
-msgstr "Перемкніть, щоб увімкнути функцію перетягування на комп’ютерах і мобільних пристроях."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
+msgstr ""
+"Перемкніть, щоб увімкнути функцію перетягування на комп’ютерах і мобільних "
+"пристроях."
 
 #: src/components/slider-panel/index.js:35
 msgid "Showing slide navigation arrows."
@@ -2387,44 +2273,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Перемкніть, щоб показувати стрілки навігації між слайдами."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Показ стрілок навігації крапками."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Перемкніть, щоб показувати засоби навігації крапками."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Проміжок у контейнері"
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Перемкніть, щоб вимкнути звук фонового відео."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Перемкніть, щоб закільцювати фонове відео."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Настройки повзунка"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Автовідтворення"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Швидкість переходу"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "З перетягуванням"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Навігація стрілками"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Навігація крапками"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Великими літерами"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Звичайний"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2360,6 @@ msgstr "Без проміжку внизу"
 msgid "Change typography"
 msgstr "Змінити типографіку"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "Жирний"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Верхній регістр"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Нижній регістр"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Стос на мобільному"
@@ -2487,25 +2376,29 @@ msgstr "Перемкніть, щоб у малому полі зору скла�
 msgid "Remove Top Spacing"
 msgstr "Видалити проміжок вгорі"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "У цьому блоці видалено поле вгорі."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Перемкніть, щоб додати тінь картки."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Перемкніть, щоб видалити поле, застосоване вгорі цього блока."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Перемкніть, щоб показувати засоби навігації крапками."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Видалити проміжок внизу"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "У цьому блоці видалено поле внизу."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Перемкніть, щоб додати тінь картки."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Перемкніть, щоб видалити поле, застосоване внизу цього блока."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Перемкніть, щоб показувати засоби навігації крапками."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2412,14 @@ msgstr "Показ із повною шириною."
 msgid "Toggle to display button as full width."
 msgstr "Перемкніть, щоб показувати кнопку з повною шириною."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Коло"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "‌‌Настройки Hero"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Тінь"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Прапорець"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Верхній регістр"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2445,793 @@ msgstr "Цей блок додано на сторінку, зараз не мо
 msgid "Disable all"
 msgstr "Вимкнути все"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Не знайдено жодного блока «%s»."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Галереї - %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Показувати у відкритому стані"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Додати заголовок гармошки..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Елемент гармошки"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "вкладки"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "запитання й відповіді"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "нотатка"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "повідомлення"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "біографія"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "профіль"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "посилання"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "заклик до дії"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "поширення"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "роздільник"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "послуги"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "меню"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "ресторан"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "електронна пошта"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "пошта"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Прізвище"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Текстова область"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Багаторядковий текст"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "ел. пошта"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "інформація"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "контакт"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "галерея"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "фотографії"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Ніч"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "анімоване"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "код"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "кнопка"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "заклик до дії"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "текст"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "абзац"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "значки"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "клієнти"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "доказ"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "відгуки"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "адреса"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "мапи"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "зображення"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "відео"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "адреса"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "цільова"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "порівняння"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "рядки"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "стовпці"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "макети"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "особливості"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "роздільник"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "спільнота"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "посилання"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Показувати у відкритому стані"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Додати елемент гармошки"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Гармошка"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Напишіть текст..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Напишіть заголовок..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Сповіщення"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Автор"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Кнопки"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Клацніть, щоб зробити твіт"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "Динамічний HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Функція"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Особливості"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Страва"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Їжа та напої"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Електронна пошта"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Ім'я"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Повідомлення"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Форма"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "Карусель"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Кам'яна кладка"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Один на одному"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Hero"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Виділення"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Значок"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Логотипи та емблеми"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Мапа"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Картка мультимедіа"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "Карусель"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Таблиця цін"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Елемент таблиці цін"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Стовпець"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Рядок"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Послуги"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Послуга"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Фігурний роздільник"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Поширити"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Профілі в соціальних мережах"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Інформація"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Успішно"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Попередження"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Помилка"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Точка"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Лінія"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Повна ширина"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Таблиця"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Список"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "За промовчанням"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Шари"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Контур"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Заповнення"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Один на одному"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Повторювати по горизонталі"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Хвилястий"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Пагорби"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Хвилі"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Під кутом"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Похилий"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Заокруглений"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Трикутник"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Загострений"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Маска"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Значок"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Текст"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Значок і текст"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Коло"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Внизу зліва"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Вгорі зліва"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Перетягніть зображення для аватару"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Автор"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3251,34 @@ msgstr "Додайте вміст особливості"
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Це блок особливості, який можна використовувати для виокремлення особливостей."
+msgstr ""
+"Це блок особливості, який можна використовувати для виокремлення "
+"особливостей."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Додайте заголовок hero..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Додайте заголовок hero..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Додайте вміст hero, зазвичай це вступна частина сторінки, яка "
+"супроводжується одним чи двома закликами до дії."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Додайте вміст hero, зазвичай це вступна частина сторінки, яка супроводжується одним чи двома закликами до дії."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Додайте основну дію..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Додайте допоміжну дію..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3297,125 @@ msgstr "Додайте вміст..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Замініть цей текст на опис, який додається до зображення на картці. Потім додайте на цю картку інші блоки, наприклад кнопки, списки або зображення."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Замініть цей текст на опис, який додається до зображення на картці. Потім "
+"додайте на цю картку інші блоки, наприклад кнопки, списки або зображення."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Напишіть заголовок..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Напишіть опис..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Звичайний"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Настройки кнопок"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Довільний"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Стос на мобільному"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Настройки динамічного HR"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Немає"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Немає"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Малий"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Cередній"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Великий"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Дуже великий"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Немає"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Малий"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Cередній"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Великий"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,8 +3934,12 @@ msgstr "музика мікрофон пісня артист твір муль�
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "мікрофон подкаст комп’ютер пристрій музика пісня артист твір мультимедіа аудіо"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"мікрофон подкаст комп’ютер пристрій музика пісня артист твір мультимедіа "
+"аудіо"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
@@ -3284,8 +3963,12 @@ msgstr "фільм відеографія режисер автор мульти
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "відео відеографія режисер автор мультимедіа творчі камера фотограф фотографія отвір"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"відео відеографія режисер автор мультимедіа творчі камера фотограф "
+"фотографія отвір"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3985,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "палітра дизайн кольори художник творчі мультимедіа малювати пензель"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Стандартний"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Сріблистий"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Ретро"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Темний"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Ніч"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Баклажан"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Коло"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Тінь"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "За промовчанням"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Немає"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Прапорець"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Заголовок меню..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Малий"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Cередній"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Великий"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Дуже великий"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Авто"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Обкладинка"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Містять"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Вгорі зліва"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Вгорі по центру"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Вгорі справа"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Посередині зліва"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Посередині по центру"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Посередині справа"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Внизу зліва"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Внизу по центру"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Внизу справа"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Не повторювати"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Повторити"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Повторювати по горизонталі"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Повторювати по вертикалі"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "REL посилання"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Темний"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Світлий"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Немає"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Зображення"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Піксел"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Відсоток"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Оригінал"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Відтінки сірого"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Файл мультимедіа"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Насичення"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Вінтажний фільтр"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Вінтажний фільтр"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Великими літерами"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Звичайний"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "Жирний"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "За промовчанням"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Верхній регістр"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Нижній регістр"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4333,14 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks — це набір професійних <strong>блоків вмісту для створення сторінок </strong>, призначених для редактора блоків WordPress Gutenberg. Завдяки нашим блокам хто завгодно може створювати вражаючі сторінки у WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks — це набір професійних <strong>блоків вмісту для створення сторінок "
+"</strong>, призначених для редактора блоків WordPress Gutenberg. Завдяки "
+"нашим блокам хто завгодно може створювати вражаючі сторінки у WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4350,169 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "А це чесно?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Залишити відгук"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s р."
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "рік"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s тиж."
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "тиждень"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s днів"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "день"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s год"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "година"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s хв."
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "хвилину"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s с"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "секунду"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Плагін %s WordPress"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Чи подобається вам %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Ви використовуєте %1$s вже %2$s. Чи не бажаєте залишити відгук, щоб повідомити нам свою думку? Ми будемо дуже вдячні вам!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Залишити відгук"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Ви використовуєте %1$s вже %2$s. Чи не бажаєте залишити відгук, щоб "
+"повідомити нам свою думку? Ми будемо дуже вдячні вам!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Ні, дякую / Я вже маю"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Дякуємо за вибір CoBlocks — найкращого конструктора сторінок для нового редактора блоків WordPress."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Дякуємо за вибір CoBlocks — найкращого конструктора сторінок для нового "
+"редактора блоків WordPress."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Ви щойно додали велику кількість корисних блоків і новий набір інструментів для побудови сторінок у редактор WordPress. CoBlocks пропонує вам неймовірні можливості: %1$s десятки блоків%2$s, %1$sпобудовник сторінок%2$s і %1$s нестандартні засоби керування типографікою%2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Ви щойно додали велику кількість корисних блоків і новий набір інструментів "
+"для побудови сторінок у редактор WordPress. CoBlocks пропонує вам неймовірні "
+"можливості: %1$s десятки блоків%2$s, %1$sпобудовник сторінок%2$s і %1$s "
+"нестандартні засоби керування типографікою%2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Ось кілька відео, щоб допомогти вам розпочати роботу:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Подивіться, як створити вашу першу сторінку за допомогою %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Подивіться, як створити вашу першу сторінку"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Подивіться, як використовувати блоки «Рядок» і «Фігурний роздільник»"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Подивіться, як використовувати блок «Картка мультимедіа»"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Вам подобається? %1$sПідпишіться на наш канал YouTube%2$s, і ми будемо сповіщати вас про вихід нових посібників для відео."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Вам подобається? %1$sПідпишіться на наш канал YouTube%2$s, і ми будемо "
+"сповіщати вас про вихід нових посібників для відео."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Якщо ви маєте будь-які запитання чи відгуки, повідомте нам у %1$sTwitter%4$s або в нашій %2$sгрупі Facebook%4$s. Також %3$sпідпишіться на нашу розсилку новин%4$s, якщо бажаєте бути в курсі справ CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Якщо ви маєте будь-які запитання чи відгуки, повідомте нам у %1$sTwitter%4$s "
+"або в нашій %2$sгрупі Facebook%4$s. Також %3$sпідпишіться на нашу розсилку "
+"новин%4$s, якщо бажаєте бути в курсі справ CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Насолоджуйтесь!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "CoBlocks починається тут:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4526,27 @@ msgstr "Ключ сайту Google reCaptcha для захисту форм ві
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "Секретний ключ Google reCaptcha для захисту форм від спаму"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Ім'я"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Перша"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Остання"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Повідомлення"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Надіслати"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Ваше повідомлення надіслано:"
 
@@ -3490,3 +4561,85 @@ msgstr "Опублікувати в LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "Тип оповіщення"
+
+#~ msgid "Edit image"
+#~ msgstr "Змінити зображення"
+
+#~ msgid "Remove image"
+#~ msgstr "Видалити зображення"
+
+#~ msgid "Heading..."
+#~ msgstr "Заголовок..."
+
+#~ msgid "Author Name"
+#~ msgstr "Ім'я автора"
+
+#~ msgid "Write biography..."
+#~ msgstr "Напишіть біографію..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Додайте біографію автора."
+
+#~ msgid "%s Settings"
+#~ msgstr "Настройки %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Колір підпису"
+
+#~ msgid "Highlight text."
+#~ msgstr "Виділіть текст."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Таблиці: %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Настройки таблиці цін"
+
+#~ msgid "Tables"
+#~ msgstr "Таблиці"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Стовпець, розташований у блоці таблиці цін."
+
+#~ msgid "Sepia"
+#~ msgstr "Сепія"
+
+#~ msgid "Dim"
+#~ msgstr "Тьмяний"
+
+#~ msgid "Vintage"
+#~ msgstr "Вінтаж"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Виберіть орієнтацію"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "У цьому блоці видалено поле вгорі."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "Перемкніть, щоб видалити поле, застосоване вгорі цього блока."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "У цьому блоці видалено поле внизу."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "Перемкніть, щоб видалити поле, застосоване внизу цього блока."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Додайте основну дію..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Додайте допоміжну дію..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Звичайний"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "CoBlocks починається тут:"

--- a/languages/coblocks-vi.po
+++ b/languages/coblocks-vi.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "Hiển thị mở"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "Thêm tiêu đề với nội dung có thể thu gọn..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "Mục nội dung có thể thu gọn"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "Thêm các mục nội dung có thể thu gọn vào mục có thể thu gọn."
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "thẻ"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "câu hỏi thường gặp"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -45,57 +24,39 @@ msgstr "Mục nội dung có thể thu gọn được mở theo mặc định."
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Toggle to set this accordion item to be open by default."
-msgstr "Bật tắt để cài đặt mục nội dung có thể thu gọn này được mở theo mặc định."
+msgstr ""
+"Bật tắt để cài đặt mục nội dung có thể thu gọn này được mở theo mặc định."
 
 #: src/blocks/accordion/accordion-item/inspector.js:63
 msgid "Accordion Item Settings"
 msgstr "Các cài đặt của mục nội dung có thể thu gọn"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "Hiển thị Mở"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "Cài đặt Màu"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "Màu nền"
@@ -103,14 +64,6 @@ msgstr "Màu nền"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "Màu văn bản của tựa đề"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "Thêm mục nội dung có thể thu gọn"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "Nội dung có thể thu gọn"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -126,143 +79,82 @@ msgstr "Hỗ trợ Internet Explorer"
 
 #: src/blocks/accordion/inspector.js:31
 msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
-msgstr "Thêm hỗ trợ cho Internet Explorer bằng cách tải một đoạn mã của JavaScript."
+msgstr ""
+"Thêm hỗ trợ cho Internet Explorer bằng cách tải một đoạn mã của JavaScript."
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
-msgstr "Hỗ trợ Internet Explorer bằng cách tải một đoạn mã của JavaScript trên trang này."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgstr ""
+"Hỗ trợ Internet Explorer bằng cách tải một đoạn mã của JavaScript trên trang "
+"này."
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "Thông báo"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "Lỗi"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "Loại thông báo"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "Mặc định"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "Thông tin"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "Thành công"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "Viết tiêu đề..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "Viết văn bản..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "Cảnh báo"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "Cung cấp thông báo phản hồi theo ngữ cảnh."
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "chú ý"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "tin nhắn"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "Màu văn bản"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "Sửa ảnh"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "Chỉnh sửa thư viện"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "Xóa ảnh"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "Viết chú thích…"
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "Thả để thêm hình đại diện"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "Đề mục..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "Tên tác giả"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "Viết tiểu sử..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "Cài đặt biểu mẫu"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "Tác giả"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "Thêm tiểu sử tác giả."
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "tiểu sử"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "hồ sơ"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "Nút"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "Nhắc nhở khách truy cập thao tác với nhiều nút song song."
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "liên kết"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "CTA"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "Cài đặt của nút"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "Xếp chồng trên di động"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "Nút"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +172,25 @@ msgstr "Tên người dùng Twitter"
 msgid "Username"
 msgstr "Tên người dùng"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "Thêm nút..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "Thêm một câu trích dẫn cho bài đăng..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "Nhấp để Đăng"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "Thêm một câu trích dẫn cho độc giả để đăng qua Twitter."
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "chia sẻ"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "Twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +198,18 @@ msgid "Text Settings"
 msgstr "Cài đặt văn bản"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "Màu nút"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "HR Động"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "Thêm một ký tự cách có thể thay đổi kích cỡ giữa các khối khác."
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "ký tự cách"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "Cài đặt HR Động"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "Chiều cao tính bằng pixel"
 
@@ -347,17 +221,12 @@ msgstr "Chiều cao cho phần tử dấu tách động tính theo pixel."
 msgid "Color"
 msgstr "Màu sắc"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "Thêm như phông nền"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "Tính năng"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "Thêm một cột con trong khối tính năng chính."
 
@@ -366,73 +235,54 @@ msgid "Feature Settings"
 msgstr "Cài đặt Tính năng"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "Phần đệm"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "Các tính năng"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "Thêm lên đến ba cột ghi chú nhỏ cho sản phẩm hoặc dịch vụ của bạn."
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "dịch vụ"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "Lề"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "Máng ngăn"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "Khoảng cách giữa mỗi cột."
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "Nhỏ"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "Trung bình"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +292,8 @@ msgstr "Lớn"
 msgid "Features Settings"
 msgstr "Cài đặt các tính năng"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "Các cột"
 
@@ -455,76 +305,72 @@ msgstr "Thêm Mục Menu"
 msgid "Menu title..."
 msgstr "Tiêu đề menu..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "Lưới"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "Danh sách"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "Thả ảnh để thay thế"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "Xóa Ảnh"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "Thêm tiêu đề..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "Cay"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "Hấp dẫn"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "Người ăn chay"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "Không chứa gluten"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "Người ăn bán chay"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "Ăn chay"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "Thêm mô tả..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "$0.00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "Mục Đồ ăn"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "Thêm mục thức đồ uống trong khối Thức ăn & Đồ uống."
 
@@ -560,62 +406,46 @@ msgstr "Bật tắt để hiển thị giá cho mục này."
 msgid "Item Attributes"
 msgstr "Thuộc tính của Mục"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "Cay hơn"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "Cài đặt Ảnh"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Văn bản thay thế"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "Miêu tả mục đích của ảnh"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "Hãy để trống nếu ảnh chỉ là để trang trí."
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "Tiêu điểm"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "Thực phẩm & Nước uống"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "Hiển thị một menu hay danh sách giá."
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "nhà hàng"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "menu"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "Phong cách"
@@ -648,134 +478,86 @@ msgstr "Hiển thị giá cho từng mục"
 msgid "Toggle to show the price of each item."
 msgstr "Bật tắt để hiển thị giá cho từng mục."
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "Email"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "e-mail"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "thư"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "Một trường địa chỉ email."
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "Thư"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "Vùng văn bản"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "Văn bản nhiều dòng"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "Một hộp văn bản cho những phản hồi dài hơn"
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s không phải là một địa chỉ email hợp lệ."
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s và %skhông phải là các địa chỉ email hợp lệ."
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s không phải là địa chỉ email hợp lệ."
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "Địa chỉ email"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "Chủ đề"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "Cài đặt biểu mẫu"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "reCAPTCHA của Google"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
-msgstr "Thêm trang reCAPTCHA của bạn và các khóa bí mật để bảo vệ biểu mẫu của bạn khỏi thư rác."
+msgstr ""
+"Thêm trang reCAPTCHA của bạn và các khóa bí mật để bảo vệ biểu mẫu của bạn "
+"khỏi thư rác."
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "Tạo các khóa"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "Khóa của tôi"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "Nhận trợ giúp"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "Khóa của trang"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "Khóa bí mật"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "Đang lưu"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "Lưu"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "Xóa"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "Tên"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "Họ"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "Tên"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "Một trường văn bản cho tên."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "Một trường địa chỉ email."
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "Thêm nhãn…"
 
@@ -783,41 +565,38 @@ msgstr "Thêm nhãn…"
 msgid "Required"
 msgstr "Được yêu cầu"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "Các cài đặt trường tên"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "Họ"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "Hiển thị cả trường họ lẫn tên."
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "Bật tắt để thêm một trường họ."
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "Mẫu"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "Một trường văn bản cho tên."
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "Một hộp văn bản cho những phản hồi dài hơn"
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "Thêm một biểu mẫu cho trang của bạn."
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "email"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "Giới thiệu về"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "liên hệ"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "Chủ đề"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +606,217 @@ msgstr "Thêm văn bản…"
 msgid "Button Text Color"
 msgstr "Màu văn bản của nút"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "Chỉnh sửa thư viện"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "xem băng chuyền"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "ảnh %1$d trong số %2$d trong thư viện"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "Viết chú thích…"
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "xem băng chuyền"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "Hiển thị nhiều ảnh trong một thư viện băng chuyền bắt mắt."
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "thư viện"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "các ảnh"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "Cài đặt %s"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "Độ cao của dòng"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "Hiển thị các mũi tên điều hướng dấu chấm."
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "Bật tắt để hiển thị chú thích truyền thông."
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "Cài đặt Màu"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "Kích cỡ"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "Các góc tròn"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "Màu sắc của chú thích"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "Áp dụng"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "Ô xen kẽ"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "Viết mô tả..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "Hiển thị nhiều ảnh trong thư viện được sắp xếp ô xen kẽ."
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "Hiển thị nhiều ảnh trong một thư viện băng chuyền bắt mắt."
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "Kích thước của cột"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "Cài đặt Ảnh"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "Thêm các góc tròn cho các mục của thư viện."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "Bóng"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "Chú thích"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "Kiểu chú thích"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "Hiển thị chú thích cho mỗi mục truyền thông."
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "Bật tắt để hiển thị chú thích truyền thông."
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "Ô xen kẽ"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "Hiển thị nhiều ảnh trong thư viện được sắp xếp ô xen kẽ."
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "Bật tắt để bật các tùy chọn kiểm soát bản đồ."
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "Cài đặt của bản đồ"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "Kích thước của cột"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "Thêm các góc tròn cho các mục của thư viện."
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "Sáng"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "Xếp chồng"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "Hiển thị nhiều ảnh trong một thư viện xếp chồng một cột."
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "Các ảnh đủ độ rộng"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "Ảnh đủ độ rộng"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "Bóng của hộp"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "Đã bật ảnh đủ độ rộng."
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
 msgstr "Bật tắt để phủ các vùng thư viện khả dụng với toàn các ảnh đủ độ rộng."
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "Thiết lập Mục"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "Các ảnh đủ độ rộng"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "Ảnh đủ độ rộng"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "Xóa GIF"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "Ảnh GIF này có thuộc tính ALT trống"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "Tìm kiếm GIF hoàn hảo này trên Giphy"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "Tìm kiếm các ảnh GIF"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "Hãy chọn một ảnh GIF, bất kỳ ảnh GIF nào."
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "động"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +842,11 @@ msgstr "Tập tin GitHub"
 msgid "File"
 msgstr "Tập tin"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "Xem lưu trữ mã này trên GitHub"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "URL của lưu trữ mã"
 
@@ -1024,12 +859,9 @@ msgid "Loading Gist"
 msgstr "Đang tải lưu trữ mã"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "Nhúng lưu trữ mã của GitHub bằng cách thêm liên kết lưu trữ mã."
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "mã"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +884,159 @@ msgid "Gist Meta"
 msgstr "Meta của lưu trữ mã"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "Thay đổi bố cục"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "Thêm nền cho %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "Nội dung chính"
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
+msgstr ""
+"Một đoạn giới thiệu của trang được kèm theo với một đoạn văn bản nhỏ và kêu "
+"gọi thao tác."
 
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
-msgstr "Một đoạn giới thiệu của trang được kèm theo với một đoạn văn bản nhỏ và kêu gọi thao tác."
-
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "nút"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "kêu gọi thao tác"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "Chiều rộng của nội dung tính theo pixel"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "Cài đặt Nội dung chính"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "Không gian bên trong của vùng chứa."
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "Phía trên bên trái"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "Phía trên ở giữa"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "Phía trên bên phải"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "Ở giữa bên trái"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "Chính giữa"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "Ở giữa bên phải"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "Phía dưới bên trái"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "Phía dưới ở giữa"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "Phía dưới bên phải"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "Thêm văn bản được tô sáng..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "Tô sáng"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "Văn bản tô sáng."
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "văn bản"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "đoạn văn"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "Biểu tượng"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "Thêm một biểu tượng đồ họa cách điệu để truyền tải nhiều ý nghĩa hơn."
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "các biểu tượng"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "Khổng lồ"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "Thêm một biểu tượng đồ họa cách điệu để truyền tải nhiều ý nghĩa hơn."
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "Cài đặt của biểu tượng"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "Tắt các cài đặt %s nâng cao"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "Cài đặt lại"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "Kích thước %s tùy chỉnh"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "Các cài đặt %s nâng cao"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "Tùy chỉnh"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "Nâng cao"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "Bán kính"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "Tìm kiếm Biểu tượng"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "Không tìm thấy kết quả nào."
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "Các cài đặt của liên kết"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "URL của liên kết"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "REl của liên kết"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "Đang mở trong một thẻ mới"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "Mở trong một thẻ mới"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "Màu của biểu tượng"
 
@@ -1261,30 +1045,17 @@ msgid "Edit logos"
 msgstr "Chỉnh sửa logo"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "Logo & Phù hiệu"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr "Kéo ảnh, tải lên các ảnh mới hay chọn tập tin từ thư viện của bạn."
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "Thêm ảnh, huy hiệu hay chứng nhận để gây dựng lòng tin."
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "Ứng dụng khách"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "bằng chứng"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "cảm nhận của khách hàng"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1077,139 @@ msgstr "Chỉnh sửa Địa điểm"
 msgid "Map style"
 msgstr "Kiểu bản đồ"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "Khóa API không hợp lệ hoặc có quá nhiều yêu cầu"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Bản đồ của Google"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "Nhập một địa điểm hay địa chỉ để thả ghim trên bản đồ Google."
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "Tìm kiếm một nơi hay địa chỉ…"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "Áp dụng"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "Bản đồ"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "Thêm một địa chỉ hay thả một ghim trên bản đồ Google."
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "địa chỉ"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "bản đồ"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "Google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "Chọn kiểu bản đồ"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "Cài đặt của bản đồ"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "Mức thu phóng"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "Chiều cao của bản đồ tính theo pixel"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "Mức thu phóng"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "Kích cỡ của dấu"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "Đã bật các tùy chọn kiểm soát hoàn toàn."
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "Bật tắt để bật các tùy chọn kiểm soát bản đồ."
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "Kiểm soát bản đồ"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "Kiểu Bản đồ"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "Đã bật chuyển đổi giữa dạng xem tiêu chuẩn và vệ tinh."
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "Bật tắt để bật chuyển đổi giữa dạng xem tiêu chuẩn và vệ tinh."
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "Kiểm soát thu phóng"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "Hiển thị kiểm soát thu phóng bản đồ."
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
-msgstr "Bật tắt để bật phóng to và thu nhỏ trên bản đồ với kiểm soát thu phóng."
+msgstr ""
+"Bật tắt để bật phóng to và thu nhỏ trên bản đồ với kiểm soát thu phóng."
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "Chế độ xem đường phố"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "Đang hiển thị kiểm soát bản đồ theo dạng xem đường phố."
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "Bật tắt để hiển thị kiểm soát dạng xem đường phố ở phía dưới bên phải."
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "Bật tắt toàn màn hình"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "Đang hiển thị kiểm soát bản đồ toàn màn hình."
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "Bật tắt để hiển thị kiểm soát bản đồ toàn màn hình."
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Khóa API của Bản đồ Google"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "Thêm khóa API cho Bản đồ Google. Cập nhật khóa API này sẽ cài đặt tất cả bản đồ của bạn sử dụng khóa mới."
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"Thêm khóa API cho Bản đồ Google. Cập nhật khóa API này sẽ cài đặt tất cả bản "
+"đồ của bạn sử dụng khóa mới."
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "Lấy khóa của bạn"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "Bạn cần hỗ trợ?"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "Nhập khóa API của Google…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "Đã lưu"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "Thông thường"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "Bạc"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "Cổ điển"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "Tối"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "Đêm"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "Tím cà"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1219,9 @@ msgstr "Truyền thông phía bên phải"
 msgid "Media on left"
 msgstr "Truyền thông phía bên trái"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "Thẻ truyền thông"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "Thêm một ảnh hay video với một thẻ khoảng cách song song."
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "ảnh"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "video"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1235,18 @@ msgstr "Hiển thị bóng của thẻ."
 msgid "Toggle to add a card shadow."
 msgstr "Bật tắt để thêm bóng cho thẻ."
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " Bóng %s"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "Hiển thị bóng %s."
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "Bật tắt để thêm bóng cho %s"
 
@@ -1545,40 +1270,171 @@ msgstr "Thả để thay thế truyền thông"
 msgid "Edit media"
 msgstr "Chỉnh sửa truyền thông"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "Bảng %s"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "URL của lưu trữ mã"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "Gói %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "xem băng chuyền"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "URL của lưu trữ mã"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "Cài đặt Màu"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "Hiển thị giá cho mục này."
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "Bật tắt để hiển thị dữ liệu meta của lưu trữ mã."
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "Hiển thị nút kêu gọi thao tác."
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "Bật tắt để hiển thị dữ liệu meta của lưu trữ mã."
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "Cài đặt Tính năng"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "Truyền thông phía bên trái"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "Truyền thông phía bên phải"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "Kích thước của cột"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Cài đặt của lưu trữ mã"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "Bảng giá"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "Bảng giá"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "Bảng giá"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "Bảng giá"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "Thêm các bảng giá."
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "đích"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "Gói %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "so sánh"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "Các cài đặt bảng giá"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "Bảng biểu"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1452,171 @@ msgstr "Gói A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "Mục của Bảng giá"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "Một cột được đặt bên trong khối bảng giá."
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "Thêm nền cho %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "Cột"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "Một hàng phụ tức thì của dòng."
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "Chiều rộng"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "Các cài đặt của cột"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "Khoảng cách chung quanh vùng chứa."
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "Chiều rộng"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "Thay đổi bố cục"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "một"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "hai"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "ba"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "bốn"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "Thêm nền cho %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "Một cột"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "Hai cột"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "Ba cột"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "Bốn cột"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "Bố cục của Hàng"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "Hàng"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "Giờ bạn hãy bố cục cho hàng của cột %s này."
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "Chọn số cột cho hàng này."
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "Chọn các cột cho hàng"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "Chọn bố cục cho hàng"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "Quay trở lại các cột"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
-msgstr "Thêm một trình bao bọc có cấu trúc cho các khối của cột, sau đó thêm khối nội dung bạn muốn cho các cột."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
+msgstr ""
+"Thêm một trình bao bọc có cấu trúc cho các khối của cột, sau đó thêm khối "
+"nội dung bạn muốn cho các cột."
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "các hàng"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "cột"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "bố cục"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "Bố cục"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "Các cài đặt của hàng"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "Không có"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1626,9 @@ msgstr "Hình vuông"
 msgid "Circle"
 msgstr "Hình tròn"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "Các dịch vụ"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "Thêm trên bốn cột dịch vụ để hiển thị."
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "các tính năng"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1650,7 @@ msgstr "Hiển thị các nút kêu gọi thao tác."
 msgid "Toggle to show call to action buttons."
 msgstr "Bật tắt để hiển thị các nút kêu gọi thao tác."
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "Dịch vụ"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "Một mục dịch vụ trong một khối các dịch vụ."
 
@@ -1785,264 +1671,228 @@ msgid "Toggle to show a call to action button."
 msgstr "Bật tắt để hiển thị nút kêu gọi thao tác."
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "Lật theo chiều ngang"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "Lật theo chiều dọc"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "Bộ chia Hình dạng"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "Thêm một bộ chia hình dạng để phân biệt các phần của trang."
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "dấu tách"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "Màu sắc của hình dạng"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "Các cài đặt của bộ chia"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "Chiều cao của hình dạng tính bằng pixel"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "Nền của hình dạng tính bằng pixel"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "Hướng"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "Màu sắc của hình dạng"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "Chia sẻ trên Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "Chia sẻ trên Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "Chia sẻ trên Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "Chia sẻ trên Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "Chia sẻ trên LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "Chia sẻ qua Email"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "Chia sẻ trên Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "Chia sẻ trên Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "Chia sẻ trên Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "Chia sẻ"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "mạng xã hội"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
-msgstr "Thêm các liên kết chia sẻ mạng xã hội để giúp bạn được thích và chia sẻ."
+msgstr ""
+"Thêm các liên kết chia sẻ mạng xã hội để giúp bạn được thích và chia sẻ."
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "Màu sắc của mạng xã hội"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "Kích thước của biểu tượng"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "Kích cỡ của hình tròn"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "Kích cỡ của nút"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "Các biểu tượng"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "Đã bật chia sẻ màu cho các nút."
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
 msgstr "Bật tắt để sử dụng màu chính thức từ từng nền tảng phương tiện xã hội."
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "Màu sắc của mạng xã hội"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "Thêm Hồ sơ của Facebook"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "Thêm hồ sơ Twitter"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "Thêm hồ sơ Instagram"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "Thêm hồ sơ Pinterest"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "Thêm hồ sơ LinkedIn"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "Thêm hồ sơ YouTube"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "Thêm hồ sơ Yelp"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "Thêm hồ sơ Houzz"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "Hồ sơ Xã hội"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "các liên kết"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "Hiển thị các liên kết đến hồ sơ phương tiện xã hội."
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "Các liên kết của hồ sơ"
 
@@ -2057,18 +1907,6 @@ msgstr "Xóa nền"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "Nền"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "Tự động"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "Trang bìa"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "Chứa"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1964,6 @@ msgstr "Xóa nền"
 msgid "Remove "
 msgstr "Xóa "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "Không lặp lại"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "Lặp ngang"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "Lặp dọc"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "Di chuyển ảnh về phía sau"
@@ -2150,17 +1976,14 @@ msgstr "Di chuyển ảnh về phía trước"
 msgid "Link To"
 msgstr "Liên kết đến"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "Thư viện %s"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "Tải lên một ảnh"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "Sáng"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +1997,110 @@ msgstr "Trang đính kèm"
 msgid "Custom URL"
 msgstr "URL tùy chỉnh"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "Hướng"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "Tỷ lệ phần trăm"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "Cài đặt lại"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "Chọn các đơn vị"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s Đơn vị"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "Tắt các cài đặt %s nâng cao"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s Phía trên"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s Bên phải"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s Phía dưới"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s Bên trái"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "Không đồng bộ hóa"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "Đồng bộ hóa"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "Đồng bộ hóa các đơn vị"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "Đầu trang"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "Bên phải"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "Cuối trang"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "Bên trái"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "Các cài đặt %s nâng cao"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "Nâng cao"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "Mặc định"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "Bố cục"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2119,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "Bật tắt để bật chế độ toàn màn hình."
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "Đề mục %d"
@@ -2263,43 +2128,16 @@ msgstr "Đề mục %d"
 msgid "Custom color picker"
 msgstr "Bộ chọn màu tùy chỉnh"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "Gốc"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "Thang độ xám"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "Màu nâu đỏ"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "Bão hòa"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "Mờ"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "Cổ điển"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "Áp dụng bộ lọc"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "Chọn Hướng"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "Chiều cao"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "Di động %s"
@@ -2333,7 +2171,8 @@ msgid "Five Seconds"
 msgstr "Năm giây"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "Sáu giây"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2191,22 @@ msgstr "Chín giây"
 msgid "Ten Seconds"
 msgstr "Mười giây"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "Điều hướng mũi tên"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "Điều hướng dấu chấm"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "giây"
@@ -2361,21 +2216,25 @@ msgid "second"
 msgstr "giây"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "Tiếp tục sau %1$d %2$s."
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "Tự động tiếp tục sang bản chiếu tiếp theo"
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "Kéo và vuốt được bật trên các thiết bị máy tính và di động."
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
 msgstr "Bật tắt để bật chức năng kéo trên các thiết bị máy tính và di động."
 
 #: src/components/slider-panel/index.js:35
@@ -2387,44 +2246,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "Bật tắt để hiển thị các mũi tên điều hướng của bản chiếu."
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "Hiển thị các mũi tên điều hướng dấu chấm."
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "Bật tắt để hiển thị điều hướng dấu chấm."
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "Không gian bên trong của vùng chứa."
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "Bật tắt để tắt tiếng video."
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "Bật tắt để lặp video."
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "Cài đặt của con trượt"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "Phát tự động"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "Tốc độ chuyển tiếp"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "Có thể kéo được"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "Điều hướng mũi tên"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "Điều hướng dấu chấm"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "Viết hoa"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "Bình thường"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2333,6 @@ msgstr "Không dãn cách cuối trang"
 msgid "Change typography"
 msgstr "Thay đổi nghệ thuật ghép chữ in"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "In đậm"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "Chữ hoa"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "Chữ thường"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "Xếp chồng trên Di động"
@@ -2487,25 +2349,29 @@ msgstr "Bật tắt để xếp chồng các phần tử lên nhau trên các c�
 msgid "Remove Top Spacing"
 msgstr "Bỏ dãn cách đầu trang"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "Lề đầu trang bị xóa cho khối này."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "Bật tắt để thêm bóng cho thẻ."
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "Bật tắt để xóa bất kỳ lề nào được áp dụng cho đầu khối này."
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "Bật tắt để hiển thị điều hướng dấu chấm."
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "Xóa dãn cách cuối trang"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "Lề cuối trang bị xóa trên khối này."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "Bật tắt để thêm bóng cho thẻ."
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "Bật tắt để xóa bất kỳ lề nào được áp dụng cho cuối khối này."
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "Bật tắt để hiển thị điều hướng dấu chấm."
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2385,14 @@ msgstr "Đang hiển thị theo đủ độ rộng."
 msgid "Toggle to display button as full width."
 msgstr "Bật tắt để hiển thị nút theo đủ độ rộng."
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "Vòng tròn"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "Cài đặt Nội dung chính"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "Bóng"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "Hộp kiểm"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "Chữ hoa"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2418,793 @@ msgstr "Khối này được thêm vào trang và hiện tại không thể tắ
 msgid "Disable all"
 msgstr "Tắt tất cả"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "Không tìm thấy khối \"%s\" nào."
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "Các thư viện %s"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "Hiển thị mở"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "Thêm tiêu đề với nội dung có thể thu gọn..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "Mục nội dung có thể thu gọn"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "thẻ"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "câu hỏi thường gặp"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "chú ý"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "tin nhắn"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "tiểu sử"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "hồ sơ"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "liên kết"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "CTA"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "chia sẻ"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "Twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "ký tự cách"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "dịch vụ"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "menu"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "nhà hàng"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "e-mail"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "thư"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "Họ"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "Vùng văn bản"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "Văn bản nhiều dòng"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "email"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "Giới thiệu về"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "liên hệ"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "thư viện"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "các ảnh"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "Đêm"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "động"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "mã"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "nút"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "kêu gọi thao tác"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "văn bản"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "đoạn văn"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "các biểu tượng"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "Ứng dụng khách"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "bằng chứng"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "cảm nhận của khách hàng"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "địa chỉ"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "bản đồ"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "Google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "ảnh"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "video"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "địa chỉ"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "đích"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "so sánh"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "các hàng"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "cột"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "bố cục"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "các tính năng"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "dấu tách"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "mạng xã hội"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "các liên kết"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "Hiển thị Mở"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "Thêm mục nội dung có thể thu gọn"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "Nội dung có thể thu gọn"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "Viết văn bản..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "Viết tiêu đề..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "Cảnh báo"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "Tác giả"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "Nút"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "Nhấp để Đăng"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "HR Động"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "Tính năng"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "Các tính năng"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "Mục Đồ ăn"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "Thực phẩm & Nước uống"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "Email"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "Tên"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "Thư"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "Mẫu"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "xem băng chuyền"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "Ô xen kẽ"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "Xếp chồng"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "URL của lưu trữ mã"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "Nội dung chính"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "Tô sáng"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "Biểu tượng"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "Logo & Phù hiệu"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "Bản đồ"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "Thẻ truyền thông"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "xem băng chuyền"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "Bảng giá"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "Mục của Bảng giá"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "Cột"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "Hàng"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "Các dịch vụ"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "Dịch vụ"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "Bộ chia Hình dạng"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "Chia sẻ"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "Hồ sơ Xã hội"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "Thông tin"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "Thành công"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "Thông báo"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "Lỗi"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "Dấu chấm"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "Dòng"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "Đủ độ rộng"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "Lưới"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "Danh sách"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "Mặc định"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "Tầng"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "Có viền"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "Lấp đầy"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "Xếp chồng"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "Lặp ngang"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "Gợn sóng"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "Đồi"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "Sóng"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "Góc cạnh"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "Nghiêng"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "Bo tròn"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "Tam giác"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "Nhọn"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "Mặt nạ"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "Biểu tượng"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "Văn bản"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "Biểu tượng & Văn bản"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "Vòng tròn"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "Phía dưới bên trái"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "Phía trên bên trái"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "Thả để thêm hình đại diện"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "Tác giả"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2680,27 +3224,33 @@ msgstr "Thêm tiêu đề của tính năng"
 #: src/blocks/features/feature/edit.js:32
 msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
-msgstr "Đây là khối tính năng mà bạn có thể sử dụng để làm nổi bật các tính năng."
+msgstr ""
+"Đây là khối tính năng mà bạn có thể sử dụng để làm nổi bật các tính năng."
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Thêm đầu trang chính..."
 
 #: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero heading..."
-msgstr "Thêm đầu trang chính..."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Thêm nội dung chính mà thường là phần giới thiệu của trang, kèm theo là một "
+"hay hai kêu gọi thao tác."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
-msgstr "Thêm nội dung chính mà thường là phần giới thiệu của trang, kèm theo là một hay hai kêu gọi thao tác."
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "Thêm thao tác chính..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "Thêm thao tác phụ..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3269,125 @@ msgstr "Thêm nội dung..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "Thay thế văn bản này với bản sao có mô tả phù hợp với ảnh của thẻ. Sau đó thêm nhiều khối cho thẻ này, chẳng hạn như nút, danh sách hay ảnh."
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"Thay thế văn bản này với bản sao có mô tả phù hợp với ảnh của thẻ. Sau đó "
+"thêm nhiều khối cho thẻ này, chẳng hạn như nút, danh sách hay ảnh."
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "Viết tiêu đề..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "Viết mô tả..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "Bình thường"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "Cài đặt của nút"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "Tùy chỉnh"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "Xếp chồng trên di động"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "Cài đặt HR Động"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "Không có"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "Không có"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "Nhỏ"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "Trung bình"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "Lớn"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "Cực lớn"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "Không có"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "Nhỏ"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "Trung bình"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "Lớn"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3160,7 +3807,9 @@ msgstr "thế giới công chúng toàn cầu trái đất địa điểm bản 
 #: src/blocks/icon/svgs.js:258
 msgctxt "tags"
 msgid "location map public business corporation building town skyscraper"
-msgstr "bản đồ địa điểm công cộng công ty kinh doanh xây dựng thị trấn tòa nhà chọc trời"
+msgstr ""
+"bản đồ địa điểm công cộng công ty kinh doanh xây dựng thị trấn tòa nhà chọc "
+"trời"
 
 #: src/blocks/icon/svgs.js:263
 msgctxt "tags"
@@ -3180,7 +3829,8 @@ msgstr "vui vẻ bữa tiệc kỷ niệm hạnh phục thử món ăn"
 #: src/blocks/icon/svgs.js:280
 msgctxt "tags"
 msgid "petal scent smell nice relax landscape gardening outdoors outside"
-msgstr "ngửi mùi cánh hoa tuyệt vời thư giãn phong cảnh làm vườn ngoài trời bên ngoài"
+msgstr ""
+"ngửi mùi cánh hoa tuyệt vời thư giãn phong cảnh làm vườn ngoài trời bên ngoài"
 
 #: src/blocks/icon/svgs.js:292
 msgctxt "tags"
@@ -3210,7 +3860,8 @@ msgstr "ngôn ngữ toàn cầu thế giới diễn văn"
 #: src/blocks/icon/svgs.js:319
 msgctxt "tags"
 msgid "music microphone song artist creative media audio badge"
-msgstr "nhạc micrô podcast bài hát nghệ sĩ sáng tạo truyền thông âm thanh huy hiệu"
+msgstr ""
+"nhạc micrô podcast bài hát nghệ sĩ sáng tạo truyền thông âm thanh huy hiệu"
 
 #: src/blocks/icon/svgs.js:32
 msgctxt "tags"
@@ -3259,18 +3910,25 @@ msgstr "nhạc micrô podcast bài hát nghệ sĩ sáng tạo truyền thông �
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
-msgstr "micrô podcast máy tính thiết bị âm nhạc loa bài hát nghệ sĩ sáng tạo truyền thông audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
+msgstr ""
+"micrô podcast máy tính thiết bị âm nhạc loa bài hát nghệ sĩ sáng tạo truyền "
+"thông audio"
 
 #: src/blocks/icon/svgs.js:49
 msgctxt "tags"
 msgid "photo photographer photography camera film creative media"
-msgstr "ảnh nhiếp ảnh gia nghệ thuật nhiếp ảnh máy ảnh phim sáng tạo truyền thông"
+msgstr ""
+"ảnh nhiếp ảnh gia nghệ thuật nhiếp ảnh máy ảnh phim sáng tạo truyền thông"
 
 #: src/blocks/icon/svgs.js:55
 msgctxt "tags"
 msgid "photo photographer photography camera aperture film creative media"
-msgstr "ảnh nhiếp ảnh gia nghệ thuật nhiếp ảnh máy ảnh khẩu độ phim sáng tạo truyền thông"
+msgstr ""
+"ảnh nhiếp ảnh gia nghệ thuật nhiếp ảnh máy ảnh khẩu độ phim sáng tạo truyền "
+"thông"
 
 #: src/blocks/icon/svgs.js:61
 msgctxt "tags"
@@ -3284,8 +3942,12 @@ msgstr "phim quay phim nhiếp ảnh đạo diễn nhà sản xuất truyền th
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
-msgstr "video quay phim nhiếp ảnh đạo diễn nhà sản xuất truyền thông sáng tạo camera nhiếp ảnh gia nhiếp ảnh khẩu độ"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
+msgstr ""
+"video quay phim nhiếp ảnh đạo diễn nhà sản xuất truyền thông sáng tạo camera "
+"nhiếp ảnh gia nhiếp ảnh khẩu độ"
 
 #: src/blocks/icon/svgs.js:85
 msgctxt "tags"
@@ -3302,12 +3964,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "bảng thiết kế màu nghệ sĩ sáng tạo truyền thông sơn cọ"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "Thông thường"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "Bạc"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "Cổ điển"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "Tối"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "Đêm"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "Tím cà"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "Vòng tròn"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "Bóng"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "Mặc định"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "Không có"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "Hộp kiểm"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "Tiêu đề menu..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "Nhỏ"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "Trung bình"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "Lớn"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "Cực lớn"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "Tự động"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "Trang bìa"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "Chứa"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "Phía trên bên trái"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "Phía trên ở giữa"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "Phía trên bên phải"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "Ở giữa bên trái"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "Chính giữa"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "Ở giữa bên phải"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "Phía dưới bên trái"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "Phía dưới ở giữa"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "Phía dưới bên phải"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "Không lặp lại"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "Lặp lại"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "Lặp ngang"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "Lặp dọc"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "REl của liên kết"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "Tối"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "Sáng"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "Không có"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "Hình ảnh"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "Pixel"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "Tỷ lệ phần trăm"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "Gốc"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "Thang độ xám"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "Tập tin Truyền thông"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "Bão hòa"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "Bộ lọc Cổ điển"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "Bộ lọc Cổ điển"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "Viết hoa"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "Bình thường"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "In đậm"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "Mặc định"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "Chữ hoa"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "Chữ thường"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4312,14 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks là bộ <strong>khối nội dung giúp xây dựng trang</strong> cho trình biên tập khối WordPress Gutenberg. Các khối của chúng tôi là căn siêu nét để giúp xây dựng các trang phong phú và quyến rũ trong WordPress."
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks là bộ <strong>khối nội dung giúp xây dựng trang</strong> cho trình "
+"biên tập khối WordPress Gutenberg. Các khối của chúng tôi là căn siêu nét để "
+"giúp xây dựng các trang phong phú và quyến rũ trong WordPress."
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4329,170 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "Lừa dối, hở?"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "Để lại đánh giá"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s năm"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "một năm"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s tuần"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "một tuần"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s ngày"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "một ngày"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s giờ"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "một giờ"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s phút"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "một phút"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s giây"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "một giây"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "Trình cắm WordPress %s"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "Bạn có đang tận hưởng %s?"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "Bạn hiện tại đang sử dụng %1$s trong %2$s. Bạn có muốn để lại một đánh giá để cho chúng tôi biết cảm nghĩ của bạn? Chúng tôi rất cảm kích điều đó!"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "Để lại đánh giá"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"Bạn hiện tại đang sử dụng %1$s trong %2$s. Bạn có muốn để lại một đánh giá "
+"để cho chúng tôi biết cảm nghĩ của bạn? Chúng tôi rất cảm kích điều đó!"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "Không, cảm ơn/ Tôi đánh giá rồi"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "Cảm ơn bạn đã sử dụng CoBlocks, trình dựng trang cao cấp dành cho trình biên tập khối WordPress mới."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"Cảm ơn bạn đã sử dụng CoBlocks, trình dựng trang cao cấp dành cho trình biên "
+"tập khối WordPress mới."
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "Bạn vừa thêm nhiều khối hữu dụng và một bộ công cụ trình dựng trang mới cho trình biên tập WordPress. CoBlocks sẽ cung cấp bộ tính năng thay đổi thế cờ : %1$s mười khối%2$s, một %1$s trải nghiệm trình dựng trang %2$s và %1$s kiểm soát sắp kiểu chữ tùy chỉnh %2$s."
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"Bạn vừa thêm nhiều khối hữu dụng và một bộ công cụ trình dựng trang mới cho "
+"trình biên tập WordPress. CoBlocks sẽ cung cấp bộ tính năng thay đổi thế "
+"cờ : %1$s mười khối%2$s, một %1$s trải nghiệm trình dựng trang %2$s và %1$s "
+"kiểm soát sắp kiểu chữ tùy chỉnh %2$s."
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "Đây là một vài video để giúp bạn bắt đầu:"
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "Hãy xem cách tạo trang đầu tiên của bạn với %s"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "Hãy xem cách tạo trang đầu tiên của bạn"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "Hãy xem cách sử dụng các khối hàng và Bộ chia Hình dạng"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "Xem cách sử dụng khối Thẻ Truyền thông"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "Bạn có thích những gì bạn thấy? Vui lòng %1$sĐăng ký kênh YouTube của chúng tôi%2$s và chúng tôi sẽ cho bạn biết khi video hướng dẫn mới được phát hành."
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"Bạn có thích những gì bạn thấy? Vui lòng %1$sĐăng ký kênh YouTube của chúng "
+"tôi%2$s và chúng tôi sẽ cho bạn biết khi video hướng dẫn mới được phát hành."
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "Nếu bạn có bất kỳ câu hỏi hay phản hồi gì, hãy cho chúng tôi biết trên %1$sTwitter%4$s hoặc %2$snhóm Facebook %4$s của chúng tôi. Bên cạnh đó, bạn hãy %3$sđăng ký bản tin của chúng tôi%4$s nếu bạn muốn cập nhật tin tức mới nhất và sắp phát hành tại CoBlocks."
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"Nếu bạn có bất kỳ câu hỏi hay phản hồi gì, hãy cho chúng tôi biết trên "
+"%1$sTwitter%4$s hoặc %2$snhóm Facebook %4$s của chúng tôi. Bên cạnh đó, bạn "
+"hãy %3$sđăng ký bản tin của chúng tôi%4$s nếu bạn muốn cập nhật tin tức mới "
+"nhất và sắp phát hành tại CoBlocks."
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "Hãy dùng và cảm nhận!"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "Hãy bắt đầu với CoBlocks tại đây:"
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4506,27 @@ msgstr "Khóa trang reCaptcha của Google để bảo vệ chống lại thư r
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "Khóa bí mật reCaptcha của Google để bảo vệ chống lại thư rác với mẫu"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "Tên"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "Tên"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "Họ"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "Thư"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "Gửi đi"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "Tin nhắn của bạn đã được gửi:"
 
@@ -3490,3 +4541,85 @@ msgstr "Chia sẻ trên LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "Loại thông báo"
+
+#~ msgid "Edit image"
+#~ msgstr "Sửa ảnh"
+
+#~ msgid "Remove image"
+#~ msgstr "Xóa ảnh"
+
+#~ msgid "Heading..."
+#~ msgstr "Đề mục..."
+
+#~ msgid "Author Name"
+#~ msgstr "Tên tác giả"
+
+#~ msgid "Write biography..."
+#~ msgstr "Viết tiểu sử..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "Thêm tiểu sử tác giả."
+
+#~ msgid "%s Settings"
+#~ msgstr "Cài đặt %s"
+
+#~ msgid "Caption Color"
+#~ msgstr "Màu sắc của chú thích"
+
+#~ msgid "Highlight text."
+#~ msgstr "Văn bản tô sáng."
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "Bảng %s"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "Các cài đặt bảng giá"
+
+#~ msgid "Tables"
+#~ msgstr "Bảng biểu"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "Một cột được đặt bên trong khối bảng giá."
+
+#~ msgid "Sepia"
+#~ msgstr "Màu nâu đỏ"
+
+#~ msgid "Dim"
+#~ msgstr "Mờ"
+
+#~ msgid "Vintage"
+#~ msgstr "Cổ điển"
+
+#~ msgid "Select Orientation"
+#~ msgstr "Chọn Hướng"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "Lề đầu trang bị xóa cho khối này."
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "Bật tắt để xóa bất kỳ lề nào được áp dụng cho đầu khối này."
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "Lề cuối trang bị xóa trên khối này."
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "Bật tắt để xóa bất kỳ lề nào được áp dụng cho cuối khối này."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "Thêm thao tác chính..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "Thêm thao tác phụ..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "Bình thường"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "Hãy bắt đầu với CoBlocks tại đây:"

--- a/languages/coblocks-zh_CN.po
+++ b/languages/coblocks-zh_CN.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "显示打开"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "添加折叠项标题..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "折叠项"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "将可折叠的折叠项添加到折叠组件。"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "选项卡"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "常见问题解答"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "进行切换，将此折叠项设置为默认处于打开状态。"
 msgid "Accordion Item Settings"
 msgstr "折叠项设置"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "显示打开"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "颜色设置"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "背景色"
@@ -103,14 +63,6 @@ msgstr "背景色"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "标题文本颜色"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "添加折叠项"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "折叠组件"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -129,140 +81,76 @@ msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
 msgstr "通过加载一个 JavaScript polyfill 添加对 Internet Explorer 的支持。"
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
 msgstr "通过在此页面上加载一个 JavaScript polyfill 来支持 Internet Explorer。"
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "警告"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "错误"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "警报类型"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "默认"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "信息"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "成功"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "编写标题..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "编写文本..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "提醒"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "提供有上下文的反馈消息。"
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "通知"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "信息"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "文本颜色"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "编辑图片"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "编辑图片库"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "删除图片"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "编写标题..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "拖放添加为头像"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "标题..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "创建者姓名"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "编写传记..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "表单设置"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "创建者"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "添加创建者传记。"
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "传记"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "基本资料"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "按钮"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "利用并排的多个按钮，提示访问者进行操作。"
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "链接"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "cta"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "按钮设置"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "在移动设备上叠放"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "按钮"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +168,25 @@ msgstr "Twitter 用户名"
 msgid "Username"
 msgstr "用户名"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "添加按钮..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "将引用添加到 Tweet..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "单击以推送 Tweet"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "添加引用以供读者通过 Twitter 推送。"
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "分享"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +194,18 @@ msgid "Text Settings"
 msgstr "文本设置"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "按钮颜色"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "动态 HR"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "在其他模块之间添加可调整大小的间隔区。"
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "间隔区"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "动态 HR 设置"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "高度（像素）"
 
@@ -347,17 +217,12 @@ msgstr "动态分隔符元素的高度，以像素为单位。"
 msgid "Color"
 msgstr "颜色"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "添加为背景"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "功能"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "父级功能块内的单一子列。"
 
@@ -366,73 +231,54 @@ msgid "Feature Settings"
 msgstr "功能设置"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "填充"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "功能"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "为您的产品或服务添加最多三列小注释。"
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "服务"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "边距"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "槽宽"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "各列之间的间隔。"
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "小"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "中"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +288,8 @@ msgstr "大"
 msgid "Features Settings"
 msgstr "功能设置"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "列"
 
@@ -455,76 +301,72 @@ msgstr "添加菜单部分"
 msgid "Menu title..."
 msgstr "菜单标题..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "网格"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "列表"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "拖放图片以替换"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "删除图片"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "添加标题..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "辛辣"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "热"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "素食主义者"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "无麸质"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "鱼素者"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "素食"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "添加描述..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "0.00 美元"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "食品项"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "食品与饮料模块内的食品和饮料项。"
 
@@ -560,62 +402,46 @@ msgstr "进行切换，显示此项目的价格。"
 msgid "Item Attributes"
 msgstr "项目属性"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "更辣"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "图片设置"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "Alt Text（替代文本）"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "描述该图片的用途"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "如果图片只是装饰用途，则保持空白。"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "焦点"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "食品和饮料"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "显示菜单或价目表。"
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "餐厅"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "菜单"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "样式"
@@ -648,134 +474,84 @@ msgstr "显示各项目的价格"
 msgid "Toggle to show the price of each item."
 msgstr "进行切换，显示各项目的价格。"
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "电子邮件"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "电子邮件"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "邮件"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "电子邮件地址字段。"
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "信息"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "文本区域"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "多行文本"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "用于较长回复内容的文本框。"
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s 不是有效的电子邮件地址。"
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s 和 %s 不是有效的电子邮件地址。"
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s 不是有效的电子邮件地址。"
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "电子邮件地址"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "主题"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "表单设置"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
 msgstr "添加您的 reCAPTCHA 网站密钥和密钥，保护您的表单不受垃圾数据侵扰。"
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "生成密钥"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "我的密钥"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "获取帮助"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "网站密钥"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "密钥"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "正在保存"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "保存"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "删除"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "首页"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "最后一页"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "名称"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "用于名称的文本字段。"
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "电子邮件地址字段。"
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "添加标签..."
 
@@ -783,41 +559,38 @@ msgstr "添加标签..."
 msgid "Required"
 msgstr "必填"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "名称字段设置"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "姓氏"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "同时显示名字和姓氏字段。"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "进行切换，添加姓氏字段。"
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "表单"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "用于名称的文本字段。"
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "用于较长回复内容的文本框。"
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "将一个简单表单添加到您的页面。"
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "电子邮件"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "关于"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "联系人"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "主题"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +600,217 @@ msgstr "添加文本…"
 msgid "Button Text Color"
 msgstr "按钮文本颜色"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "编辑图片库"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "滚动"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "图片库中的第 %1$d 张图片（共 %2$d 张）"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "编写标题..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "滚动"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "显示精美的滚动图片库中的多张图片。"
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "图片库"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "照片"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s 设置"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "线高度"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "显示圆点导航箭头。"
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "进行切换，显示媒体标题。"
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "颜色设置"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "大小"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "圆角"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "标题颜色"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "应用"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "砖石布局"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "编写描述..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "显示有条理的砖石布局图片库中的多张图片。"
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "显示精美的滚动图片库中的多张图片。"
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "列大小"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "图片设置"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "将圆角添加到图片库项目。"
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "阴影"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "标题"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "标题样式"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "显示各个媒体项的标题。"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "进行切换，显示媒体标题。"
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "砖石布局"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "显示有条理的砖石布局图片库中的多张图片。"
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "进行切换，启用地图控制选项。"
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "地图设置"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "列大小"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "将圆角添加到图片库项目。"
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "轻型"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "堆叠"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "显示单列叠放图片库中的多张图片。"
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "全宽图片"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "全宽图片"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "方框阴影"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "全宽图片已启用。"
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
 msgstr "进行切换，用全宽图片完全填充可用的图片库区域。"
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "项目设置"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "全宽图片"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "全宽图片"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "删除 gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "此 gif 具有空白 alt 属性"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "在 Giphy 上搜索完美 gif"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "搜索 gif"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "选取 gif，任何 gif。"
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "动画"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +836,11 @@ msgstr "GitHub 文件"
 msgid "File"
 msgstr "文件"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "查看 GitHub 上的此 gist"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist URL"
 
@@ -1024,12 +853,9 @@ msgid "Loading Gist"
 msgstr "正在加载 Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "通过添加 gist 链接嵌入 GitHub gist。"
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "代码"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +878,157 @@ msgid "Gist Meta"
 msgstr "Gist Meta"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "更改布局"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "将背景添加到 %s"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "首页"
-
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
 msgstr "一个页面的介绍性区域，配有少量文字和行动号召。"
 
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "按钮"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "行动号召"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "内容宽度（像素）"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "首页设置"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "容器内部空间。"
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "左上方"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "中上方"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "右上方"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "左中部"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "正中部"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "右中部"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "左下方"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "中下方"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "右下方"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "添加突出显示的文本..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "高光"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "突出显示文本。"
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "文本"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "段落"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "图标"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "添加特定风格的图形符号，以传达更多信息。"
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "图标"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "巨大"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "添加特定风格的图形符号，以传达更多信息。"
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "图标设置"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "关闭高级 %s 设置"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "重置"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "自定义 %s 大小"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "高级 %s 设置"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "自定义"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "高级"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "半径"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "图标搜索"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "未找到结果。"
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "链接设置"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "链接 URL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "链接 Rel"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "在新选项卡中打开"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "在新选项卡中打开"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "图标颜色"
 
@@ -1261,30 +1037,17 @@ msgid "Edit logos"
 msgstr "编辑徽标"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "徽标和徽章"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr "拖放图片、上传新图片或从您的库中选择文件。"
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "添加徽标、徽章或证书，以建立信誉。"
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "客户"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "证明"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "感言"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1069,138 @@ msgstr "编辑地点"
 msgid "Map style"
 msgstr "地图样式"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "无效 API 密钥，或请求太多"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google 地图"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "输入地点或地址，在 Google 地图上放一个大头针。"
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "搜索地方或地址…"
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "应用"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "地图"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "添加地址并在 Google 地图上放一个大头针。"
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "地址"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "地图"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "选择地图样式"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "地图设置"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "缩放级别"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "地图的高度，以像素为单位"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "缩放级别"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "标记大小"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "精细控制选项已启用。"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "进行切换，启用地图控制选项。"
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "地图控件"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "地图类型"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "启用在标准地图和卫星地图视图之间切换。"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "进行切换，启用在标准地图和卫星地图之间切换。"
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "缩放控件"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "显示地图缩放控件。"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "进行切换，启用通过缩放控件放大和缩小地图。"
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "街景视图"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "显示街景视图地图控件。"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "进行切换，在右下方显示街景视图控件。"
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "全屏切换"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "显示全屏地图控件。"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "进行切换，显示全屏地图控件。"
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google 地图 API 密钥"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "添加您的 Google 地图 API 密钥。更新此 API 密钥将会设置您的所有地图使用新密钥。"
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"添加您的 Google 地图 API 密钥。更新此 API 密钥将会设置您的所有地图使用新密"
+"钥。"
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "获取您的密钥"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "需要帮助？"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "输入 Google API 密钥…"
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "已保存"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "标准"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "银色"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "质璞复古"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "暗黑"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "夜晚"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "紫红色"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1210,9 @@ msgstr "媒体在右侧"
 msgid "Media on left"
 msgstr "媒体在左侧"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "媒体卡"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "使用并排胶印卡添加图片或视频。"
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "图片"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "视频"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1226,18 @@ msgstr "显示卡阴影。"
 msgid "Toggle to add a card shadow."
 msgstr "进行切换，添加卡阴影。"
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s 阴影"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "显示 %s 阴影。"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "进行切换，添加 %s 阴影"
 
@@ -1545,40 +1261,171 @@ msgstr "拖放以替换媒体"
 msgid "Edit media"
 msgstr "编辑媒体"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s 表格"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist URL"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "套餐 %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "滚动"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist URL"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "颜色设置"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "显示此项目的价格。"
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "进行切换，显示 gist 元数据。"
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "显示行动号召按钮。"
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "进行切换，显示 gist 元数据。"
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "功能设置"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "媒体在左侧"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "媒体在右侧"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "列大小"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gist 设置"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "价目表"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "价目表"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "价目表"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "价目表"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "添加价目表。"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "登陆"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "套餐 %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "比较"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "价目表设置"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "表格"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1443,169 @@ msgstr "套餐 A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "价目表项"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "放在价目表模块内的一列。"
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "将背景添加到 %s"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "列"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "一行的直接子级。"
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "宽度"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "列设置"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "容器周围的空间。"
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "宽度"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "更改布局"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "一"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "二"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "三"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "四"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "将背景添加到 %s"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "一列"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "两列"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "三列"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "四列"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "行布局"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "行"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "现在为此 %s 列的行选择一种布局。"
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "选择此行的列数。"
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "选择行列数"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "选择行布局"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "返回到列"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
 msgstr "为列模块添加结构化的包装器，然后将所需内容模块添加到列。"
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "行"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "列"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "布局"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "布局"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "行设置"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "无"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1615,9 @@ msgstr "方形"
 msgid "Circle"
 msgstr "圆形"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "服务"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "添加最多四列要显示的服务。"
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "功能"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1639,7 @@ msgstr "显示行动号召按钮。"
 msgid "Toggle to show call to action buttons."
 msgstr "进行切换，显示行动号召按钮。"
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "服务"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "服务模块内的一个服务项目。"
 
@@ -1785,264 +1660,227 @@ msgid "Toggle to show a call to action button."
 msgstr "进行切换，显示行动号召按钮。"
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "水平翻转"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "垂直翻转"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "形状分割器"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "添加形状分割器，直观地分割页面各部分。"
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "分隔符"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "形状颜色"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "分割器设置"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "形状高度（像素）"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "背景高度（像素）"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "方向"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "形状颜色"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "在 Twitter 上分享"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "在 Facebook 上分享"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "在 Twitter 上分享"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "在 Pinterest 上分享"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "在 LinkedIn 上分享"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "通过电子邮件分享"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "在 Tumblr 上分享"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "在 Google 上分享"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "在 Reddit 上分享"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "分享"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "社交"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
 msgstr "添加社交分享链接，帮助您获得链接和分享。"
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "社交颜色"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "图标大小"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "圆形大小"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "按钮大小"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "图标"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "电子邮件"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "分享按钮颜色已启用。"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
 msgstr "进行切换，使用各个社交媒体平台的官方颜色。"
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "社交颜色"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "添加 Facebook 个人资料"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "添加 Twitter 个人资料"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "添加 Instagram 个人资料"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "添加 Pinterest 个人资料"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "添加 LinkedIn 个人资料"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "添加 YouTube 个人资料"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "添加 Yelp 个人资料"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "添加 Houzz 个人资料"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "社交档案"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "链接"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "显示社交媒体档案页链接。"
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "个人资料链接"
 
@@ -2057,18 +1895,6 @@ msgstr "删除背景"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "背景"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "汽车机械"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "封面"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "包含"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1952,6 @@ msgstr "删除背景"
 msgid "Remove "
 msgstr "删除 "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "不重复"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "水平重复"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "垂直重复"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "向后移动图片"
@@ -2150,17 +1964,14 @@ msgstr "向前移动图片"
 msgid "Link To"
 msgstr "链接到"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s 图片库"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "上传图片"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "轻型"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +1985,110 @@ msgstr "附件页面"
 msgid "Custom URL"
 msgstr "自定义 URL"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "像素"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "方向"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "百分比"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "重置"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "选择单位"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s 个单位"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "关闭高级 %s 设置"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "%s 顶部"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "%s 右侧"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "%s 底部"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "%s 左侧"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "不同步"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "同步"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "同步单位"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "顶部"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "右侧"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "底部"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "左侧"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "高级 %s 设置"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "高级"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "默认"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "布局"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2107,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "进行切换，启用全屏模式。"
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "标题 %d"
@@ -2263,43 +2116,16 @@ msgstr "标题 %d"
 msgid "Custom color picker"
 msgstr "自定义颜色选择器"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "原始"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "灰阶"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "深褐色"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "饱和度"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "暗淡"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "复古"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "应用滤镜"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "选择方向"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "高度"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "移动 %s"
@@ -2333,7 +2159,8 @@ msgid "Five Seconds"
 msgstr "五秒"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "六秒"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2179,22 @@ msgstr "九秒"
 msgid "Ten Seconds"
 msgstr "十秒"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "箭头导航"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "圆点导航"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "秒"
@@ -2361,21 +2204,25 @@ msgid "second"
 msgstr "秒"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "%1$d %2$s 之后前进。"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "自动前进到下一张幻灯片。"
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "在台式和移动设备上启用了拖动和翻阅。"
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
 msgstr "进行切换，在台式和移动设备上启用拖动功能。"
 
 #: src/components/slider-panel/index.js:35
@@ -2387,44 +2234,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "进行切换，显示幻灯片导航箭头。"
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "显示圆点导航箭头。"
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "进行切换，显示圆点导航。"
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "容器内部空间。"
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "进行切换，使视频静音。"
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "进行切换，循环播放视频。"
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "幻灯片设置"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "自动播放"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "过渡速度"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "可拖动"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "箭头导航"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "圆点导航"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "首字母大写"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "普通"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2321,6 @@ msgstr "无底部间距"
 msgid "Change typography"
 msgstr "更改排版"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "粗体"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "大写字母"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "小写字母"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "在移动设备上叠放"
@@ -2487,25 +2337,29 @@ msgstr "进行切换，在较小检视区的顶部相互重叠地堆放元素。
 msgid "Remove Top Spacing"
 msgstr "移除顶部间距"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "移除在此模块上的顶部边距。"
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "进行切换，添加卡阴影。"
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "进行切换，移除应用于此模块顶部的任何边距。"
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "进行切换，显示圆点导航。"
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "移除底部间距"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "移除在此模块上的底部边距。"
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "进行切换，添加卡阴影。"
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "进行切换，移除应用于此模块底部的任何边距。"
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "进行切换，显示圆点导航。"
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2373,14 @@ msgstr "显示为全宽。"
 msgid "Toggle to display button as full width."
 msgstr "进行切换，将按钮显示为全宽。"
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "圆形"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "首页设置"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "阴影"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "复选框"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "大写字母"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2406,793 @@ msgstr "此模块已添加到页面，目前无法禁用"
 msgid "Disable all"
 msgstr "全部禁用"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "未找到“%s”模块。"
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s 图片库"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "显示打开"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "添加折叠项标题..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "折叠项"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "选项卡"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "常见问题解答"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "通知"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "信息"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "传记"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "基本资料"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "链接"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "cta"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "分享"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "间隔区"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "服务"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "菜单"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "餐厅"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "电子邮件"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "邮件"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "姓氏"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "文本区域"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "多行文本"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "电子邮件"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "关于"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "联系人"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "图片库"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "照片"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "夜晚"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "动画"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "代码"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "按钮"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "行动号召"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "文本"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "段落"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "图标"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "客户"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "证明"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "感言"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "地址"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "地图"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "图片"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "视频"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "地址"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "登陆"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "比较"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "行"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "列"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "布局"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "功能"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "分隔符"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "社交"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "链接"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "显示打开"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "添加折叠项"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "折叠组件"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "编写文本..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "编写标题..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "提醒"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "创建者"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "按钮"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "单击以推送 Tweet"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "动态 HR"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "功能"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "功能"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "食品项"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "食品和饮料"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "电子邮件"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "名称"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "信息"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "表单"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "滚动"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "砖石布局"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "堆叠"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist URL"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "首页"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "高光"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "图标"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "徽标和徽章"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "地图"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "媒体卡"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "滚动"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "价目表"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "价目表项"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "列"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "行"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "服务"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "服务"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "形状分割器"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "分享"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "社交档案"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "信息"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "成功"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "警告"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "错误"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "点"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "线"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "全宽"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "网格"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "列表"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "默认"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "层"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "轮廓"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "填充"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "堆叠"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "水平重复"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "波纹"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "山丘"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "波浪"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "有角"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "倾斜"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "圆润"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "三角"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "点状"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "掩饰"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "图标"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "文本"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "图标和文本"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "圆形"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "左下方"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "左上方"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "拖放添加为头像"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "创建者"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3214,28 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "这是可用来突出显示功能的功能块。"
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "添加首页标题..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
 msgstr "添加首页内容，通常是页面的介绍性区域，配有行动号召或两个。"
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "添加主要行动..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "添加辅助行动..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3254,125 @@ msgstr "添加内容..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "将此文本替换为与卡图片相配的描述性副本。然后向此卡中添加更多模块，如按钮、列表或图片。"
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"将此文本替换为与卡图片相配的描述性副本。然后向此卡中添加更多模块，如按钮、列"
+"表或图片。"
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "编写标题..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "编写描述..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "普通"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "按钮设置"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "自定义"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "在移动设备上叠放"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "动态 HR 设置"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "无"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "无"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "小"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "中"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "大"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "超大"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "无"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "小"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "中"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "大"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,7 +3891,9 @@ msgstr "音乐 麦克风 歌曲 艺术家 创意 媒体 音频"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
 msgstr "麦克风 播客 计算机 设备 音乐 麦克风 歌曲 艺术家 创意 媒体 音频"
 
 #: src/blocks/icon/svgs.js:49
@@ -3284,7 +3918,9 @@ msgstr "电影 摄像 导演 制片人 媒体 创意"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
 msgstr "视频 摄像 导演 制片人 媒体 创意 相机 摄影师 摄影 光圈"
 
 #: src/blocks/icon/svgs.js:85
@@ -3302,12 +3938,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "调色板 设计 颜色 艺术家 创意 媒体 绘画 画笔"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "标准"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "银色"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "质璞复古"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "暗黑"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "夜晚"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "紫红色"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "圆形"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "阴影"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "默认"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "无"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "复选框"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "菜单标题..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "小"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "中"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "大"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "超大"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "汽车机械"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "封面"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "包含"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "左上方"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "中上方"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "右上方"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "左中部"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "正中部"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "右中部"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "左下方"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "中下方"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "右下方"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "不重复"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "重复"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "水平重复"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "垂直重复"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "链接 Rel"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "暗黑"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "轻型"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "无"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "图片"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "像素"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "百分比"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "原始"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "灰阶"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "媒体文件"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "饱和度"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "复古滤镜"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "复古滤镜"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "首字母大写"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "普通"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "粗体"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "默认"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "大写字母"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "小写字母"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4286,14 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks 是用于 WordPress Gutenberg 模块编辑器的一套专业<strong>网页构建内容模块</strong>。我们的模块侧重点是让制作者能够在 WordPress 中构建内容丰富的精美页面。"
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks 是用于 WordPress Gutenberg 模块编辑器的一套专业<strong>网页构建内容"
+"模块</strong>。我们的模块侧重点是让制作者能够在 WordPress 中构建内容丰富的精"
+"美页面。"
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4303,165 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "作弊啊？"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "留下评论"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s 年"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "一年"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s 周"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "一周"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s 天"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "一天"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s 小时"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "一小时"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s 分钟"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "一分钟"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s 秒"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "一秒"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPress 插件"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "喜欢 %s 吗？"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "现在您已经使用 %1$s %2$s 了。是否介意留下评论，让我们知道您是怎么想的？我们将万分感谢！"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "留下评论"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"现在您已经使用 %1$s %2$s 了。是否介意留下评论，让我们知道您是怎么想的？我们将"
+"万分感谢！"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "不，谢谢/我已经有了"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
 msgstr "感谢您选择 CoBlocks，适用于新 WordPress 模块编辑器的首要页面构建器。"
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "我们刚向 WordPress 编辑器中添加了很多有用的模块和一个新的页面构建工具包。CoBlocks 为您提供一组颠覆性的功能：%1$s几十个模块%2$s、%1$s页面构建器体验%2$s和%1$s自定义排版控制%2$s。"
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"我们刚向 WordPress 编辑器中添加了很多有用的模块和一个新的页面构建工具包。"
+"CoBlocks 为您提供一组颠覆性的功能：%1$s几十个模块%2$s、%1$s页面构建器体验%2$s"
+"和%1$s自定义排版控制%2$s。"
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "这里有一些视频，可帮助您入门："
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "观看如何使用 %s 创建您的第一个网页"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "观看如何创建您的第一个网页"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "观看如何使用行和形状分割器模块"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "观看如何使用媒体卡模块"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "喜欢吗？%1$s订阅我们的 YouTube 频道%2$s，当发布新的视频教程时，我们会通知您。"
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"喜欢吗？%1$s订阅我们的 YouTube 频道%2$s，当发布新的视频教程时，我们会通知您。"
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "如果您有任何问题或反馈，请通过 %1$sTwitter%4$s 或我们的 %2$sFacebook 群组%4$s告诉我们。另外，如果您想跟上 CoBlocks 的新功能，掌握最新情况，请%3$s订阅我们的内部通讯%4$s。"
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"如果您有任何问题或反馈，请通过 %1$sTwitter%4$s 或我们的 %2$sFacebook 群组%4$s"
+"告诉我们。另外，如果您想跟上 CoBlocks 的新功能，掌握最新情况，请%3$s订阅我们"
+"的内部通讯%4$s。"
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "祝使用愉快！"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "从这里开始使用 CoBlocks："
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4475,27 @@ msgstr "用于表单垃圾防护的 Google reCaptcha 网站密钥"
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "用于表单垃圾防护的 Google reCaptcha 密钥"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "名称"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "首页"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "最后一页"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "信息"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "提交"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "您的消息已发送："
 
@@ -3490,3 +4510,85 @@ msgstr "在 Linkedin 上分享"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "Linkedin"
+
+#~ msgid "Alert Type"
+#~ msgstr "警报类型"
+
+#~ msgid "Edit image"
+#~ msgstr "编辑图片"
+
+#~ msgid "Remove image"
+#~ msgstr "删除图片"
+
+#~ msgid "Heading..."
+#~ msgstr "标题..."
+
+#~ msgid "Author Name"
+#~ msgstr "创建者姓名"
+
+#~ msgid "Write biography..."
+#~ msgstr "编写传记..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "添加创建者传记。"
+
+#~ msgid "%s Settings"
+#~ msgstr "%s 设置"
+
+#~ msgid "Caption Color"
+#~ msgstr "标题颜色"
+
+#~ msgid "Highlight text."
+#~ msgstr "突出显示文本。"
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s 表格"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "价目表设置"
+
+#~ msgid "Tables"
+#~ msgstr "表格"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "放在价目表模块内的一列。"
+
+#~ msgid "Sepia"
+#~ msgstr "深褐色"
+
+#~ msgid "Dim"
+#~ msgstr "暗淡"
+
+#~ msgid "Vintage"
+#~ msgstr "复古"
+
+#~ msgid "Select Orientation"
+#~ msgstr "选择方向"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "移除在此模块上的顶部边距。"
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "进行切换，移除应用于此模块顶部的任何边距。"
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "移除在此模块上的底部边距。"
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "进行切换，移除应用于此模块底部的任何边距。"
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "添加主要行动..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "添加辅助行动..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "普通"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "从这里开始使用 CoBlocks："

--- a/languages/coblocks-zh_TW.po
+++ b/languages/coblocks-zh_TW.po
@@ -3,41 +3,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr "顯示開啟"
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr "新增折疊式功能表標題..."
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr "折疊式功能表項目"
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
 msgstr "在折疊式功能表內新增可收合的折疊式功能表項目。"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr "標籤"
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
-msgstr "常見問題"
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
 msgid "Accordion item is open by default."
@@ -51,51 +30,32 @@ msgstr "切換此選項即可將此折疊式功能表項目設為預設開啟。
 msgid "Accordion Item Settings"
 msgstr "折疊式功能表項目設定"
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr "顯示開啟"
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
-#: src/blocks/alert/inspector.js:49
+#: src/blocks/alert/inspector.js:49 src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
-#: src/blocks/features/inspector.js:173
-#: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
-#: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/features/inspector.js:173 src/blocks/form/submit-button.js:118
+#: src/blocks/hero/inspector.js:137 src/blocks/highlight/inspector.js:43
+#: src/blocks/icon/inspector.js:302 src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165 src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92 src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr "色彩設定"
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55 src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
-#: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
-#: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/features/inspector.js:191 src/blocks/hero/inspector.js:150
+#: src/blocks/highlight/inspector.js:49 src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171 src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103 src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr "背景色彩"
@@ -103,14 +63,6 @@ msgstr "背景色彩"
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
 msgstr "標題文字色彩"
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr "新增折疊式功能表項目"
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
-msgstr "折疊式功能表"
 
 #: src/blocks/accordion/index.js:28
 msgid "Organize content within collapsable accordion items."
@@ -129,140 +81,76 @@ msgid "Add support for Internet Explorer by loading a JavaScript polyfill."
 msgstr "載入 JavaScript polyfill，以便新增 Internet Explorer 支援功能。"
 
 #: src/blocks/accordion/inspector.js:31
-msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
+msgid ""
+"Supporting Internet Explorer by loading a JavaScript polyfill on this page."
 msgstr "在此頁面載入 JavaScript polyfill，以便支援 Internet Explorer。"
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
-msgstr "警告"
-
-#: src/blocks/alert/controls.js:111
-msgid "Error"
-msgstr "錯誤"
-
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
-msgstr "警示類型"
-
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr "預設"
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr "資訊"
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr "成功"
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr "撰寫標題..."
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr "撰寫文字..."
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr "警告"
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
+#: src/blocks/alert/index.js:29
+#, fuzzy
+msgid "Provide contextual feedback messages or notices."
 msgstr "詳細提供回饋訊息。"
 
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr "通知"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
+msgstr ""
 
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr "訊息"
+#: src/blocks/alert/index.js:46
+msgid ""
+"An alert is a message that displays outside the flow of typical content. "
+"Alerts provide contextual feedback, typically asking readers to take an "
+"action."
+msgstr ""
 
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60 src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
-#: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/features/inspector.js:195 src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176 src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66 src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr "文字色彩"
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
-msgstr "編輯圖片"
+#: src/blocks/author/controls.js:36
+#, fuzzy
+msgid "Edit avatar"
+msgstr "編輯圖庫"
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
-msgstr "移除圖片"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+#, fuzzy
+msgid "Write author name…"
+msgstr "撰寫標題..."
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
-msgstr "拖曳至此即可新增為頭像"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid ""
+"Write a biography that distills objective credibility and authority to your "
+"readers…"
+msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
-msgstr "標題..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
+msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
-msgstr "作者名稱"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
+msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
-msgstr "撰寫自傳..."
+#: src/blocks/author/inspector.js:41
+#, fuzzy
+msgid "Author Settings"
+msgstr "表格設定"
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr "作者"
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr "新增作者自傳。"
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr "自傳"
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr "個人檔案"
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr "按鈕"
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr "一對一引導使用者操作多種按鈕。"
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr "連結"
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr "行動呼籲"
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr "按鈕設定"
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
-msgstr "在行動裝置上堆疊"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
+msgstr "按鈕"
 
 #: src/blocks/buttons/inspector.js:48
 msgid "Stacking buttons on mobile."
@@ -280,31 +168,25 @@ msgstr "Twitter 使用者名稱"
 msgid "Username"
 msgstr "使用者名稱"
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr "新增按鈕..."
 
 # the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr "在推文內新增引言..."
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr "按一下即可發出"
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr "新增可讓讀者透過 Twitter 推文的引言。"
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr "分享"
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
-msgstr "Twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid ""
+"The easiest way to promote and advertise your blog, website, and business on "
+"Twitter."
+msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
 #: src/blocks/highlight/inspector.js:35
@@ -312,30 +194,18 @@ msgid "Text Settings"
 msgstr "文字設定"
 
 #: src/blocks/click-to-tweet/inspector.js:71
-#: src/blocks/form/submit-button.js:127
+#: src/blocks/form/submit-button.js:127 src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr "按鈕色彩"
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr "動態水平線"
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr "在其他區塊之間插入可調整大小的空白區域。"
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr "空白區域"
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr "動態水平線設定"
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108 src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr "高度 (像素)"
 
@@ -347,17 +217,12 @@ msgstr "動態分隔元素高度 (像素)"
 msgid "Color"
 msgstr "色彩"
 
-#: src/blocks/features/edit.js:78
-#: src/blocks/features/feature/edit.js:63
+#: src/blocks/features/edit.js:78 src/blocks/features/feature/edit.js:63
 #: src/blocks/media-card/edit.js:173
 msgid "Add as backround"
 msgstr "新增為背景"
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr "功能"
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr "在母功能區塊下的單一子欄。"
 
@@ -366,73 +231,54 @@ msgid "Feature Settings"
 msgstr "功能設定"
 
 #: src/blocks/features/feature/inspector.js:71
-#: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
-#: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/features/inspector.js:143 src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217 src/blocks/media-card/inspector.js:62
+#: src/blocks/row/column/inspector.js:133 src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr "邊框間距"
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr "功能"
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr "為您的產品或服務新增最多三個欄。"
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr "服務"
-
-#: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/features/inspector.js:122 src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr "邊界"
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91 src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr "裝訂邊"
 
-#: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/features/inspector.js:167 src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr "欄間距"
 
-#: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
-#: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/features/inspector.js:86 src/blocks/icon/icon-size-select.js:16
+#: src/blocks/row/inspector.js:99 src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr "小"
 
-#: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
-#: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/features/inspector.js:87 src/blocks/icon/icon-size-select.js:21
+#: src/blocks/row/inspector.js:100 src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr "中"
 
-#: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
-#: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/features/inspector.js:88 src/blocks/icon/icon-size-select.js:26
+#: src/blocks/row/inspector.js:101 src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -442,8 +288,8 @@ msgstr "大"
 msgid "Features Settings"
 msgstr "功能設定"
 
-#: src/blocks/features/inspector.js:96
-#: src/blocks/services/inspector.js:69
+#: src/blocks/features/inspector.js:96 src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110 src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr "欄"
 
@@ -455,76 +301,72 @@ msgstr "新增選單區段"
 msgid "Menu title..."
 msgstr "選單標題..."
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr "方格"
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr "清單"
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr "拖曳圖片即可取代"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr "移除圖片"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr "新增標題..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr "辣味"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr "熱"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
 msgstr "蔬食"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
+#: src/blocks/food-and-drinks/food-item/edit.js:324
+#: src/blocks/food-and-drinks/food-item/inspector.js:50
+#: src/blocks/food-and-drinks/food-item/save.js:98
 msgid "Gluten Free"
 msgstr "無麩質"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:324
-#: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr "魚素"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr "純素"
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr "新增說明..."
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr "US$0.00"
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr "食品項目"
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr "「餐飲」區塊內的餐飲項目。"
 
@@ -560,62 +402,46 @@ msgstr "切換此選項即可顯示此項目的價格。"
 msgid "Item Attributes"
 msgstr "項目屬性"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr "較辣"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr "圖片設定"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
-#: src/blocks/gif/inspector.js:31
-#: src/blocks/media-card/inspector.js:95
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
+#: src/blocks/gif/inspector.js:31 src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr "所有文字 (替代文字)"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
-#: src/blocks/gif/inspector.js:37
-#: src/blocks/media-card/inspector.js:101
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
+#: src/blocks/gif/inspector.js:37 src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr "說明圖片用途"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
-#: src/blocks/gif/inspector.js:39
-#: src/blocks/media-card/inspector.js:103
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/gif/inspector.js:39 src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr "如果這個圖片只有裝飾功能，請將其留白。"
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr "焦點"
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr "餐飲"
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr "顯示選單或價目表。"
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr "餐廳"
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr "選單"
-
-#: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/food-and-drinks/inspector.js:26 src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187 src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr "樣式"
@@ -648,134 +474,84 @@ msgstr "顯示每個項目的價格"
 msgid "Toggle to show the price of each item."
 msgstr "切換此選項即可顯示每個項目的價格。"
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr "email"
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr "e-mail"
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr "郵件"
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr "email 地址欄位。"
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr "訊息"
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr "文字區域"
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr "多行文字"
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr "可容納較長回應的文字方塊。"
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr "%s 並非有效的 email 地址。"
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr "%s 及 %s 並非有效的 email 地址。"
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr "%s 並非有效的 email 地址。"
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr "email 地址"
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr "主旨"
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr "表格設定"
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr "Google reCAPTCHA"
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
 msgstr "新增您的 reCAPTCHA 網站及祕密金鑰，以便防止您的表單收到垃圾訊息。"
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr "產生金鑰"
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr "我的金鑰"
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr "取得說明"
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr "網站金鑰"
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr "秘密金鑰"
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323 src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr "正在儲存"
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323 src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr "儲存"
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338 src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr "移除"
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr "名"
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr "姓"
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr "姓名"
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
-msgstr "填寫姓名的文字欄位。"
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
+msgstr "email 地址欄位。"
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr "新增標籤..."
 
@@ -783,41 +559,38 @@ msgstr "新增標籤..."
 msgid "Required"
 msgstr "必填"
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr "姓名欄位設定"
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr "姓氏"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr "顯示姓氏與名字欄位。"
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr "切換此選項後即可新增姓氏欄位。"
 
-#: src/blocks/form/index.js:25
-msgid "Form"
-msgstr "表格"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr "填寫姓名的文字欄位。"
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
+msgstr "可容納較長回應的文字方塊。"
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr "在頁面上新增簡易表格。"
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr "email"
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr "關於"
-
-#: src/blocks/form/index.js:29
-msgid "contact"
-msgstr "聯絡人"
+#: src/blocks/form/index.js:36
+#, fuzzy
+msgid "Subject example"
+msgstr "主旨"
 
 #: src/blocks/form/submit-button.js:107
 msgid "Add text…"
@@ -827,159 +600,217 @@ msgstr "新增文字..."
 msgid "Button Text Color"
 msgstr "按鈕文字色彩"
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr "編輯圖庫"
 
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr "浮動切換"
+
 # %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr "圖片 %1$d，圖庫內共有 %2$d 張"
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376 src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr "撰寫標題..."
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr "浮動切換"
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr "用美觀的浮動切換圖庫顯示多張圖片。"
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr "圖庫"
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
-msgstr "相片"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
+msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
-msgstr "%s 設定"
+#, fuzzy
+msgid "Responsive Height"
+msgstr "線條高度"
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Showing thumbnail navigation."
+msgstr "顯示點狀導覽箭頭。"
+
+#: src/blocks/gallery-carousel/inspector.js:40
+#, fuzzy
+msgid "Toggle to show thumbnails."
+msgstr "切換此選項即可顯示媒體標題。"
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+#, fuzzy
+msgid "Carousel Settings"
+msgstr "色彩設定"
+
+#: src/blocks/gallery-carousel/inspector.js:71 src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr "大小"
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95 src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr "圓角"
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
-msgstr "標題色彩"
+#: src/blocks/gallery-collage/edit.js:174 src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
+msgstr "套用"
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
-msgstr "並列"
+#: src/blocks/gallery-collage/edit.js:183
+#, fuzzy
+msgid "Write caption..."
+msgstr "撰寫說明..."
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
-msgstr "用整齊的並列圖庫顯示多張圖片。"
+#: src/blocks/gallery-collage/index.js:34
+#, fuzzy
+msgid "Assemble images into a beautiful collage gallery."
+msgstr "用美觀的浮動切換圖庫顯示多張圖片。"
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
-msgstr "欄大小"
+#: src/blocks/gallery-collage/inspector.js:105
+#, fuzzy
+msgid "Collage Settings"
+msgstr "圖片設定"
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
-msgstr "將圖庫項目設為圓角。"
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
+msgstr "陰影"
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr "標題"
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr "標題樣式"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr "顯示每個媒體項目的標題。"
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr "切換此選項即可顯示媒體標題。"
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr "並列"
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr "用整齊的並列圖庫顯示多張圖片。"
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+#, fuzzy
+msgid "Toggle to enable the image lightbox."
+msgstr "切換此選項即可啟用地圖控制選項。"
+
+#: src/blocks/gallery-masonry/inspector.js:73
+#, fuzzy
+msgid "Masonry Settings"
+msgstr "地圖設定"
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr "欄大小"
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr "將圖庫項目設為圓角。"
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+#, fuzzy
+msgid "Lightbox"
+msgstr "明亮"
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr "堆疊"
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr "在單一欄的堆疊圖庫內顯示多張圖片。"
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr "滿版圖片"
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr "滿版圖片"
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr "方塊陰影"
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr "已啟用滿版圖片。"
 
-#: src/blocks/gallery-stacked/inspector.js:51
-msgid "Toggle to fill the available gallery area with completely fullwidth images."
+#: src/blocks/gallery-stacked/inspector.js:48
+msgid ""
+"Toggle to fill the available gallery area with completely fullwidth images."
 msgstr "切換此選項即可以完全滿版的圖片填滿可用圖庫空間。"
+
+#: src/blocks/gallery-stacked/inspector.js:80
+#, fuzzy
+msgid "Stacked Settings"
+msgstr "項目設定"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr "滿版圖片"
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
+msgstr "滿版圖片"
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr "移除 gif"
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr "此 gif 無 alt 屬性"
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr "前往 Giphy 搜尋完美的 gif"
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr "搜尋 gif"
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
 msgstr "任選 gif，什麼 gif 都沒問題。"
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
-msgstr "動畫"
 
 #: src/blocks/gif/inspector.js:29
 msgid "Gif Settings"
@@ -1005,13 +836,11 @@ msgstr "GitHub 檔案"
 msgid "File"
 msgstr "檔案"
 
-#: src/blocks/gist/deprecated.js:30
-#: src/blocks/gist/save.js:29
+#: src/blocks/gist/deprecated.js:30 src/blocks/gist/save.js:29
 msgid "View this gist on GitHub"
 msgstr "前往 GitHub 檢視此 Gist"
 
-#: src/blocks/gist/edit.js:124
-#: src/blocks/gist/inspector.js:51
+#: src/blocks/gist/edit.js:124 src/blocks/gist/inspector.js:51
 msgid "Gist URL"
 msgstr "Gist 網址"
 
@@ -1024,12 +853,9 @@ msgid "Loading Gist"
 msgstr "載入 Gist"
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
+#, fuzzy
+msgid "Embed GitHub gists by adding a gist link."
 msgstr "新增此 Gist 連結即可嵌入 GitHub Gist。"
-
-#: src/blocks/gist/index.js:31
-msgid "code"
-msgstr "代碼"
 
 #: src/blocks/gist/inspector.js:31
 msgid "Showing gist meta data."
@@ -1052,207 +878,157 @@ msgid "Gist Meta"
 msgstr "Gist 中繼資料"
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr "變更版面"
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add backround to hero"
 msgstr "為 %s 新增背景"
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr "首頁"
-
-#: src/blocks/hero/index.js:43
-msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
+#: src/blocks/hero/index.js:41
+msgid ""
+"An introductory area of a page accompanied by a small amount of text and a "
+"call to action."
 msgstr "頁面的介紹區域，有少量的文字和行動呼籲。"
 
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr "按鈕"
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr "行動呼籲"
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr "內容寬度 (像素)"
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr "主頁設定"
 
-#: src/blocks/hero/inspector.js:75
-#: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/hero/inspector.js:85 src/blocks/media-card/inspector.js:63
+#: src/blocks/row/column/inspector.js:134 src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr "容器內部間距。"
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr "左上方"
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr "正上方"
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr "右上方"
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr "中間靠左"
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr "正中間"
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr "中間靠右"
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr "左下方"
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr "正下方"
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr "右下方"
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr "新增重點文字..."
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
-msgstr "重點"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
-msgstr "重點文字。"
+#: src/blocks/highlight/index.js:33
+msgid ""
+"Add a highlight effect to paragraph text in order to grab attention and "
+"emphasize important narrative."
+msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr "文字"
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr "段落"
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr "圖示"
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr "新增風格圖像符號，以便傳達更多訊息。"
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr "圖示"
-
-#: src/blocks/icon/inspector.js:168
-#: src/blocks/row/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:30 src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr "大型"
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr "新增風格圖像符號，以便傳達更多訊息。"
+
+#: src/blocks/icon/inspector.js:155 src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr "圖示設定"
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
-msgstr "開啟進階 %s 設定"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
+msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr "重設"
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+#, fuzzy
+msgid "Apply custom size"
 msgstr "自訂 %s 大小"
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
-msgstr "進階 %s 設定"
+#: src/blocks/icon/inspector.js:201
+#, fuzzy
+msgid "Custom"
+msgstr "自訂"
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr "進階"
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr "半徑"
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr "圖示搜尋"
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr "找不到結果。"
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr "連結設定"
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr "連結 URL"
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr "連結關聯性"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr "正在新分頁中開啟"
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr "在新分頁中開啟"
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309 src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr "圖示色彩"
 
@@ -1261,30 +1037,17 @@ msgid "Edit logos"
 msgstr "編輯標誌"
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr "標誌及徽章"
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr "拖曳圖片、上傳新圖片，或選擇媒體庫中的檔案。"
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
 msgstr "新增標誌、徽章或憑證，以便提高您的公信力。"
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr "客戶"
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr "證明"
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
-msgstr "感言"
 
 #: src/blocks/logos/inspector.js:12
 msgid "Logos Settings"
@@ -1306,176 +1069,138 @@ msgstr "編輯位置"
 msgid "Map style"
 msgstr "地圖樣式"
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr "API 金鑰無效或要求過多"
 
-#: src/blocks/map/edit.js:295
-#: src/blocks/map/save.js:48
+#: src/blocks/map/edit.js:294 src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr "Google 地圖"
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr "輸入地區或地址，即可在 Google 地圖上置放圖釘。"
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr "搜尋地區或地址..."
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
-msgstr "套用"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
+msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
-msgstr "地圖"
-
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
+#: src/blocks/map/index.js:28
+#, fuzzy
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr "新增地址並將圖釘拖曳到 Google 地圖上"
 
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr "地址"
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr "地圖"
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr "Google"
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr "選擇地圖樣式"
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr "地圖設定"
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr "縮放比例"
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr "地圖高度 (像素)"
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr "縮放比例"
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr "標記大小"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr "已啟用微調選項。"
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr "切換此選項即可啟用地圖控制選項。"
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr "地圖控制"
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr "地圖類型"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr "切換啟用標準與衛星地圖檢視。"
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr "切換此選項即可啟用標準語衛星地圖檢視切換功能。"
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr "縮放控制"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr "顯示地圖縮放控制。"
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr "切換此選項其可啟用以縮放控制調整地圖縮放的功能。"
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr "街景"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr "顯示街景地圖控制。"
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr "切換此選項即可在右下角顯示街景控制。"
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr "全螢幕切換"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr "顯示全螢幕地圖控制。"
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr "切換此選項即可顯示全螢幕地圖控制。"
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr "Google 地圖 API 金鑰"
 
-#: src/blocks/map/inspector.js:202
-msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
-msgstr "新增您的 Google 地圖 API 金鑰。更新此 API 金鑰會將您的所有地圖都設為使用新的金鑰。"
+#: src/blocks/map/inspector.js:208
+msgid ""
+"Add your Google Maps API key. Updating this API key will set all your maps "
+"to use the new key."
+msgstr ""
+"新增您的 Google 地圖 API 金鑰。更新此 API 金鑰會將您的所有地圖都設為使用新的"
+"金鑰。"
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr "取得金鑰"
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr "需要幫助嗎？"
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr "輸入 Google API 金鑰..."
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
 msgstr "已儲存"
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr "標準"
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr "銀灰"
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr "復古"
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr "暗色"
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr "夜晚"
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
-msgstr "茄紫"
 
 #: src/blocks/media-card/controls.js:28
 msgid "Media on right"
@@ -1485,21 +1210,9 @@ msgstr "在右方顯示媒體"
 msgid "Media on left"
 msgstr "在左方顯示媒體"
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr "媒體卡片"
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
 msgstr "新增圖片或影片並在旁顯示位移卡片。"
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr "圖片"
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
-msgstr "影片"
 
 #: src/blocks/media-card/inspector.js:109
 msgid "Card Shadow"
@@ -1513,15 +1226,18 @@ msgstr "顯示卡片陰影"
 msgid "Toggle to add a card shadow."
 msgstr "切換此選項即可新增卡片陰影。"
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr " %s陰影"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr "顯示%s陰影"
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr "切換此選項即可新增%s陰影"
 
@@ -1545,40 +1261,171 @@ msgstr "拖曳至此即可取代媒體"
 msgid "Edit media"
 msgstr "編輯媒體"
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
-msgstr "%s表格"
+#: src/blocks/post-carousel/edit.js:123 src/blocks/posts/edit.js:247
+#, fuzzy
+msgid "Edit RSS URL"
+msgstr "Gist 網址"
 
-#: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr "方案 %s"
+#: src/blocks/post-carousel/edit.js:178
+#, fuzzy
+msgid "Post Carousel"
+msgstr "浮動切換"
 
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+#: src/blocks/post-carousel/edit.js:184 src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187 src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193 src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216 src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217 src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221 src/blocks/posts/edit.js:337
+#, fuzzy
+msgid "https://example.com/feed…"
+msgstr "https://yelp.com/"
+
+#: src/blocks/post-carousel/edit.js:227 src/blocks/posts/edit.js:343
+#, fuzzy
+msgid "Use URL"
+msgstr "Gist 網址"
+
+#: src/blocks/post-carousel/edit.js:320 src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366 src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108 src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+#, fuzzy
+msgid "Post Carousel Settings"
+msgstr "色彩設定"
+
+#: src/blocks/post-carousel/inspector.js:41 src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45 src/blocks/posts/inspector.js:85
+#, fuzzy
+msgid "Showing the publish date."
+msgstr "顯示此項目的價格。"
+
+#: src/blocks/post-carousel/inspector.js:46 src/blocks/posts/inspector.js:86
+#, fuzzy
+msgid "Toggle to show the publish date."
+msgstr "切換此選項即可顯示 Gist 中繼資料。"
+
+#: src/blocks/post-carousel/inspector.js:51 src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55 src/blocks/posts/inspector.js:95
+#, fuzzy
+msgid "Showing the post content."
+msgstr "顯示行動呼籲按鈕。"
+
+#: src/blocks/post-carousel/inspector.js:56 src/blocks/posts/inspector.js:96
+#, fuzzy
+msgid "Toggle to show the post content."
+msgstr "切換此選項即可顯示 Gist 中繼資料。"
+
+#: src/blocks/post-carousel/inspector.js:62 src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86 src/blocks/posts/inspector.js:152
+#, fuzzy
+msgid "Feed Settings"
+msgstr "功能設定"
+
+#: src/blocks/post-carousel/inspector.js:90 src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91 src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+#, fuzzy
+msgid "Image on left"
+msgstr "在左方顯示媒體"
+
+#: src/blocks/posts/edit.js:265
+#, fuzzy
+msgid "Image on right"
+msgstr "在右方顯示媒體"
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+#, fuzzy
+msgid "Thumbnail Size"
+msgstr "欄大小"
+
+#: src/blocks/posts/inspector.js:78
+#, fuzzy
+msgid "Posts Settings"
+msgstr "Gist 設定"
+
+#: src/blocks/pricing-table/controls.js:17
+#, fuzzy
+msgid "One Pricing Table"
 msgstr "價格表格"
 
-#: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
+#: src/blocks/pricing-table/controls.js:22
+#, fuzzy
+msgid "Two Pricing Tables"
+msgstr "價格表格"
+
+#: src/blocks/pricing-table/controls.js:27
+#, fuzzy
+msgid "Three Pricing Tables"
+msgstr "價格表格"
+
+#: src/blocks/pricing-table/controls.js:32
+#, fuzzy
+msgid "Four Pricing Tables"
+msgstr "價格表格"
+
+#: src/blocks/pricing-table/controls.js:62
+#, fuzzy
+msgid "Change pricing table count"
 msgstr "新增價格表格。"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr "登陸"
+#: src/blocks/pricing-table/edit.js:39
+#, fuzzy
+msgid "Plan %d"
+msgstr "方案 %s"
 
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr "比較"
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr "價格表格設定"
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
-msgstr "表格"
+#: src/blocks/pricing-table/index.js:29
+msgid "Add pricing tables to help visitors compare products and plans."
+msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
 msgid "Add features"
@@ -1596,129 +1443,169 @@ msgstr "方案 A"
 msgid "$"
 msgstr "$"
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
-msgstr "價格表格項目"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
+msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
-msgstr "置於價格表格區塊內的欄。"
+#: src/blocks/row/column/edit.js:90
+#, fuzzy
+msgid "Add backround to column"
+msgstr "為 %s 新增背景"
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr "欄"
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr "位於下方的子列。"
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr "寬度"
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr "欄位設定"
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112 src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr "容器周遭空間。"
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr "寬度"
+
+#: src/blocks/row/controls.js:70
+#, fuzzy
+msgid "Change row block layout"
+msgstr "變更版面"
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr "一"
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr "二"
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr "三"
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr "四"
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+#, fuzzy
+msgid "Add backround to row"
+msgstr "為 %s 新增背景"
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr "一欄"
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr "二欄"
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr "三欄"
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr "四欄"
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr "列版面配置"
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr "列"
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr "請為此 %s 欄的列選擇版面配置。"
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr "選擇此列欄數。"
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr "選擇列欄數"
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236 src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr "選擇列版面配置"
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr "返回欄"
 
-#: src/blocks/row/index.js:40
-msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
+#: src/blocks/row/index.js:38
+msgid ""
+"Add a structured wrapper for column blocks, then add content blocks you’d "
+"like to the columns."
 msgstr "為欄位區塊新增結構包裝函式，再為欄位新增您想插入的內容區塊。"
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr "列"
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr "欄"
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr "版面配置"
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr "版面配置"
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr "列設定"
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
 msgstr "無"
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
+msgstr ""
 
 #: src/blocks/services/edit.js:44
 msgid "Square"
@@ -1728,17 +1615,9 @@ msgstr "方形"
 msgid "Circle"
 msgstr "圓形"
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr "服務"
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
 msgstr "新增欲顯示的服務欄，最多四欄。"
-
-#: src/blocks/services/index.js:30
-msgid "features"
-msgstr "功能"
 
 #: src/blocks/services/inspector.js:67
 msgid "Services Settings"
@@ -1760,11 +1639,7 @@ msgstr "顯示行動呼籲按鈕。"
 msgid "Toggle to show call to action buttons."
 msgstr "切換此選項即可顯示行動呼籲按鈕。"
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr "服務"
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr "服務區塊內的單一服務項目。"
 
@@ -1785,264 +1660,227 @@ msgid "Toggle to show a call to action button."
 msgstr "切換此選項即可顯示行動呼籲按鈕。"
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr "水平翻轉"
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr "垂直翻轉"
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr "形狀分隔線"
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr "新增形狀分隔線，以便分割頁面區段。"
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr "分隔線"
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr "形狀色彩"
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr "分隔線設定"
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr "形狀高度 (像素)"
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr "背景高度 (像素)"
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
-msgstr "方向"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
+msgstr "形狀色彩"
 
-#: src/blocks/share/edit.js:102
-#: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr "分享到 Twitter"
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
+#: src/blocks/share/edit.js:113 src/blocks/share/index.php:133
 msgid "Share on Facebook"
 msgstr "分享到 Facebook"
 
-#: src/blocks/share/edit.js:118
-#: src/blocks/share/index.php:141
+#: src/blocks/share/edit.js:121 src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr "分享到 Twitter"
+
+#: src/blocks/share/edit.js:129 src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr "分享到 Pinterest"
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr "分享到 LinkedIn"
 
-#: src/blocks/share/edit.js:134
-#: src/blocks/share/index.php:149
+#: src/blocks/share/edit.js:145 src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr "以 email 分享"
 
-#: src/blocks/share/edit.js:142
-#: src/blocks/share/index.php:153
+#: src/blocks/share/edit.js:153 src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr "分享到 Tumblr"
 
-#: src/blocks/share/edit.js:150
-#: src/blocks/share/index.php:157
+#: src/blocks/share/edit.js:161 src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr "分享到 Google"
 
-#: src/blocks/share/edit.js:158
-#: src/blocks/share/index.php:161
+#: src/blocks/share/edit.js:169 src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr "分享到 Reddit"
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr "分享"
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr "社交"
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
 msgstr "新增社交平台分享連結，幫助您取得更多讚和分享。"
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr "社交平台顏色"
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr "圖示大小"
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr "圓形大小"
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr "按鈕大小"
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr "圖示"
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157 src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162 src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr "Facebook"
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167 src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr "Pinterest"
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172 src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177 includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr "email"
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr "Tumblr"
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr "Google"
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr "Reddit"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:36
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:36
 msgid "Share button colors are enabled."
 msgstr "已啟用分享按鈕顏色。"
 
-#: src/blocks/share/inspector.js:25
-#: src/blocks/social-profiles/inspector.js:37
+#: src/blocks/share/inspector.js:25 src/blocks/social-profiles/inspector.js:37
 msgid "Toggle to use official colors from each social media platform."
 msgstr "切換此選項即可使用每個社交媒體平台的官方色彩。"
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr "社交平台顏色"
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr "新增 Facebook 個人檔案"
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr "https://facebook.com/"
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr "新增 Twitter 個人檔案"
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr "https://twitter.com/"
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr "新增 Instagram 個人檔案"
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr "Instagram"
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr "https://instagram.com/"
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr "新增 Pinterest 個人檔案"
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr "https://pinterest.com/"
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr "新增 LinkedIn 個人檔案"
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr "https://linkedin.com/"
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr "新增 YouTube 個人檔案"
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr "YouTube"
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr "https://youtube.com/"
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr "新增 Yelp 個人檔案"
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr "Yelp"
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr "https://yelp.com/"
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr "新增 Houzz 個人檔案"
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr "Houzz"
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr "https://houzz.com/"
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
-msgstr "社交平台個人檔案"
-
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr "連結"
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
+#: src/blocks/social-profiles/index.js:25
+#, fuzzy
+msgid "Grow your audience with links to social media profiles."
 msgstr "顯示您的社交媒體個人檔案連結。"
 
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr "個人檔案連結"
 
@@ -2057,18 +1895,6 @@ msgstr "移除背景"
 #: src/components/background/controls.js:96
 msgid "Background"
 msgstr "背景"
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr "汽車"
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr "封面"
-
-#: src/components/background/panel.js:104
-msgid "Contain"
-msgstr "包含"
 
 #: src/components/background/panel.js:113
 msgid "Background Settings"
@@ -2126,18 +1952,6 @@ msgstr "移除背景"
 msgid "Remove "
 msgstr "移除 "
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr "不重複"
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr "水平重複"
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr "垂直重複"
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr "將圖片往後移"
@@ -2150,17 +1964,14 @@ msgstr "將圖片往前移"
 msgid "Link To"
 msgstr "連結至"
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr "%s圖庫"
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
 msgstr "上傳圖片"
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
-msgstr "明亮"
 
 #: src/components/block-gallery/options/link-options.js:11
 msgid "Media File"
@@ -2174,69 +1985,110 @@ msgstr "附件頁面"
 msgid "Custom URL"
 msgstr "自訂網址"
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
-msgstr "像素"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
+msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
-msgstr "Em"
+#: src/components/crop-settings/index.js:304
+#, fuzzy
+msgid "Image Orientation"
+msgstr "方向"
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
-msgstr "百分比"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+#, fuzzy
+msgid "Reset All"
+msgstr "重設"
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr "選擇單位"
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr "%s單位"
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr "開啟進階 %s 設定"
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr "頂端%s"
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr "右方%s"
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr "底部%s"
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr "左方%s"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr "非同步"
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr "同步"
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr "同步單位"
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr "頂端"
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr "右方"
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr "底部"
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
 msgstr "左方"
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr "進階 %s 設定"
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr "進階"
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr "預設"
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
+msgstr "版面配置"
 
 #: src/components/grid-control/index.js:123
 msgid "Select Layout"
@@ -2255,6 +2107,7 @@ msgid "Toggle to enable fullscreen mode."
 msgstr "切換此選項即可啟用全螢幕模式。"
 
 # %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr "標題 %d"
@@ -2263,43 +2116,16 @@ msgstr "標題 %d"
 msgid "Custom color picker"
 msgstr "自訂顏色挑選工具"
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr "原始"
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr "灰階"
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr "深褐色"
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr "飽和度"
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr "暗度"
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr "復古"
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
 msgstr "套用濾鏡"
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
-msgstr "選擇方向"
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr "高度"
 
 # Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr "行動裝置%s"
@@ -2333,7 +2159,8 @@ msgid "Five Seconds"
 msgstr "五秒"
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+#, fuzzy
+msgid "Six Seconds"
 msgstr "六秒"
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2179,22 @@ msgstr "九秒"
 msgid "Ten Seconds"
 msgstr "十秒"
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr "箭頭導覽"
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr "點狀導覽"
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr "秒"
@@ -2361,21 +2204,25 @@ msgid "second"
 msgstr "秒"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr "%1$d %2$s後換下一張。"
 
 # 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr "自動換到下一張投影片。"
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+#, fuzzy
+msgid "Dragging and flicking enabled."
 msgstr "已啟用桌上型電腦與行動裝置的拖曳及撥動輸入功能。"
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+#, fuzzy
+msgid "Toggle to enable drag functionality."
 msgstr "切換此選項即可啟用桌上型電腦及行動裝置的拖曳功能。"
 
 #: src/components/slider-panel/index.js:35
@@ -2387,44 +2234,60 @@ msgid "Toggle to show slide navigation arrows."
 msgstr "切換此選項即可顯示投影片導覽箭頭。"
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+#, fuzzy
+msgid "Showing dot navigation."
 msgstr "顯示點狀導覽箭頭。"
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr "切換此選項即可顯示點狀導覽。"
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+#, fuzzy
+msgid "Aligning slides to the center."
+msgstr "容器內部間距。"
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+#, fuzzy
+msgid "Toggle to pause autoplay when hovered."
+msgstr "切換此選項即可將影片設為靜音。"
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+#, fuzzy
+msgid "Toggle to scroll without fixed slides."
+msgstr "切換此選項即可循環播放影片。"
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr "投影片設定"
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr "自動播放"
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr "轉換速度"
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
 msgstr "可拖曳"
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr "箭頭導覽"
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr "點狀導覽"
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr "大寫"
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
-msgstr "正常"
 
 #: src/components/typography-controls/index.js:164
 msgid "Font"
@@ -2458,19 +2321,6 @@ msgstr "無底部間距"
 msgid "Change typography"
 msgstr "變更印刷樣式"
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr "粗體"
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr "大寫"
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr "小寫"
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr "在行動裝置上堆疊"
@@ -2487,25 +2337,29 @@ msgstr "切換此選項即可在較小的檢視區中互相堆疊元素。"
 msgid "Remove Top Spacing"
 msgstr "移除頂端間距"
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
-msgstr "此區塊內將會移除頂端邊界。"
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to add top margin back."
+msgstr "切換此選項即可新增卡片陰影。"
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
-msgstr "切換此選項即可移除系統在此區塊內套用的所有頂端邊界。"
+#: src/extensions/advanced-controls/index.js:135
+#, fuzzy
+msgid "Toggle to remove any top margin."
+msgstr "切換此選項即可顯示點狀導覽。"
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr "移除底部間距"
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
-msgstr "此區塊內將會移除底部邊界。"
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to add bottom margin back."
+msgstr "切換此選項即可新增卡片陰影。"
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
-msgstr "切換此選項即可移除系統在此區塊內套用的所有底部邊界。"
+#: src/extensions/advanced-controls/index.js:163
+#, fuzzy
+msgid "Toggle to remove any bottom margin."
+msgstr "切換此選項即可顯示點狀導覽。"
 
 #: src/extensions/button-controls/index.js:71
 msgid "Display Fullwidth"
@@ -2519,21 +2373,14 @@ msgstr "顯示為滿版。"
 msgid "Toggle to display button as full width."
 msgstr "切換此選項即可將按鈕以滿版顯示。"
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
-msgstr "循環"
+#: src/extensions/image-crop/index.js:169
+#, fuzzy
+msgid "Crop Settings"
+msgstr "主頁設定"
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr "3D"
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr "陰影"
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
-msgstr "核取方塊"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
+msgstr "大寫"
 
 #: src/sidebars/block-manager/components/modal.js:132
 msgid "Manage Blocks"
@@ -2559,108 +2406,793 @@ msgstr "此區塊已加入頁面，目前無法停用"
 msgid "Disable all"
 msgstr "停用全部"
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr "系統找不到「%s」區塊。"
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr "%s圖庫"
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+#, fuzzy
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr "顯示開啟"
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+#, fuzzy
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr "新增折疊式功能表標題..."
+
+#: src/blocks/accordion/accordion-item/index.js:26
+#, fuzzy
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr "折疊式功能表項目"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "tabs"
+msgstr "標籤"
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "faq"
+msgstr "常見問題"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "notice"
+msgstr "通知"
+
+#: src/blocks/alert/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "message"
+msgstr "訊息"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "biography"
+msgstr "自傳"
+
+#: src/blocks/author/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "profile"
+msgstr "個人檔案"
+
+#: src/blocks/buttons/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "link"
+msgstr "連結"
+
+#: src/blocks/buttons/index.js:31 src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "cta"
+msgstr "行動呼籲"
+
+#: src/blocks/click-to-tweet/index.js:31 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "share"
+msgstr "分享"
+
+#: src/blocks/click-to-tweet/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "twitter"
+msgstr "Twitter"
+
+#: src/blocks/dynamic-separator/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "spacer"
+msgstr "空白區域"
+
+#: src/blocks/features/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "services"
+msgstr "服務"
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "menu"
+msgstr "選單"
+
+#: src/blocks/food-and-drinks/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr "餐廳"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr "e-mail"
+
+#: src/blocks/form/fields/email/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "mail"
+msgstr "郵件"
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "last name"
+msgstr "姓氏"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr "文字區域"
+
+#: src/blocks/form/fields/textarea/index.js:22
+#, fuzzy
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr "多行文字"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "email"
+msgstr "email"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "about"
+msgstr "關於"
+
+#: src/blocks/form/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "contact"
+msgstr "聯絡人"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "gallery"
+msgstr "圖庫"
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "photos"
+msgstr "相片"
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+#, fuzzy
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr "夜晚"
+
+#: src/blocks/gif/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "animated"
+msgstr "動畫"
+
+#: src/blocks/gist/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "code"
+msgstr "代碼"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "button"
+msgstr "按鈕"
+
+#: src/blocks/hero/index.js:43
+#, fuzzy
+msgctxt "block keyword"
+msgid "call to action"
+msgstr "行動呼籲"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "text"
+msgstr "文字"
+
+#: src/blocks/highlight/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr "段落"
+
+#: src/blocks/icon/index.js:35 src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "icons"
+msgstr "圖示"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "clients"
+msgstr "客戶"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "proof"
+msgstr "證明"
+
+#: src/blocks/logos/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr "感言"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "address"
+msgstr "地址"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "maps"
+msgstr "地圖"
+
+#: src/blocks/map/index.js:30
+#, fuzzy
+msgctxt "block keyword"
+msgid "google"
+msgstr "Google"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "image"
+msgstr "圖片"
+
+#: src/blocks/media-card/index.js:38
+#, fuzzy
+msgctxt "block keyword"
+msgid "video"
+msgstr "影片"
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29 src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "rss"
+msgstr "地址"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "landing"
+msgstr "登陸"
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "comparison"
+msgstr "比較"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "rows"
+msgstr "列"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "columns"
+msgstr "欄"
+
+#: src/blocks/row/index.js:40
+#, fuzzy
+msgctxt "block keyword"
+msgid "layouts"
+msgstr "版面配置"
+
+#: src/blocks/services/index.js:29
+#, fuzzy
+msgctxt "block keyword"
+msgid "features"
+msgstr "功能"
+
+#: src/blocks/shape-divider/index.js:31
+#, fuzzy
+msgctxt "block keyword"
+msgid "separator"
+msgstr "分隔線"
+
+#: src/blocks/share/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "social"
+msgstr "社交"
+
+#: src/blocks/social-profiles/index.js:28
+#, fuzzy
+msgctxt "block keyword"
+msgid "links"
+msgstr "連結"
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+#, fuzzy
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr "顯示開啟"
+
+#: src/blocks/accordion/edit.js:74
+#, fuzzy
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr "新增折疊式功能表項目"
+
+#: src/blocks/accordion/index.js:27
+#, fuzzy
+msgctxt "block title"
+msgid "Accordion"
+msgstr "折疊式功能表"
+
+#: src/blocks/alert/edit.js:102
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr "撰寫文字..."
+
+#: src/blocks/alert/edit.js:94
+#, fuzzy
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr "撰寫標題..."
+
+#: src/blocks/alert/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Alert"
+msgstr "警告"
+
+#: src/blocks/author/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Author"
+msgstr "作者"
+
+#: src/blocks/buttons/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Buttons"
+msgstr "按鈕"
+
+#: src/blocks/click-to-tweet/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr "按一下即可發出"
+
+#: src/blocks/dynamic-separator/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr "動態水平線"
+
+#: src/blocks/features/feature/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Feature"
+msgstr "功能"
+
+#: src/blocks/features/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Features"
+msgstr "功能"
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food Item"
+msgstr "食品項目"
+
+#: src/blocks/food-and-drinks/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr "餐飲"
+
+#: src/blocks/form/fields/email/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Email"
+msgstr "email"
+
+#: src/blocks/form/fields/name/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Name"
+msgstr "姓名"
+
+#: src/blocks/form/fields/textarea/index.js:19
+#, fuzzy
+msgctxt "block name"
+msgid "Message"
+msgstr "訊息"
+
+#: src/blocks/form/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Form"
+msgstr "表格"
+
+#: src/blocks/gallery-carousel/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Carousel"
+msgstr "浮動切換"
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Masonry"
+msgstr "並列"
+
+#: src/blocks/gallery-stacked/index.js:34
+#, fuzzy
+msgctxt "block name"
+msgid "Stacked"
+msgstr "堆疊"
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Gist"
+msgstr "Gist 網址"
+
+#: src/blocks/hero/index.js:40
+#, fuzzy
+msgctxt "block name"
+msgid "Hero"
+msgstr "首頁"
+
+#: src/blocks/highlight/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Highlight"
+msgstr "重點"
+
+#: src/blocks/icon/index.js:32
+#, fuzzy
+msgctxt "block name"
+msgid "Icon"
+msgstr "圖示"
+
+#: src/blocks/logos/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr "標誌及徽章"
+
+#: src/blocks/map/index.js:27
+#, fuzzy
+msgctxt "block name"
+msgid "Map"
+msgstr "地圖"
+
+#: src/blocks/media-card/index.js:35
+#, fuzzy
+msgctxt "block name"
+msgid "Media Card"
+msgstr "媒體卡片"
+
+#: src/blocks/post-carousel/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr "浮動切換"
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr "價格表格"
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr "價格表格項目"
+
+#: src/blocks/row/column/index.js:29
+#, fuzzy
+msgctxt "block name"
+msgid "Column"
+msgstr "欄"
+
+#: src/blocks/row/index.js:37
+#, fuzzy
+msgctxt "block name"
+msgid "Row"
+msgstr "列"
+
+#: src/blocks/services/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Services"
+msgstr "服務"
+
+#: src/blocks/services/service/index.js:26
+#, fuzzy
+msgctxt "block name"
+msgid "Service"
+msgstr "服務"
+
+#: src/blocks/shape-divider/index.js:28
+#, fuzzy
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr "形狀分隔線"
+
+#: src/blocks/share/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Share"
+msgstr "分享"
+
+#: src/blocks/social-profiles/index.js:24
+#, fuzzy
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr "社交平台個人檔案"
+
+#: src/blocks/alert/index.js:33
+#, fuzzy
+msgctxt "block style"
+msgid "Info"
+msgstr "資訊"
+
+#: src/blocks/alert/index.js:34
+#, fuzzy
+msgctxt "block style"
+msgid "Success"
+msgstr "成功"
+
+#: src/blocks/alert/index.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Warning"
+msgstr "警告"
+
+#: src/blocks/alert/index.js:36
+#, fuzzy
+msgctxt "block style"
+msgid "Error"
+msgstr "錯誤"
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr "點"
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr "線"
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr "滿版"
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+#, fuzzy
+msgctxt "block style"
+msgid "Grid"
+msgstr "方格"
+
+#: src/blocks/food-and-drinks/edit.js:42
+#, fuzzy
+msgctxt "block style"
+msgid "List"
+msgstr "清單"
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+#, fuzzy
+msgctxt "block style"
+msgid "Default"
+msgstr "預設"
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Layered"
+msgstr "多層"
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr "空心"
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr "填滿"
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+#, fuzzy
+msgctxt "block style"
+msgid "Stacked"
+msgstr "堆疊"
+
+#: src/blocks/posts/edit.js:55
+#, fuzzy
+msgctxt "block style"
+msgid "Horizontal"
+msgstr "水平重複"
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr "浪狀"
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr "山丘"
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr "海浪"
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr "角度"
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr "傾斜"
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr "圓形"
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr "三角"
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
 msgstr "尖端"
 
-#: src/blocks/share/index.js:33
-#: src/blocks/social-profiles/index.js:33
+#: src/blocks/share/index.js:30 src/blocks/social-profiles/index.js:30
 msgctxt "block style"
 msgid "Mask"
 msgstr "遮罩"
 
-#: src/blocks/share/index.js:34
-#: src/blocks/social-profiles/index.js:34
+#: src/blocks/share/index.js:31 src/blocks/social-profiles/index.js:31
 msgctxt "block style"
 msgid "Icon"
 msgstr "圖示"
 
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
+#: src/blocks/share/index.js:32 src/blocks/social-profiles/index.js:32
 msgctxt "block style"
 msgid "Text"
 msgstr "文字"
 
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
+#: src/blocks/share/index.js:33 src/blocks/social-profiles/index.js:33
 msgctxt "block style"
 msgid "Icon & Text"
 msgstr "圖示與文字"
 
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
+#: src/blocks/share/index.js:34 src/blocks/social-profiles/index.js:34
 msgctxt "block style"
 msgid "Circular"
 msgstr "循環"
+
+#: src/extensions/image-styles/index.js:21
+#, fuzzy
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr "左下方"
+
+#: src/extensions/image-styles/index.js:27
+#, fuzzy
+msgctxt "block style"
+msgid "Top Wave"
+msgstr "左上方"
+
+#: src/blocks/author/edit.js:63
+#, fuzzy
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr "拖曳至此即可新增為頭像"
+
+#: src/blocks/author/edit.js:149
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Author link…"
+msgstr "作者"
 
 #: src/blocks/features/feature/edit.js:31
 msgctxt "content placeholder"
@@ -2682,25 +3214,28 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr "您可以透過此功能區塊強調功能。"
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
+#, fuzzy
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr "新增主頁標題..."
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
-msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
 msgstr "新增主頁內容，此區域一般用來介紹頁面，通常也會附上些許行動呼籲。"
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
 
 #: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add primary action..."
-msgstr "新增主要操作..."
-
-#: src/blocks/hero/edit.js:41
-msgctxt "content placeholder"
-msgid "Add secondary action..."
-msgstr "新增次要操作..."
+msgid "Secondary button…"
+msgstr ""
 
 #: src/blocks/media-card/edit.js:46
 msgctxt "content placeholder"
@@ -2719,28 +3254,125 @@ msgstr "新增內容..."
 
 #: src/blocks/media-card/edit.js:47
 msgctxt "content placeholder"
-msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
-msgstr "以說明文案替換此處文字，以便搭配卡片圖片。然後在卡片中新增更多區塊，如按鈕、清單、圖片等。"
+msgid ""
+"Replace this text with descriptive copy to go along with the card image. "
+"Then add more blocks to this card, such as buttons, lists or images."
+msgstr ""
+"以說明文案替換此處文字，以便搭配卡片圖片。然後在卡片中新增更多區塊，如按鈕、"
+"清單、圖片等。"
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr "撰寫標題..."
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr "撰寫說明..."
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
-msgstr "正常"
+#: src/blocks/buttons/inspector.js:28
+#, fuzzy
+msgctxt "block settings"
+msgid "Buttons Settings"
+msgstr "按鈕設定"
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
-msgstr "自訂"
+#: src/blocks/buttons/inspector.js:43
+#, fuzzy
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr "在行動裝置上堆疊"
+
+#: src/blocks/dynamic-separator/inspector.js:43
+#, fuzzy
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr "動態水平線設定"
+
+#: src/blocks/gallery-collage/inspector.js:55
+#, fuzzy
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr "無"
+
+#: src/blocks/gallery-collage/inspector.js:84
+#, fuzzy
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr "無"
+
+#: src/blocks/gallery-collage/inspector.js:60
+#, fuzzy
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr "小"
+
+#: src/blocks/gallery-collage/inspector.js:89 src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+#, fuzzy
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr "中"
+
+#: src/blocks/gallery-collage/inspector.js:94 src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+#, fuzzy
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr "大"
+
+#: src/blocks/gallery-collage/inspector.js:99 src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+#, fuzzy
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr "特大"
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+#, fuzzy
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr "無"
+
+#: src/blocks/gallery-collage/inspector.js:88
+#, fuzzy
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr "小"
+
+#: src/blocks/gallery-collage/inspector.js:93
+#, fuzzy
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr "中"
+
+#: src/blocks/gallery-collage/inspector.js:98
+#, fuzzy
+msgctxt "label for large shadow option"
+msgid "Large"
+msgstr "大"
 
 #: src/blocks/icon/svgs.js:102
 msgctxt "label"
@@ -3259,7 +3891,9 @@ msgstr "音樂麥克風歌曲歌手創作媒體音訊"
 
 #: src/blocks/icon/svgs.js:43
 msgctxt "tags"
-msgid "microphone podcast computer device music microphone song artist creative media audio"
+msgid ""
+"microphone podcast computer device music microphone song artist creative "
+"media audio"
 msgstr "麥克風廣播電腦裝置音樂麥克風歌曲歌手創作媒體音訊"
 
 #: src/blocks/icon/svgs.js:49
@@ -3284,7 +3918,9 @@ msgstr "電影攝影導演製片媒體創作"
 
 #: src/blocks/icon/svgs.js:73
 msgctxt "tags"
-msgid "video videography director producer media creative camera photographer photography aperture"
+msgid ""
+"video videography director producer media creative camera photographer "
+"photography aperture"
 msgstr "影片攝影導演製片媒體創作相機攝影失攝影光圈"
 
 #: src/blocks/icon/svgs.js:85
@@ -3302,12 +3938,346 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr "調色盤設計色彩藝術家創作媒體彩繪筆刷"
 
+#: src/blocks/map/styles.js:12
+#, fuzzy
+msgctxt "block styles"
+msgid "Standard"
+msgstr "標準"
+
+#: src/blocks/map/styles.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Silver"
+msgstr "銀灰"
+
+#: src/blocks/map/styles.js:20
+#, fuzzy
+msgctxt "block styles"
+msgid "Retro"
+msgstr "復古"
+
+#: src/blocks/map/styles.js:24
+#, fuzzy
+msgctxt "block styles"
+msgid "Dark"
+msgstr "暗色"
+
+#: src/blocks/map/styles.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Night"
+msgstr "夜晚"
+
+#: src/blocks/map/styles.js:32
+#, fuzzy
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr "茄紫"
+
+#: src/extensions/button-styles/index.js:16
+#, fuzzy
+msgctxt "block styles"
+msgid "Circular"
+msgstr "循環"
+
+#: src/extensions/button-styles/index.js:22
+#, fuzzy
+msgctxt "block styles"
+msgid "3D"
+msgstr "3D"
+
+#: src/extensions/button-styles/index.js:28
+#, fuzzy
+msgctxt "block styles"
+msgid "Shadow"
+msgstr "陰影"
+
+#: src/extensions/list-styles/index.js:15
+#, fuzzy
+msgctxt "block styles"
+msgid "Default"
+msgstr "預設"
+
+#: src/extensions/list-styles/index.js:21
+#, fuzzy
+msgctxt "block styles"
+msgid "None"
+msgstr "無"
+
+#: src/extensions/list-styles/index.js:27
+#, fuzzy
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr "核取方塊"
+
+#: src/blocks/post-carousel/edit.js:302 src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185 src/blocks/posts/index.php:202
+#, fuzzy
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr "選單標題..."
+
+#: src/blocks/posts/inspector.js:57
+#, fuzzy
+msgctxt "label for small size option"
+msgid "Small"
+msgstr "小"
+
+#: src/blocks/posts/inspector.js:62
+#, fuzzy
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr "中"
+
+#: src/blocks/posts/inspector.js:67
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Large"
+msgstr "大"
+
+#: src/blocks/posts/inspector.js:72
+#, fuzzy
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr "特大"
+
+#: src/components/background/panel.js:102
+#, fuzzy
+msgctxt "block layout"
+msgid "Auto"
+msgstr "汽車"
+
+#: src/components/background/panel.js:103
+#, fuzzy
+msgctxt "block layout"
+msgid "Cover"
+msgstr "封面"
+
+#: src/components/background/panel.js:104
+#, fuzzy
+msgctxt "block layout"
+msgid "Contain"
+msgstr "包含"
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Left"
+msgstr "左上方"
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Center"
+msgstr "正上方"
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+#, fuzzy
+msgctxt "block layout"
+msgid "Top Right"
+msgstr "右上方"
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Left"
+msgstr "中間靠左"
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Center"
+msgstr "正中間"
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+#, fuzzy
+msgctxt "block layout"
+msgid "Center Right"
+msgstr "中間靠右"
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr "左下方"
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr "正下方"
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+#, fuzzy
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr "右下方"
+
+#: src/components/background/panel.js:95
+#, fuzzy
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr "不重複"
+
+#: src/components/background/panel.js:96
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat"
+msgstr "重複"
+
+#: src/components/background/panel.js:97
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr "水平重複"
+
+#: src/components/background/panel.js:98
+#, fuzzy
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr "垂直重複"
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+#, fuzzy
+msgctxt ""
+"HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr "連結關聯性"
+
+#: src/components/block-gallery/options/caption-options.js:10
+#, fuzzy
+msgctxt "visual style option"
+msgid "Dark"
+msgstr "暗色"
+
+#: src/components/block-gallery/options/caption-options.js:11
+#, fuzzy
+msgctxt "visual style option"
+msgid "Light"
+msgstr "明亮"
+
+#: src/components/block-gallery/options/caption-options.js:12
+#, fuzzy
+msgctxt "visual style option"
+msgid "None"
+msgstr "無"
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+#, fuzzy
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr "圖片"
+
+#: src/components/dimensions-control/index.js:408
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr "像素"
+
+#: src/components/dimensions-control/index.js:412
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr "Em"
+
+#: src/components/dimensions-control/index.js:416
+#, fuzzy
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr "百分比"
+
+#: src/components/media-filter-control/index.js:31
+#, fuzzy
+msgctxt "image styles"
+msgid "Original"
+msgstr "原始"
+
+#: src/components/media-filter-control/index.js:39
+#, fuzzy
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr "灰階"
+
+#: src/components/media-filter-control/index.js:47
+#, fuzzy
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr "媒體檔案"
+
+#: src/components/media-filter-control/index.js:55
+#, fuzzy
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr "飽和度"
+
+#: src/components/media-filter-control/index.js:63
+#, fuzzy
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr "復古濾鏡"
+
+#: src/components/media-filter-control/index.js:71
+#, fuzzy
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr "復古濾鏡"
+
+#: src/components/typography-controls/index.js:103
+#, fuzzy
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr "大寫"
+
+#: src/components/typography-controls/index.js:107
+#, fuzzy
+msgctxt "typography styles"
+msgid "Normal"
+msgstr "正常"
+
+#: src/components/typography-controls/index.js:84
+#, fuzzy
+msgctxt "typography styles"
+msgid "Bold"
+msgstr "粗體"
+
+#: src/components/typography-controls/index.js:91
+#, fuzzy
+msgctxt "typography styles"
+msgid "Default"
+msgstr "預設"
+
+#: src/components/typography-controls/index.js:95
+#, fuzzy
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr "大寫"
+
+#: src/components/typography-controls/index.js:99
+#, fuzzy
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr "小寫"
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr "CoBlocks"
 
@@ -3316,8 +4286,14 @@ msgid "https://coblocks.com"
 msgstr "https://coblocks.com"
 
 #. Description of the plugin
-msgid "CoBlocks is a suite of professional <strong>page building content blocks</strong> for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress."
-msgstr "CoBlocks 是供 WordPress Gutenberg 區塊編輯工具使用的<strong>網頁製作內容區塊</strong>套件我們提供專門讓創作者使用的區塊，可助您製作美觀而豐富的 WordPress 頁面。"
+msgid ""
+"CoBlocks is a suite of professional <strong>page building content blocks</"
+"strong> for the WordPress Gutenberg block editor. Our blocks are hyper-"
+"focused on empowering makers to build beautifully rich pages in WordPress."
+msgstr ""
+"CoBlocks 是供 WordPress Gutenberg 區塊編輯工具使用的<strong>網頁製作內容區塊"
+"</strong>套件我們提供專門讓創作者使用的區塊，可助您製作美觀而豐富的 "
+"WordPress 頁面。"
 
 #. Author of the plugin
 msgid "GoDaddy"
@@ -3327,137 +4303,167 @@ msgstr "GoDaddy"
 msgid "https://www.godaddy.com"
 msgstr "https://www.godaddy.com"
 
-#: class-coblocks.php:77
-#: class-coblocks.php:89
+#: class-coblocks.php:77 class-coblocks.php:89
 msgid "Cheating huh?"
 msgstr "想作弊？"
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr "留下評論"
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+#, fuzzy
+msgid "%d years"
 msgstr "%s 年"
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr "1 年"
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+#, fuzzy
+msgid "%d weeks"
 msgstr "%s 週"
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr "1 週"
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+#, fuzzy
+msgid "%d days"
 msgstr "%s 天"
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr "1 天"
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+#, fuzzy
+msgid "%d hours"
 msgstr "%s 小時"
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr "1 小時"
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+#, fuzzy
+msgid "%d minutes"
 msgstr "%s 分鐘"
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr "1 分鐘"
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+#, fuzzy
+msgid "%d seconds"
 msgstr "%s 秒"
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr "1 秒"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr "%s WordPress 外掛程式"
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr "您滿意 %s 的表現嗎？"
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
-msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr "您已經使用 %1$s 達 %2$s了。您願意留個評論，告訴我們您的想法嗎？非常感謝！"
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
-msgstr "留下評論"
+msgid ""
+"You have been using %1$s for %2$s now. Mind leaving a review to let us know "
+"know what you think? We'd really appreciate it!"
+msgstr ""
+"您已經使用 %1$s 達 %2$s了。您願意留個評論，告訴我們您的想法嗎？非常感謝！"
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr "不用了 / 我做過了"
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
-msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
-msgstr "感謝您選擇使用 CoBlocks，專為新 WordPress 區塊編輯工具使用的頂級網頁製作工具。"
+#: includes/admin/class-coblocks-getting-started-page.php:121
+msgid ""
+"Thanks for choosing CoBlocks, the premier page builder for the new WordPress "
+"block editor."
+msgstr ""
+"感謝您選擇使用 CoBlocks，專為新 WordPress 區塊編輯工具使用的頂級網頁製作工"
+"具。"
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
-msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
-msgstr "您已經在 WordPress 編輯工具中加入不少十分實用的區塊，還有一組全新的網頁製作工具組。CoBlocks 可以為您提供前所未有的功能：%1$s 數十種區塊%2$s、%1$s 網頁製作工具體驗 %2$s 還有 %1$s 自訂印刷樣式控制功能%2$s。"
+#: includes/admin/class-coblocks-getting-started-page.php:127
+msgid ""
+"You've just added lots of useful blocks and a new page builder toolkit to "
+"the WordPress editor. CoBlocks gives you a game-changing set of features: "
+"%1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom "
+"typography controls%2$s."
+msgstr ""
+"您已經在 WordPress 編輯工具中加入不少十分實用的區塊，還有一組全新的網頁製作工"
+"具組。CoBlocks 可以為您提供前所未有的功能：%1$s 數十種區塊%2$s、%1$s 網頁製作"
+"工具體驗 %2$s 還有 %1$s 自訂印刷樣式控制功能%2$s。"
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr "此處影片可以幫助您更瞭解如何使用："
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr "立即觀看如何使用 %s 建立第一個網頁"
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr "立即觀看如何建立第一個網頁"
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr "立即觀看如何使用列與形狀分隔線區塊"
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr "觀看「媒體卡片」區塊的使用方式"
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
-msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
-msgstr "喜歡這些內容嗎？%1$s訂閱我們的 YouTube 頻道%2$s即可在我們推出新影片教學時收到通知。"
+#: includes/admin/class-coblocks-getting-started-page.php:153
+msgid ""
+"Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let "
+"you know when new video tutorials are released."
+msgstr ""
+"喜歡這些內容嗎？%1$s訂閱我們的 YouTube 頻道%2$s即可在我們推出新影片教學時收到"
+"通知。"
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
-msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
-msgstr "如果您有任何疑問或指教，歡迎透過 %1$sTwitter%4$s 或 %2$sFacebook 社團%4$s通知我們。另外，如果您想隨時瞭解 CoBlocks 最新消息和未來功能，不妨%3$s訂閱我們的電子報%4$s。"
+#: includes/admin/class-coblocks-getting-started-page.php:164
+msgid ""
+"If you have any questions or feedback, let us know on %1$sTwitter%4$s or our "
+"%2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you "
+"want to stay up to date with what's new and upcoming at CoBlocks."
+msgstr ""
+"如果您有任何疑問或指教，歡迎透過 %1$sTwitter%4$s 或 %2$sFacebook 社團%4$s通知"
+"我們。另外，如果您想隨時瞭解 CoBlocks 最新消息和未來功能，不妨%3$s訂閱我們的"
+"電子報%4$s。"
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
 msgstr "請盡情使用！"
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
-msgstr "前往開始使用 CoBlocks："
 
 #: includes/class-coblocks-block-settings.php:80
 msgid "Enable or disable blocks"
@@ -3471,11 +4477,27 @@ msgstr "防止垃圾表單用 Google reCaptcha 網站金鑰"
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr "防止垃圾表單用 Google reCaptcha 祕密金鑰"
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr "姓名"
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr "名"
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr "姓"
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr "訊息"
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr "提交"
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr "系統已送出您的訊息："
 
@@ -3490,3 +4512,85 @@ msgstr "分享到 LinkedIn"
 #: src/blocks/social-profiles/index.php:84
 msgid "Linkedin"
 msgstr "LinkedIn"
+
+#~ msgid "Alert Type"
+#~ msgstr "警示類型"
+
+#~ msgid "Edit image"
+#~ msgstr "編輯圖片"
+
+#~ msgid "Remove image"
+#~ msgstr "移除圖片"
+
+#~ msgid "Heading..."
+#~ msgstr "標題..."
+
+#~ msgid "Author Name"
+#~ msgstr "作者名稱"
+
+#~ msgid "Write biography..."
+#~ msgstr "撰寫自傳..."
+
+#~ msgid "Add an author biography."
+#~ msgstr "新增作者自傳。"
+
+#~ msgid "%s Settings"
+#~ msgstr "%s 設定"
+
+#~ msgid "Caption Color"
+#~ msgstr "標題色彩"
+
+#~ msgid "Highlight text."
+#~ msgstr "重點文字。"
+
+# %s: number of tables
+#~ msgid "%s Tables"
+#~ msgstr "%s表格"
+
+#~ msgid "Pricing Table Settings"
+#~ msgstr "價格表格設定"
+
+#~ msgid "Tables"
+#~ msgstr "表格"
+
+#~ msgid "A column placed within the pricing table block."
+#~ msgstr "置於價格表格區塊內的欄。"
+
+#~ msgid "Sepia"
+#~ msgstr "深褐色"
+
+#~ msgid "Dim"
+#~ msgstr "暗度"
+
+#~ msgid "Vintage"
+#~ msgstr "復古"
+
+#~ msgid "Select Orientation"
+#~ msgstr "選擇方向"
+
+#~ msgid "Top margin is removed on this block."
+#~ msgstr "此區塊內將會移除頂端邊界。"
+
+#~ msgid "Toggle to remove any margin applied to the top of this block."
+#~ msgstr "切換此選項即可移除系統在此區塊內套用的所有頂端邊界。"
+
+#~ msgid "Bottom margin is removed on this block."
+#~ msgstr "此區塊內將會移除底部邊界。"
+
+#~ msgid "Toggle to remove any margin applied to the bottom of this block."
+#~ msgstr "切換此選項即可移除系統在此區塊內套用的所有底部邊界。"
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add primary action..."
+#~ msgstr "新增主要操作..."
+
+#~ msgctxt "content placeholder"
+#~ msgid "Add secondary action..."
+#~ msgstr "新增次要操作..."
+
+#~ msgctxt "size name"
+#~ msgid "Normal"
+#~ msgstr "正常"
+
+#~ msgid "Get started with CoBlocks here:"
+#~ msgstr "前往開始使用 CoBlocks："

--- a/languages/coblocks.pot
+++ b/languages/coblocks.pot
@@ -8,35 +8,13 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-27T16:28:38+00:00\n"
+"POT-Creation-Date: 2019-10-11T16:01:45+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
 
-#: src/blocks/accordion/accordion-item/controls.js:28
-msgid "Display open"
-msgstr ""
-
-#: src/blocks/accordion/accordion-item/edit.js:67
-msgid "Add accordion title..."
-msgstr ""
-
-#: src/blocks/accordion/accordion-item/index.js:24
-msgid "Accordion Item"
-msgstr ""
-
-#: src/blocks/accordion/accordion-item/index.js:26
+#: src/blocks/accordion/accordion-item/index.js:27
 msgid "Add collapsable accordion items to accordions."
-msgstr ""
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "tabs"
-msgstr ""
-
-#: src/blocks/accordion/accordion-item/index.js:28
-#: src/blocks/accordion/index.js:30
-msgid "faq"
 msgstr ""
 
 #: src/blocks/accordion/accordion-item/inspector.js:34
@@ -51,65 +29,49 @@ msgstr ""
 msgid "Accordion Item Settings"
 msgstr ""
 
-#: src/blocks/accordion/accordion-item/inspector.js:65
-msgid "Display Open"
-msgstr ""
-
 #: src/blocks/accordion/accordion-item/inspector.js:72
 #: src/blocks/alert/inspector.js:49
+#: src/blocks/author/inspector.js:50
 #: src/blocks/click-to-tweet/inspector.js:60
 #: src/blocks/dynamic-separator/inspector.js:60
 #: src/blocks/features/feature/inspector.js:92
 #: src/blocks/features/inspector.js:173
 #: src/blocks/form/submit-button.js:118
-#: src/blocks/gallery-carousel/inspector.js:165
-#: src/blocks/gallery-masonry/inspector.js:167
-#: src/blocks/gallery-stacked/inspector.js:184
-#: src/blocks/hero/inspector.js:117
+#: src/blocks/hero/inspector.js:137
 #: src/blocks/highlight/inspector.js:43
-#: src/blocks/icon/inspector.js:353
-#: src/blocks/media-card/inspector.js:124
+#: src/blocks/icon/inspector.js:302
+#: src/blocks/media-card/inspector.js:132
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:48
-#: src/blocks/row/column/inspector.js:125
-#: src/blocks/row/inspector.js:244
-#: src/blocks/shape-divider/inspector.js:102
-#: src/blocks/share/inspector.js:179
-#: src/blocks/social-profiles/inspector.js:193
+#: src/blocks/row/column/inspector.js:165
+#: src/blocks/row/inspector.js:211
+#: src/blocks/shape-divider/inspector.js:92
+#: src/blocks/share/inspector.js:200
+#: src/blocks/social-profiles/inspector.js:206
 #: src/extensions/colors/index.js:59
 msgid "Color Settings"
 msgstr ""
 
 #: src/blocks/accordion/accordion-item/inspector.js:78
-#: src/blocks/alert/inspector.js:54
+#: src/blocks/alert/inspector.js:55
+#: src/blocks/author/inspector.js:56
 #: src/blocks/features/feature/inspector.js:110
 #: src/blocks/features/inspector.js:191
-#: src/blocks/gallery-carousel/inspector.js:80
-#: src/blocks/gallery-masonry/inspector.js:93
-#: src/blocks/gallery-stacked/inspector.js:96
-#: src/blocks/hero/inspector.js:130
+#: src/blocks/hero/inspector.js:150
 #: src/blocks/highlight/inspector.js:49
-#: src/blocks/icon/inspector.js:377
-#: src/blocks/media-card/inspector.js:138
+#: src/blocks/icon/inspector.js:326
+#: src/blocks/media-card/inspector.js:146
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:53
-#: src/blocks/row/column/inspector.js:131
-#: src/blocks/row/inspector.js:260
-#: src/blocks/shape-divider/inspector.js:113
-#: src/blocks/share/inspector.js:80
-#: src/blocks/social-profiles/inspector.js:92
+#: src/blocks/row/column/inspector.js:171
+#: src/blocks/row/inspector.js:227
+#: src/blocks/shape-divider/inspector.js:103
+#: src/blocks/share/inspector.js:99
+#: src/blocks/social-profiles/inspector.js:103
 #: src/extensions/colors/index.js:47
 msgid "Background Color"
 msgstr ""
 
 #: src/blocks/accordion/accordion-item/inspector.js:83
 msgid "Title Text Color"
-msgstr ""
-
-#: src/blocks/accordion/edit.js:111
-msgid "Add Accordion Item"
-msgstr ""
-
-#: src/blocks/accordion/index.js:26
-msgid "Accordion"
 msgstr ""
 
 #: src/blocks/accordion/index.js:28
@@ -132,136 +94,66 @@ msgstr ""
 msgid "Supporting Internet Explorer by loading a JavaScript polyfill on this page."
 msgstr ""
 
-#: src/blocks/alert/controls.js:103
-msgid "Warning"
+#: src/blocks/alert/index.js:29
+msgid "Provide contextual feedback messages or notices."
 msgstr ""
 
-#: src/blocks/alert/controls.js:111
-msgid "Error"
+#: src/blocks/alert/index.js:45
+msgid "This is an alert block"
 msgstr ""
 
-#: src/blocks/alert/controls.js:76
-msgid "Alert Type"
+#: src/blocks/alert/index.js:46
+msgid "An alert is a message that displays outside the flow of typical content. Alerts provide contextual feedback, typically asking readers to take an action."
 msgstr ""
 
-#: src/blocks/alert/controls.js:80
-#: src/components/font-family/index.js:16
-#: src/components/typography-controls/index.js:91
-#: src/extensions/list-styles/index.js:15
-msgid "Default"
-msgstr ""
-
-#: src/blocks/alert/controls.js:87
-msgid "Info"
-msgstr ""
-
-#: src/blocks/alert/controls.js:95
-msgid "Success"
-msgstr ""
-
-#: src/blocks/alert/edit.js:74
-msgid "Write title..."
-msgstr ""
-
-#: src/blocks/alert/edit.js:82
-msgid "Write text..."
-msgstr ""
-
-#: src/blocks/alert/index.js:25
-msgid "Alert"
-msgstr ""
-
-#: src/blocks/alert/index.js:30
-msgid "Provide contextual feedback messages."
-msgstr ""
-
-#: src/blocks/alert/index.js:32
-msgid "notice"
-msgstr ""
-
-#: src/blocks/alert/index.js:32
-msgid "message"
-msgstr ""
-
-#: src/blocks/alert/inspector.js:59
+#: src/blocks/alert/inspector.js:60
+#: src/blocks/author/inspector.js:61
 #: src/blocks/click-to-tweet/inspector.js:66
 #: src/blocks/features/feature/inspector.js:114
 #: src/blocks/features/inspector.js:195
-#: src/blocks/hero/inspector.js:135
+#: src/blocks/hero/inspector.js:155
 #: src/blocks/highlight/inspector.js:54
 #: src/blocks/pricing-table/pricing-table-item/inspector.js:58
-#: src/blocks/row/column/inspector.js:136
-#: src/blocks/row/inspector.js:265
-#: src/blocks/share/inspector.js:72
-#: src/blocks/social-profiles/inspector.js:84
+#: src/blocks/row/column/inspector.js:176
+#: src/blocks/row/inspector.js:232
+#: src/blocks/share/inspector.js:66
+#: src/blocks/social-profiles/inspector.js:95
 #: src/extensions/colors/index.js:54
 msgid "Text Color"
 msgstr ""
 
-#: src/blocks/author/controls.js:41
-msgid "Edit image"
+#: src/blocks/author/controls.js:36
+msgid "Edit avatar"
 msgstr ""
 
-#: src/blocks/author/controls.js:49
-msgid "Remove image"
+#. placeholder text used for the author name
+#: src/blocks/author/edit.js:127
+msgid "Write author name…"
 msgstr ""
 
-#: src/blocks/author/edit.js:102
-msgid "Drop to add as avatar"
+#. placeholder text used for the biography
+#: src/blocks/author/edit.js:141
+msgid "Write a biography that distills objective credibility and authority to your readers…"
 msgstr ""
 
-#: src/blocks/author/edit.js:143
-msgid "Heading..."
+#: src/blocks/author/index.js:29
+msgid "Add an author biography to build credibility and authority."
 msgstr ""
 
-#: src/blocks/author/edit.js:154
-msgid "Author Name"
+#: src/blocks/author/index.js:35
+msgid "Born to express, not to impress. A maker making the world I want."
 msgstr ""
 
-#: src/blocks/author/edit.js:165
-msgid "Write biography..."
+#: src/blocks/author/inspector.js:41
+msgid "Author Settings"
 msgstr ""
 
-#: src/blocks/author/index.js:26
-msgid "Author"
-msgstr ""
-
-#: src/blocks/author/index.js:28
-msgid "Add an author biography."
-msgstr ""
-
-#: src/blocks/author/index.js:30
-msgid "biography"
-msgstr ""
-
-#: src/blocks/author/index.js:30
-msgid "profile"
-msgstr ""
-
-#: src/blocks/buttons/index.js:30
-#: src/blocks/buttons/inspector.js:30
-msgid "Buttons"
-msgstr ""
-
-#: src/blocks/buttons/index.js:31
+#: src/blocks/buttons/index.js:29
 msgid "Prompt visitors to take action with multiple buttons, side by side."
 msgstr ""
 
-#: src/blocks/buttons/index.js:32
-msgid "link"
-msgstr ""
-
-#: src/blocks/buttons/index.js:32
-#: src/blocks/hero/index.js:45
-msgid "cta"
-msgstr ""
-
-#: src/blocks/buttons/inspector.js:28
-msgid "Buttons Settings"
-msgstr ""
-
-#: src/blocks/buttons/inspector.js:43
-msgid "Stack on mobile"
+#: src/blocks/buttons/inspector.js:30
+msgid "Buttons"
 msgstr ""
 
 #: src/blocks/buttons/inspector.js:48
@@ -280,30 +172,21 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: src/blocks/click-to-tweet/edit.js:107
+#: src/blocks/click-to-tweet/edit.js:109
 msgid "Add button..."
 msgstr ""
 
-# the text of the click to tweet element
-#: src/blocks/click-to-tweet/edit.js:80
+#. the text of the click to tweet element
+#: src/blocks/click-to-tweet/edit.js:82
 msgid "Add a quote to tweet..."
 msgstr ""
 
-#: src/blocks/click-to-tweet/index.js:25
-msgid "Click to Tweet"
-msgstr ""
-
-#: src/blocks/click-to-tweet/index.js:27
+#: src/blocks/click-to-tweet/index.js:29
 msgid "Add a quote for readers to tweet via Twitter."
 msgstr ""
 
-#: src/blocks/click-to-tweet/index.js:29
-#: src/blocks/social-profiles/index.js:23
-msgid "share"
-msgstr ""
-
-#: src/blocks/click-to-tweet/index.js:29
-msgid "twitter"
+#: src/blocks/click-to-tweet/index.js:34
+msgid "The easiest way to promote and advertise your blog, website, and business on Twitter."
 msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:52
@@ -313,29 +196,19 @@ msgstr ""
 
 #: src/blocks/click-to-tweet/inspector.js:71
 #: src/blocks/form/submit-button.js:127
+#: src/blocks/share/inspector.js:86
+#: src/blocks/social-profiles/inspector.js:90
 msgid "Button Color"
 msgstr ""
 
-#: src/blocks/dynamic-separator/index.js:24
-msgid "Dynamic HR"
-msgstr ""
-
-#: src/blocks/dynamic-separator/index.js:29
+#: src/blocks/dynamic-separator/index.js:28
 msgid "Add a resizable spacer between other blocks."
 msgstr ""
 
-#: src/blocks/dynamic-separator/index.js:31
-msgid "spacer"
-msgstr ""
-
-#: src/blocks/dynamic-separator/inspector.js:43
-msgid "Dynamic HR Settings"
-msgstr ""
-
 #: src/blocks/dynamic-separator/inspector.js:44
-#: src/blocks/gallery-carousel/inspector.js:142
-#: src/blocks/hero/inspector.js:88
-#: src/blocks/map/inspector.js:133
+#: src/blocks/gallery-carousel/inspector.js:100
+#: src/blocks/hero/inspector.js:108
+#: src/blocks/map/inspector.js:128
 msgid "Height in pixels"
 msgstr ""
 
@@ -353,11 +226,7 @@ msgstr ""
 msgid "Add as backround"
 msgstr ""
 
-#: src/blocks/features/feature/index.js:20
-msgid "Feature"
-msgstr ""
-
-#: src/blocks/features/feature/index.js:42
+#: src/blocks/features/feature/index.js:29
 msgid "A singular child column within a parent features block."
 msgstr ""
 
@@ -367,72 +236,65 @@ msgstr ""
 
 #: src/blocks/features/feature/inspector.js:71
 #: src/blocks/features/inspector.js:143
-#: src/blocks/hero/inspector.js:74
-#: src/blocks/icon/inspector.js:268
+#: src/blocks/hero/inspector.js:84
+#: src/blocks/icon/inspector.js:217
 #: src/blocks/media-card/inspector.js:62
-#: src/blocks/row/column/inspector.js:103
-#: src/blocks/row/inspector.js:213
+#: src/blocks/row/column/inspector.js:133
+#: src/blocks/row/inspector.js:180
 #: src/components/background/panel.js:146
 msgid "Padding"
 msgstr ""
 
-#: src/blocks/features/index.js:23
-msgid "Features"
-msgstr ""
-
-#: src/blocks/features/index.js:36
+#: src/blocks/features/index.js:35
 msgid "Add up to three columns of small notes for your product or service."
 msgstr ""
 
-#: src/blocks/features/index.js:38
-msgid "services"
-msgstr ""
-
 #: src/blocks/features/inspector.js:122
-#: src/blocks/row/column/inspector.js:91
-#: src/blocks/row/inspector.js:190
+#: src/blocks/row/column/inspector.js:111
+#: src/blocks/row/inspector.js:157
 #: src/components/dimensions-control/index.js:295
 msgid "Margin"
 msgstr ""
 
 #: src/blocks/features/inspector.js:164
-#: src/blocks/gallery-carousel/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:145
-#: src/blocks/row/inspector.js:235
+#: src/blocks/gallery-carousel/inspector.js:84
+#: src/blocks/gallery-collage/inspector.js:108
+#: src/blocks/gallery-stacked/inspector.js:91
+#: src/blocks/row/inspector.js:202
 #: src/components/responsive-tabs-control/index.js:31
 msgid "Gutter"
 msgstr ""
 
 #: src/blocks/features/inspector.js:167
-#: src/blocks/row/inspector.js:238
+#: src/blocks/row/inspector.js:205
 msgid "Space between each column."
 msgstr ""
 
 #: src/blocks/features/inspector.js:86
-#: src/blocks/icon/inspector.js:154
+#: src/blocks/icon/icon-size-select.js:16
 #: src/blocks/row/inspector.js:99
-#: src/blocks/share/inspector.js:58
-#: src/blocks/social-profiles/inspector.js:70
+#: src/blocks/share/inspector.js:72
+#: src/blocks/social-profiles/inspector.js:76
 #: src/components/dimensions-control/dimensions-select.js:15
 #: src/components/size-control/index.js:116
 msgid "Small"
 msgstr ""
 
 #: src/blocks/features/inspector.js:87
-#: src/blocks/icon/inspector.js:159
+#: src/blocks/icon/icon-size-select.js:21
 #: src/blocks/row/inspector.js:100
-#: src/blocks/share/inspector.js:59
-#: src/blocks/social-profiles/inspector.js:71
+#: src/blocks/share/inspector.js:73
+#: src/blocks/social-profiles/inspector.js:77
 #: src/components/dimensions-control/dimensions-select.js:20
 #: src/components/size-control/index.js:120
 msgid "Medium"
 msgstr ""
 
 #: src/blocks/features/inspector.js:88
-#: src/blocks/icon/inspector.js:164
+#: src/blocks/icon/icon-size-select.js:26
 #: src/blocks/row/inspector.js:101
-#: src/blocks/share/inspector.js:60
-#: src/blocks/social-profiles/inspector.js:72
+#: src/blocks/share/inspector.js:74
+#: src/blocks/social-profiles/inspector.js:78
 #: src/components/dimensions-control/dimensions-select.js:25
 #: src/components/size-control/index.js:65
 msgid "Large"
@@ -443,6 +305,8 @@ msgid "Features Settings"
 msgstr ""
 
 #: src/blocks/features/inspector.js:96
+#: src/blocks/post-carousel/inspector.js:70
+#: src/blocks/posts/inspector.js:110
 #: src/blocks/services/inspector.js:69
 msgid "Columns"
 msgstr ""
@@ -455,76 +319,72 @@ msgstr ""
 msgid "Menu title..."
 msgstr ""
 
-#: src/blocks/food-and-drinks/edit.js:35
-msgid "Grid"
-msgstr ""
-
-#: src/blocks/food-and-drinks/edit.js:42
-msgid "List"
-msgstr ""
-
-#: src/blocks/food-and-drinks/food-item/edit.js:144
-#: src/blocks/services/service/edit.js:146
+#: src/blocks/food-and-drinks/food-item/edit.js:147
+#: src/blocks/gallery-collage/edit.js:140
+#: src/blocks/services/service/edit.js:156
 msgid "Drop image to replace"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/edit.js:157
-#: src/blocks/services/service/edit.js:159
+#: src/blocks/food-and-drinks/food-item/edit.js:160
+#: src/blocks/gallery-collage/edit.js:160
+#: src/blocks/services/service/edit.js:169
 #: src/components/block-gallery/gallery-image.js:208
 msgid "Remove Image"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/edit.js:222
+#: src/blocks/food-and-drinks/food-item/edit.js:225
 msgid "Add title..."
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/edit.js:233
-#: src/blocks/food-and-drinks/food-item/inspector.js:55
-#: src/blocks/food-and-drinks/food-item/save.js:65
+#: src/blocks/food-and-drinks/food-item/edit.js:238
+#: src/blocks/food-and-drinks/food-item/inspector.js:45
+#: src/blocks/food-and-drinks/food-item/save.js:66
+msgid "Popular"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:256
+#: src/blocks/food-and-drinks/food-item/inspector.js:60
+#: src/blocks/food-and-drinks/food-item/save.js:74
 msgid "Spicy"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/edit.js:253
+#: src/blocks/food-and-drinks/food-item/edit.js:276
 msgid "Hot"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/edit.js:275
-#: src/blocks/food-and-drinks/food-item/inspector.js:70
-#: src/blocks/food-and-drinks/food-item/save.js:81
+#: src/blocks/food-and-drinks/food-item/edit.js:298
+#: src/blocks/food-and-drinks/food-item/inspector.js:75
+#: src/blocks/food-and-drinks/food-item/save.js:90
 msgid "Vegetarian"
-msgstr ""
-
-#: src/blocks/food-and-drinks/food-item/edit.js:301
-#: src/blocks/food-and-drinks/food-item/inspector.js:45
-#: src/blocks/food-and-drinks/food-item/save.js:89
-msgid "Gluten Free"
 msgstr ""
 
 #: src/blocks/food-and-drinks/food-item/edit.js:324
 #: src/blocks/food-and-drinks/food-item/inspector.js:50
-#: src/blocks/food-and-drinks/food-item/save.js:97
+#: src/blocks/food-and-drinks/food-item/save.js:98
+msgid "Gluten Free"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/edit.js:347
+#: src/blocks/food-and-drinks/food-item/inspector.js:55
+#: src/blocks/food-and-drinks/food-item/save.js:106
 msgid "Pescatarian"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/edit.js:345
-#: src/blocks/food-and-drinks/food-item/inspector.js:65
-#: src/blocks/food-and-drinks/food-item/save.js:105
+#: src/blocks/food-and-drinks/food-item/edit.js:368
+#: src/blocks/food-and-drinks/food-item/inspector.js:70
+#: src/blocks/food-and-drinks/food-item/save.js:114
 msgid "Vegan"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/edit.js:363
+#: src/blocks/food-and-drinks/food-item/edit.js:386
 msgid "Add description..."
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/edit.js:372
+#: src/blocks/food-and-drinks/food-item/edit.js:395
 msgid "$0.00"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/index.js:21
-msgid "Food Item"
-msgstr ""
-
-#: src/blocks/food-and-drinks/food-item/index.js:30
+#: src/blocks/food-and-drinks/food-item/index.js:27
 msgid "A food and drink item within the Food & Drinks block."
 msgstr ""
 
@@ -560,62 +420,51 @@ msgstr ""
 msgid "Item Attributes"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:60
-#: src/blocks/food-and-drinks/food-item/save.js:73
+#: src/blocks/food-and-drinks/food-item/inspector.js:65
+#: src/blocks/food-and-drinks/food-item/save.js:82
 msgid "Spicier"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:77
+#: src/blocks/food-and-drinks/food-item/inspector.js:82
 #: src/blocks/services/service/inspector.js:31
 msgid "Image Settings"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:79
+#: src/blocks/food-and-drinks/food-item/inspector.js:84
 #: src/blocks/gif/inspector.js:31
 #: src/blocks/media-card/inspector.js:95
 #: src/blocks/services/service/inspector.js:33
 msgid "Alt Text (Alternative Text)"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:85
+#: src/blocks/food-and-drinks/food-item/inspector.js:90
 #: src/blocks/gif/inspector.js:37
 #: src/blocks/media-card/inspector.js:101
 #: src/blocks/services/service/inspector.js:39
 msgid "Describe the purpose of the image"
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:87
+#: src/blocks/food-and-drinks/food-item/inspector.js:92
 #: src/blocks/gif/inspector.js:39
 #: src/blocks/media-card/inspector.js:103
 #: src/blocks/services/service/inspector.js:41
 msgid "Leave empty if the image is purely decorative."
 msgstr ""
 
-#: src/blocks/food-and-drinks/food-item/inspector.js:92
+#: src/blocks/food-and-drinks/food-item/inspector.js:97
 #: src/blocks/services/service/inspector.js:46
 #: src/components/background/panel.js:126
 msgid "Focal Point"
 msgstr ""
 
-#: src/blocks/food-and-drinks/index.js:24
-msgid "Food & Drinks"
-msgstr ""
-
-#: src/blocks/food-and-drinks/index.js:26
+#: src/blocks/food-and-drinks/index.js:27
 msgid "Display a menu or price list."
 msgstr ""
 
-#: src/blocks/food-and-drinks/index.js:28
-msgid "restaurant"
-msgstr ""
-
-#: src/blocks/food-and-drinks/index.js:28
-msgid "menu"
-msgstr ""
-
 #: src/blocks/food-and-drinks/inspector.js:26
-#: src/blocks/map/inspector.js:98
-#: src/blocks/row/inspector.js:152
+#: src/blocks/map/inspector.js:103
+#: src/blocks/posts/inspector.js:187
+#: src/blocks/row/inspector.js:119
 #: src/blocks/services/inspector.js:32
 msgid "Styles"
 msgstr ""
@@ -648,134 +497,87 @@ msgstr ""
 msgid "Toggle to show the price of each item."
 msgstr ""
 
-#: src/blocks/form/edit.js:109
-#: src/blocks/share/inspector.js:156
-#: includes/class-coblocks-form.php:210
-#: includes/class-coblocks-form.php:297
-msgid "Email"
-msgstr ""
-
-#: src/blocks/form/edit.js:110
-msgid "e-mail"
-msgstr ""
-
-#: src/blocks/form/edit.js:110
-msgid "mail"
-msgstr ""
-
-#: src/blocks/form/edit.js:111
-msgid "An email address field."
-msgstr ""
-
-#: src/blocks/form/edit.js:120
-#: includes/class-coblocks-form.php:325
-msgid "Message"
-msgstr ""
-
-#: src/blocks/form/edit.js:121
-msgid "Textarea"
-msgstr ""
-
-#: src/blocks/form/edit.js:121
-msgid "Multiline text"
-msgstr ""
-
-#: src/blocks/form/edit.js:122
-msgid "A text box for longer responses."
-msgstr ""
-
-#: src/blocks/form/edit.js:289
+#. %s: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:164
 msgid "%s is not a valid email address."
 msgstr ""
 
-#: src/blocks/form/edit.js:298
+#. %s1: Placeholder for email address provided by user. %s2: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:174
 msgid "%s and %s are not a valid email address."
 msgstr ""
 
-#: src/blocks/form/edit.js:305
+#. %s1: Placeholder for email address provided by user.
+#: src/blocks/form/edit.js:182
 msgid "%s are not a valid email address."
 msgstr ""
 
-#: src/blocks/form/edit.js:363
+#: src/blocks/form/edit.js:240
 msgid "Email address"
 msgstr ""
 
-#: src/blocks/form/edit.js:364
+#: src/blocks/form/edit.js:241
 msgid "name@example.com"
 msgstr ""
 
-#: src/blocks/form/edit.js:374
+#: src/blocks/form/edit.js:251
 msgid "Subject"
 msgstr ""
 
-#: src/blocks/form/edit.js:404
+#: src/blocks/form/edit.js:281
 msgid "Form Settings"
 msgstr ""
 
-#: src/blocks/form/edit.js:409
+#: src/blocks/form/edit.js:286
 msgid "Google reCAPTCHA"
 msgstr ""
 
-#: src/blocks/form/edit.js:412
+#: src/blocks/form/edit.js:289
 msgid "Add your reCAPTCHA site and secret keys to protect your form from spam."
 msgstr ""
 
-#: src/blocks/form/edit.js:418
+#: src/blocks/form/edit.js:295
 msgid "Generate keys"
 msgstr ""
 
-#: src/blocks/form/edit.js:419
+#: src/blocks/form/edit.js:296
 msgid "My keys"
 msgstr ""
 
-#: src/blocks/form/edit.js:422
+#: src/blocks/form/edit.js:299
 msgid "Get help"
 msgstr ""
 
-#: src/blocks/form/edit.js:426
+#: src/blocks/form/edit.js:303
 msgid "Site Key"
 msgstr ""
 
-#: src/blocks/form/edit.js:432
+#: src/blocks/form/edit.js:309
 msgid "Secret Key"
 msgstr ""
 
-#: src/blocks/form/edit.js:446
+#: src/blocks/form/edit.js:323
+#: src/blocks/gallery-collage/edit.js:174
 #: src/components/block-gallery/gallery-image.js:221
 msgid "Saving"
 msgstr ""
 
-#: src/blocks/form/edit.js:446
-#: src/blocks/map/inspector.js:221
+#: src/blocks/form/edit.js:323
+#: src/blocks/map/inspector.js:227
 msgid "Save"
 msgstr ""
 
-#: src/blocks/form/edit.js:461
-#: src/blocks/map/inspector.js:229
+#: src/blocks/form/edit.js:338
+#: src/blocks/map/inspector.js:235
 msgid "Remove"
 msgstr ""
 
-#: src/blocks/form/edit.js:57
-#: includes/class-coblocks-form.php:248
-msgid "First"
-msgstr ""
-
-#: src/blocks/form/edit.js:61
-#: includes/class-coblocks-form.php:249
-msgid "Last"
-msgstr ""
-
-#: src/blocks/form/edit.js:88
-#: includes/class-coblocks-form.php:244
-msgid "Name"
-msgstr ""
-
-#: src/blocks/form/edit.js:89
-msgid "A text field for names."
+#: src/blocks/form/fields/email/index.js:20
+msgid "An email address field."
 msgstr ""
 
 #: src/blocks/form/fields/field-label.js:22
-#: src/blocks/form/fields/field-name.js:67
+#: src/blocks/form/fields/name/edit.js:61
 msgid "Add label…"
 msgstr ""
 
@@ -783,40 +585,36 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: src/blocks/form/fields/field-name.js:75
+#: src/blocks/form/fields/name/edit.js:69
 msgid "Name Field Settings"
 msgstr ""
 
-#: src/blocks/form/fields/field-name.js:77
+#: src/blocks/form/fields/name/edit.js:71
 msgid "Last Name"
 msgstr ""
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Showing both first and last name fields."
 msgstr ""
 
-#: src/blocks/form/fields/field-name.js:81
+#: src/blocks/form/fields/name/edit.js:75
 msgid "Toggle to add a last name field."
 msgstr ""
 
-#: src/blocks/form/index.js:25
-msgid "Form"
+#: src/blocks/form/fields/name/index.js:20
+msgid "A text field for names."
+msgstr ""
+
+#: src/blocks/form/fields/textarea/index.js:20
+msgid "A text box for longer responses."
 msgstr ""
 
 #: src/blocks/form/index.js:27
 msgid "Add a simple form to your page."
 msgstr ""
 
-#: src/blocks/form/index.js:29
-msgid "email"
-msgstr ""
-
-#: src/blocks/form/index.js:29
-msgid "about"
-msgstr ""
-
-#: src/blocks/form/index.js:29
-msgid "contact"
+#: src/blocks/form/index.js:36
+msgid "Subject example"
 msgstr ""
 
 #: src/blocks/form/submit-button.js:107
@@ -827,158 +625,207 @@ msgstr ""
 msgid "Button Text Color"
 msgstr ""
 
-#: src/blocks/gallery-carousel/controls.js:53
-#: src/blocks/gallery-masonry/controls.js:53
-#: src/blocks/gallery-stacked/controls.js:53
+#: src/blocks/gallery-carousel/controls.js:55
+#: src/blocks/gallery-masonry/controls.js:55
+#: src/blocks/gallery-stacked/controls.js:55
 msgid "Edit gallery"
 msgstr ""
 
-# %1$d is the order number of the image, %2$d is the total number of images.
-#: src/blocks/gallery-carousel/edit.js:292
-#: src/blocks/gallery-masonry/edit.js:239
-#: src/blocks/gallery-stacked/edit.js:197
+#: src/blocks/gallery-carousel/edit.js:252
+msgid "Carousel"
+msgstr ""
+
+#. %1$d is the order number of the image, %2$d is the total number of images.
+#: src/blocks/gallery-carousel/edit.js:310
+#: src/blocks/gallery-masonry/edit.js:219
+#: src/blocks/gallery-stacked/edit.js:191
 msgid "image %1$d of %2$d in gallery"
 msgstr ""
 
-#: src/blocks/gallery-carousel/edit.js:333
-#: src/blocks/gif/edit.js:248
+#: src/blocks/gallery-carousel/edit.js:376
+#: src/blocks/gif/edit.js:243
 #: src/blocks/gist/edit.js:103
 #: src/components/block-gallery/gallery-image.js:230
 msgid "Write caption…"
 msgstr ""
 
-#: src/blocks/gallery-carousel/index.js:24
-msgid "Carousel"
-msgstr ""
-
-#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-carousel/index.js:35
 msgid "Display multiple images in a beautiful carousel gallery."
 msgstr ""
 
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "gallery"
-msgstr ""
-
-#: src/blocks/gallery-carousel/index.js:42
-#: src/blocks/gallery-masonry/index.js:43
-#: src/blocks/gallery-stacked/index.js:42
-msgid "photos"
+#: src/blocks/gallery-carousel/inspector.js:109
+msgid "Thumbnails"
 msgstr ""
 
 #: src/blocks/gallery-carousel/inspector.js:119
-#: src/blocks/gallery-masonry/inspector.js:127
-#: src/blocks/gallery-stacked/inspector.js:134
-msgid "%s Settings"
+msgid "Responsive Height"
 msgstr ""
 
-#: src/blocks/gallery-carousel/inspector.js:124
-#: src/blocks/icon/inspector.js:197
+#: src/blocks/gallery-carousel/inspector.js:40
+msgid "Showing thumbnail navigation."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:40
+msgid "Toggle to show thumbnails."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Percentage based height is activated."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:44
+msgid "Toggle for percentage based height."
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:68
+msgid "Carousel Settings"
+msgstr ""
+
+#: src/blocks/gallery-carousel/inspector.js:71
+#: src/blocks/icon/inspector.js:173
 #: src/components/typography-controls/index.js:189
 msgid "Size"
 msgstr ""
 
-#: src/blocks/gallery-carousel/inspector.js:150
-#: src/blocks/gallery-masonry/inspector.js:137
-#: src/blocks/gallery-stacked/inspector.js:149
-#: src/blocks/share/inspector.js:99
-#: src/blocks/social-profiles/inspector.js:111
+#: src/blocks/gallery-carousel/inspector.js:90
+#: src/blocks/gallery-masonry/inspector.js:83
+#: src/blocks/gallery-stacked/inspector.js:95
+#: src/blocks/share/inspector.js:120
+#: src/blocks/social-profiles/inspector.js:124
 #: src/components/background/panel.js:156
 msgid "Rounded Corners"
 msgstr ""
 
-#: src/blocks/gallery-carousel/inspector.js:88
-#: src/blocks/gallery-masonry/inspector.js:101
-#: src/blocks/gallery-stacked/inspector.js:104
-msgid "Caption Color"
+#: src/blocks/gallery-collage/edit.js:174
+#: src/blocks/map/edit.js:307
+#: src/components/block-gallery/gallery-image.js:221
+msgid "Apply"
 msgstr ""
 
-#: src/blocks/gallery-masonry/index.js:24
-msgid "Masonry"
+#: src/blocks/gallery-collage/edit.js:183
+msgid "Write caption..."
 msgstr ""
 
-#: src/blocks/gallery-masonry/index.js:39
-msgid "Display multiple images in an organized masonry gallery."
+#: src/blocks/gallery-collage/index.js:34
+msgid "Assemble images into a beautiful collage gallery."
 msgstr ""
 
-#: src/blocks/gallery-masonry/inspector.js:130
-msgid "Column Size"
+#: src/blocks/gallery-collage/inspector.js:105
+msgid "Collage Settings"
 msgstr ""
 
-#: src/blocks/gallery-masonry/inspector.js:138
-msgid "Add rounded corners to the gallery items."
+#: src/blocks/gallery-collage/inspector.js:128
+msgid "Shadow"
 msgstr ""
 
-#: src/blocks/gallery-masonry/inspector.js:146
-#: src/blocks/gallery-stacked/inspector.js:165
+#: src/blocks/gallery-collage/inspector.js:147
+#: src/blocks/gallery-masonry/inspector.js:98
+#: src/blocks/gallery-stacked/inspector.js:111
 msgid "Captions"
 msgstr ""
 
-#: src/blocks/gallery-masonry/inspector.js:153
+#: src/blocks/gallery-collage/inspector.js:153
+#: src/blocks/gallery-masonry/inspector.js:105
 msgid "Caption Style"
 msgstr ""
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Showing captions for each media item."
 msgstr ""
 
-#: src/blocks/gallery-masonry/inspector.js:52
-#: src/blocks/gallery-stacked/inspector.js:55
+#: src/blocks/gallery-collage/inspector.js:30
+#: src/blocks/gallery-masonry/inspector.js:49
+#: src/blocks/gallery-stacked/inspector.js:52
 msgid "Toggle to show media captions."
 msgstr ""
 
-#: src/blocks/gallery-stacked/index.js:24
+#: src/blocks/gallery-masonry/edit.js:188
+msgid "Masonry"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:35
+msgid "Display multiple images in an organized masonry gallery."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Image lightbox is enabled."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:53
+#: src/blocks/gallery-stacked/inspector.js:56
+msgid "Toggle to enable the image lightbox."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:73
+msgid "Masonry Settings"
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:76
+msgid "Column Size"
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:84
+msgid "Add rounded corners to the gallery items."
+msgstr ""
+
+#: src/blocks/gallery-masonry/inspector.js:92
+#: src/blocks/gallery-stacked/inspector.js:123
+msgid "Lightbox"
+msgstr ""
+
+#: src/blocks/gallery-stacked/edit.js:168
 msgid "Stacked"
 msgstr ""
 
-#: src/blocks/gallery-stacked/index.js:38
+#: src/blocks/gallery-stacked/index.js:35
 msgid "Display multiple images in an single column stacked gallery."
 msgstr ""
 
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Images"
-msgstr ""
-
-#: src/blocks/gallery-stacked/inspector.js:137
-msgid "Fullwidth Image"
-msgstr ""
-
-#: src/blocks/gallery-stacked/inspector.js:159
+#: src/blocks/gallery-stacked/inspector.js:105
 msgid "Box Shadow"
 msgstr ""
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Fullwidth images are enabled."
 msgstr ""
 
-#: src/blocks/gallery-stacked/inspector.js:51
+#: src/blocks/gallery-stacked/inspector.js:48
 msgid "Toggle to fill the available gallery area with completely fullwidth images."
+msgstr ""
+
+#: src/blocks/gallery-stacked/inspector.js:80
+msgid "Stacked Settings"
+msgstr ""
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Images"
+msgstr ""
+
+#: src/blocks/gallery-stacked/inspector.js:83
+msgid "Fullwidth Image"
 msgstr ""
 
 #: src/blocks/gif/controls.js:44
 msgid "Remove gif"
 msgstr ""
 
-#: src/blocks/gif/edit.js:153
+#: src/blocks/gif/edit.js:152
 msgid "This gif has an empty alt attribute"
 msgstr ""
 
-#: src/blocks/gif/edit.js:288
+#: src/blocks/gif/edit.js:283
 msgid "Search for that perfect gif on Giphy"
 msgstr ""
 
-#: src/blocks/gif/edit.js:294
+#: src/blocks/gif/edit.js:289
 msgid "Search for gifs"
 msgstr ""
 
-#: src/blocks/gif/index.js:28
+#: src/blocks/gif/index.js:27
 msgid "Pick a gif, any gif."
-msgstr ""
-
-#: src/blocks/gif/index.js:30
-msgid "animated"
 msgstr ""
 
 #: src/blocks/gif/inspector.js:29
@@ -1024,11 +871,7 @@ msgid "Loading Gist"
 msgstr ""
 
 #: src/blocks/gist/index.js:29
-msgid "Embed GitHub gists by adding the gist link."
-msgstr ""
-
-#: src/blocks/gist/index.js:31
-msgid "code"
+msgid "Embed GitHub gists by adding a gist link."
 msgstr ""
 
 #: src/blocks/gist/inspector.js:31
@@ -1052,207 +895,155 @@ msgid "Gist Meta"
 msgstr ""
 
 #: src/blocks/hero/controls.js:32
-#: src/blocks/row/controls.js:71
 msgid "Change layout"
 msgstr ""
 
-#: src/blocks/hero/edit.js:157
-#: src/blocks/row/column/edit.js:92
-#: src/blocks/row/edit.js:170
-msgid "Add backround to %s"
+#: src/blocks/hero/edit.js:152
+msgid "Add backround to hero"
 msgstr ""
 
-#: src/blocks/hero/index.js:27
-msgid "Hero"
-msgstr ""
-
-#: src/blocks/hero/index.js:43
+#: src/blocks/hero/index.js:41
 msgid "An introductory area of a page accompanied by a small amount of text and a call to action."
 msgstr ""
 
-#: src/blocks/hero/index.js:45
-msgid "button"
-msgstr ""
-
-#: src/blocks/hero/index.js:45
-msgid "call to action"
-msgstr ""
-
-#: src/blocks/hero/inspector.js:107
+#: src/blocks/hero/inspector.js:127
 msgid "Content width in pixels"
 msgstr ""
 
-#: src/blocks/hero/inspector.js:71
+#: src/blocks/hero/inspector.js:81
 msgid "Hero Settings"
 msgstr ""
 
-#: src/blocks/hero/inspector.js:75
+#: src/blocks/hero/inspector.js:85
 #: src/blocks/media-card/inspector.js:63
-#: src/blocks/row/column/inspector.js:104
-#: src/blocks/row/inspector.js:214
+#: src/blocks/row/column/inspector.js:134
+#: src/blocks/row/inspector.js:181
 msgid "Space inside of the container."
 msgstr ""
 
 #: src/blocks/hero/layouts.js:12
-#: src/components/background/panel.js:83
-#: src/components/grid-control/index.js:35
 msgid "Top Left"
 msgstr ""
 
 #: src/blocks/hero/layouts.js:13
-#: src/components/background/panel.js:84
-#: src/components/grid-control/index.js:36
 msgid "Top Center"
 msgstr ""
 
 #: src/blocks/hero/layouts.js:14
-#: src/components/background/panel.js:85
-#: src/components/grid-control/index.js:37
 msgid "Top Right"
 msgstr ""
 
 #: src/blocks/hero/layouts.js:15
-#: src/components/background/panel.js:86
-#: src/components/grid-control/index.js:48
 msgid "Center Left"
 msgstr ""
 
 #: src/blocks/hero/layouts.js:16
-#: src/components/background/panel.js:87
-#: src/components/grid-control/index.js:49
 msgid "Center Center"
 msgstr ""
 
 #: src/blocks/hero/layouts.js:17
-#: src/components/background/panel.js:88
-#: src/components/grid-control/index.js:50
 msgid "Center Right"
 msgstr ""
 
 #: src/blocks/hero/layouts.js:18
-#: src/components/background/panel.js:89
-#: src/components/grid-control/index.js:41
 msgid "Bottom Left"
 msgstr ""
 
 #: src/blocks/hero/layouts.js:19
-#: src/components/background/panel.js:90
-#: src/components/grid-control/index.js:42
 msgid "Bottom Center"
 msgstr ""
 
 #: src/blocks/hero/layouts.js:20
-#: src/components/background/panel.js:91
-#: src/components/grid-control/index.js:43
 msgid "Bottom Right"
 msgstr ""
 
-#: src/blocks/highlight/edit.js:108
+#: src/blocks/highlight/edit.js:113
 msgid "Add highlighted text..."
 msgstr ""
 
-#: src/blocks/highlight/index.js:22
-msgid "Highlight"
+#: src/blocks/highlight/index.js:28
+msgid "Draw attention and emphasize important narrative."
 msgstr ""
 
-#: src/blocks/highlight/index.js:29
-msgid "Highlight text."
+#: src/blocks/highlight/index.js:33
+msgid "Add a highlight effect to paragraph text in order to grab attention and emphasize important narrative."
 msgstr ""
 
-#: src/blocks/highlight/index.js:31
-msgid "text"
-msgstr ""
-
-#: src/blocks/highlight/index.js:31
-msgid "paragraph"
-msgstr ""
-
-#: src/blocks/icon/index.js:27
-msgid "Icon"
-msgstr ""
-
-#: src/blocks/icon/index.js:34
-msgid "Add a stylized graphic symbol to communicate something more."
-msgstr ""
-
-#: src/blocks/icon/index.js:36
-#: src/blocks/social-profiles/index.js:23
-msgid "icons"
-msgstr ""
-
-#: src/blocks/icon/inspector.js:168
+#: src/blocks/icon/icon-size-select.js:30
 #: src/blocks/row/inspector.js:102
 #: src/components/dimensions-control/dimensions-select.js:30
 msgid "Huge"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:179
-#: src/blocks/share/inspector.js:90
-#: src/blocks/social-profiles/inspector.js:102
+#: src/blocks/icon/icon-size-select.js:79
+msgid "Choose icon size preset"
+msgstr ""
+
+#: src/blocks/icon/index.js:33
+msgid "Add a stylized graphic symbol to communicate something more."
+msgstr ""
+
+#: src/blocks/icon/inspector.js:155
+#: src/blocks/share/inspector.js:111
+#: src/blocks/social-profiles/inspector.js:115
 msgid "Icon Settings"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:192
-#: src/components/dimensions-control/index.js:484
-msgid "Turn off advanced %s settings"
+#: src/blocks/icon/inspector.js:168
+msgid "Reset icon size"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:194
-#: src/components/dimensions-control/index.js:486
+#: src/blocks/icon/inspector.js:170
+#: src/components/dimensions-control/index.js:489
 #: src/components/size-control/index.js:198
 msgid "Reset"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:221
-msgid "Custom %s size"
+#: src/blocks/icon/inspector.js:198
+msgid "Apply custom size"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:249
-#: src/components/dimensions-control/index.js:725
-msgid "Advanced %s settings"
+#: src/blocks/icon/inspector.js:201
+msgid "Custom"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:252
-#: src/components/dimensions-control/index.js:728
-msgid "Advanced"
-msgstr ""
-
-#: src/blocks/icon/inspector.js:260
+#: src/blocks/icon/inspector.js:209
 msgid "Radius"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:280
+#: src/blocks/icon/inspector.js:229
 msgid "Icon Search"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:329
+#: src/blocks/icon/inspector.js:278
 msgid "No results found."
 msgstr ""
 
-#: src/blocks/icon/inspector.js:335
+#: src/blocks/icon/inspector.js:284
 #: src/components/block-gallery/gallery-link-settings.js:63
 msgid "Link Settings"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:338
+#: src/blocks/icon/inspector.js:287
 msgid "Link URL"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:343
-#: src/components/block-gallery/gallery-link-settings.js:80
+#: src/blocks/icon/inspector.js:292
 msgid "Link Rel"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 msgid "Opening in New Tab"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:348
+#: src/blocks/icon/inspector.js:297
 #: src/components/block-gallery/gallery-link-settings.js:75
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:360
+#: src/blocks/icon/inspector.js:309
+#: src/blocks/share/inspector.js:104
+#: src/blocks/social-profiles/inspector.js:108
 msgid "Icon Color"
 msgstr ""
 
@@ -1261,29 +1052,16 @@ msgid "Edit logos"
 msgstr ""
 
 #: src/blocks/logos/edit.js:69
-#: src/blocks/logos/index.js:28
 msgid "Logos & Badges"
 msgstr ""
 
 #: src/blocks/logos/edit.js:70
-#: src/components/block-gallery/gallery-placeholder.js:71
+#: src/components/block-gallery/gallery-placeholder.js:72
 msgid "Drag images, upload new ones or select files from your library."
 msgstr ""
 
-#: src/blocks/logos/index.js:29
+#: src/blocks/logos/index.js:27
 msgid "Add logos, badges, or certifications to build credibility."
-msgstr ""
-
-#: src/blocks/logos/index.js:30
-msgid "clients"
-msgstr ""
-
-#: src/blocks/logos/index.js:30
-msgid "proof"
-msgstr ""
-
-#: src/blocks/logos/index.js:30
-msgid "testimonials"
 msgstr ""
 
 #: src/blocks/logos/inspector.js:12
@@ -1306,175 +1084,133 @@ msgstr ""
 msgid "Map style"
 msgstr ""
 
-#: src/blocks/map/edit.js:188
+#: src/blocks/map/edit.js:191
 msgid "Invalid API key, or too many requests"
 msgstr ""
 
-#: src/blocks/map/edit.js:295
+#: src/blocks/map/edit.js:294
 #: src/blocks/map/save.js:48
 msgid "Google Map"
 msgstr ""
 
-#: src/blocks/map/edit.js:296
+#: src/blocks/map/edit.js:295
 msgid "Enter a location or address to drop a pin on a Google map."
 msgstr ""
 
-#: src/blocks/map/edit.js:303
+#: src/blocks/map/edit.js:302
 msgid "Search for a place or address…"
 msgstr ""
 
-#: src/blocks/map/edit.js:308
-#: src/components/block-gallery/gallery-image.js:221
-msgid "Apply"
+#: src/blocks/map/edit.js:321
+msgid "Cancel"
 msgstr ""
 
-#: src/blocks/map/index.js:24
-msgid "Map"
+#: src/blocks/map/index.js:28
+msgid "Add an address or location to drop a pin on a Google map."
 msgstr ""
 
-#: src/blocks/map/index.js:29
-msgid "Add an address and drop a pin on a Google map."
-msgstr ""
-
-#: src/blocks/map/index.js:31
-msgid "address"
-msgstr ""
-
-#: src/blocks/map/index.js:31
-msgid "maps"
-msgstr ""
-
-#: src/blocks/map/index.js:31
-msgid "google"
-msgstr ""
-
-#: src/blocks/map/inspector.js:100
+#: src/blocks/map/inspector.js:105
 msgid "Select Map Style"
 msgstr ""
 
-#: src/blocks/map/inspector.js:121
+#: src/blocks/map/inspector.js:126
 msgid "Map Settings"
 msgstr ""
 
-#: src/blocks/map/inspector.js:124
-msgid "Zoom Level"
-msgstr ""
-
-#: src/blocks/map/inspector.js:134
+#: src/blocks/map/inspector.js:131
 msgid "Height for the map in pixels"
 msgstr ""
 
-#: src/blocks/map/inspector.js:145
+#: src/blocks/map/inspector.js:140
+msgid "Zoom Level"
+msgstr ""
+
+#: src/blocks/map/inspector.js:151
 msgid "Marker Size"
 msgstr ""
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Fine control options are enabled."
 msgstr ""
 
-#: src/blocks/map/inspector.js:160
+#: src/blocks/map/inspector.js:166
 msgid "Toggle to enable map control options."
 msgstr ""
 
-#: src/blocks/map/inspector.js:168
+#: src/blocks/map/inspector.js:174
 msgid "Map Controls"
 msgstr ""
 
-#: src/blocks/map/inspector.js:172
+#: src/blocks/map/inspector.js:178
 msgid "Map Type"
 msgstr ""
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Switching between standard and satellite map views is enabled."
 msgstr ""
 
-#: src/blocks/map/inspector.js:175
+#: src/blocks/map/inspector.js:181
 msgid "Toggle to enable switching between standard and satellite maps."
 msgstr ""
 
-#: src/blocks/map/inspector.js:178
+#: src/blocks/map/inspector.js:184
 msgid "Zoom Controls"
 msgstr ""
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Showing map zoom controls."
 msgstr ""
 
-#: src/blocks/map/inspector.js:181
+#: src/blocks/map/inspector.js:187
 msgid "Toggle to enable zooming in and out on the map with zoom controls."
 msgstr ""
 
-#: src/blocks/map/inspector.js:184
+#: src/blocks/map/inspector.js:190
 msgid "Street View"
 msgstr ""
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Showing the street view map control."
 msgstr ""
 
-#: src/blocks/map/inspector.js:187
+#: src/blocks/map/inspector.js:193
 msgid "Toggle to show the street view control at the bottom right."
 msgstr ""
 
-#: src/blocks/map/inspector.js:190
+#: src/blocks/map/inspector.js:196
 msgid "Fullscreen Toggle"
 msgstr ""
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Showing the fullscreen map control."
 msgstr ""
 
-#: src/blocks/map/inspector.js:193
+#: src/blocks/map/inspector.js:199
 msgid "Toggle to show the fullscreen map control."
 msgstr ""
 
-#: src/blocks/map/inspector.js:198
+#: src/blocks/map/inspector.js:204
 msgid "Google Maps API Key"
 msgstr ""
 
-#: src/blocks/map/inspector.js:202
+#: src/blocks/map/inspector.js:208
 msgid "Add your Google Maps API key. Updating this API key will set all your maps to use the new key."
 msgstr ""
 
-#: src/blocks/map/inspector.js:205
+#: src/blocks/map/inspector.js:211
 msgid "Retrieve your key"
 msgstr ""
 
-#: src/blocks/map/inspector.js:206
+#: src/blocks/map/inspector.js:212
 msgid "Need help?"
 msgstr ""
 
-#: src/blocks/map/inspector.js:212
+#: src/blocks/map/inspector.js:218
 msgid "Enter Google API Key…"
 msgstr ""
 
-#: src/blocks/map/inspector.js:221
+#: src/blocks/map/inspector.js:227
 msgid "Saved"
-msgstr ""
-
-#: src/blocks/map/styles.js:12
-msgid "Standard"
-msgstr ""
-
-#: src/blocks/map/styles.js:16
-msgid "Silver"
-msgstr ""
-
-#: src/blocks/map/styles.js:20
-msgid "Retro"
-msgstr ""
-
-#: src/blocks/map/styles.js:24
-#: src/components/block-gallery/options/caption-options.js:10
-msgid "Dark"
-msgstr ""
-
-#: src/blocks/map/styles.js:28
-msgid "Night"
-msgstr ""
-
-#: src/blocks/map/styles.js:32
-msgid "Aubergine"
 msgstr ""
 
 #: src/blocks/media-card/controls.js:28
@@ -1485,20 +1221,8 @@ msgstr ""
 msgid "Media on left"
 msgstr ""
 
-#: src/blocks/media-card/index.js:26
-msgid "Media Card"
-msgstr ""
-
-#: src/blocks/media-card/index.js:37
+#: src/blocks/media-card/index.js:36
 msgid "Add an image or video with an offset card side-by-side."
-msgstr ""
-
-#: src/blocks/media-card/index.js:39
-msgid "image"
-msgstr ""
-
-#: src/blocks/media-card/index.js:39
-msgid "video"
 msgstr ""
 
 #: src/blocks/media-card/inspector.js:109
@@ -1513,15 +1237,18 @@ msgstr ""
 msgid "Toggle to add a card shadow."
 msgstr ""
 
-#: src/blocks/media-card/inspector.js:116
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:118
 msgid " %s Shadow"
 msgstr ""
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:124
 msgid "Showing %s shadow."
 msgstr ""
 
-#: src/blocks/media-card/inspector.js:119
+#. %s: Placeholder is either 'Card, or 'Image'
+#: src/blocks/media-card/inspector.js:126
 msgid "Toggle to add an %s shadow"
 msgstr ""
 
@@ -1545,39 +1272,171 @@ msgstr ""
 msgid "Edit media"
 msgstr ""
 
-# %s: number of tables
-#: src/blocks/pricing-table/controls.js:38
-msgid "%s Tables"
+#: src/blocks/post-carousel/edit.js:123
+#: src/blocks/posts/edit.js:247
+msgid "Edit RSS URL"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:178
+msgid "Post Carousel"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:184
+#: src/blocks/posts/edit.js:295
+msgid "No posts found. Start publishing or add posts from an %s feed."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:187
+#: src/blocks/posts/edit.js:298
+msgid "Retrieve an External Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:193
+#: src/blocks/posts/edit.js:304
+msgid "Use External Feed"
+msgstr ""
+
+#. %s: RSS
+#: src/blocks/post-carousel/edit.js:216
+#: src/blocks/posts/edit.js:332
+msgid "%s Feed"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:217
+#: src/blocks/posts/edit.js:333
+msgid "%s URLs are generally located at the /feed/ directory of a site."
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:221
+#: src/blocks/posts/edit.js:337
+msgid "https://example.com/feed…"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:227
+#: src/blocks/posts/edit.js:343
+msgid "Use URL"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:320
+#: src/blocks/posts/edit.js:463
+#: src/blocks/post-carousel/index.php:366
+#: src/blocks/posts/index.php:385
+msgid "Read more"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:27
+msgid "Display posts or an external blog feed as a carousel."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:108
+#: src/blocks/posts/inspector.js:174
+msgid "Number of posts"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:38
+msgid "Post Carousel Settings"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:41
+#: src/blocks/posts/inspector.js:81
+msgid "Post Date"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:45
+#: src/blocks/posts/inspector.js:85
+msgid "Showing the publish date."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:46
+#: src/blocks/posts/inspector.js:86
+msgid "Toggle to show the publish date."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:51
+#: src/blocks/posts/inspector.js:91
+msgid "Post Content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:55
+#: src/blocks/posts/inspector.js:95
+msgid "Showing the post content."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:56
+#: src/blocks/posts/inspector.js:96
+msgid "Toggle to show the post content."
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:62
+#: src/blocks/posts/inspector.js:102
+msgid "Max words in content"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:86
+#: src/blocks/posts/inspector.js:152
+msgid "Feed Settings"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:90
+#: src/blocks/posts/inspector.js:156
+msgid "My Blog"
+msgstr ""
+
+#: src/blocks/post-carousel/inspector.js:91
+#: src/blocks/posts/inspector.js:157
+msgid "External Feed"
+msgstr ""
+
+#: src/blocks/posts/edit.js:260
+msgid "Image on left"
+msgstr ""
+
+#: src/blocks/posts/edit.js:265
+msgid "Image on right"
+msgstr ""
+
+#: src/blocks/posts/edit.js:289
+msgid "Blog Posts"
+msgstr ""
+
+#: src/blocks/posts/index.js:27
+msgid "Display posts or an RSS feed as stacked or horizontal cards."
+msgstr ""
+
+#: src/blocks/posts/inspector.js:129
+msgid "Thumbnail Size"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:78
+msgid "Posts Settings"
+msgstr ""
+
+#: src/blocks/pricing-table/controls.js:17
+msgid "One Pricing Table"
+msgstr ""
+
+#: src/blocks/pricing-table/controls.js:22
+msgid "Two Pricing Tables"
+msgstr ""
+
+#: src/blocks/pricing-table/controls.js:27
+msgid "Three Pricing Tables"
+msgstr ""
+
+#: src/blocks/pricing-table/controls.js:32
+msgid "Four Pricing Tables"
+msgstr ""
+
+#: src/blocks/pricing-table/controls.js:62
+msgid "Change pricing table count"
 msgstr ""
 
 #: src/blocks/pricing-table/edit.js:39
-msgid "Plan %s"
-msgstr ""
-
-#: src/blocks/pricing-table/index.js:22
-msgid "Pricing Table"
+msgid "Plan %d"
 msgstr ""
 
 #: src/blocks/pricing-table/index.js:29
-msgid "Add pricing tables."
-msgstr ""
-
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "landing"
-msgstr ""
-
-#: src/blocks/pricing-table/index.js:31
-#: src/blocks/pricing-table/pricing-table-item/index.js:31
-msgid "comparison"
-msgstr ""
-
-#: src/blocks/pricing-table/inspector.js:26
-msgid "Pricing Table Settings"
-msgstr ""
-
-#: src/blocks/pricing-table/inspector.js:28
-msgid "Tables"
+msgid "Add pricing tables to help visitors compare products and plans."
 msgstr ""
 
 #: src/blocks/pricing-table/pricing-table-item/edit.js:112
@@ -1596,128 +1455,165 @@ msgstr ""
 msgid "$"
 msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:22
-msgid "Pricing Table Item"
+#: src/blocks/pricing-table/pricing-table-item/index.js:27
+msgid "A pricing table to help visitors compare products and plans."
 msgstr ""
 
-#: src/blocks/pricing-table/pricing-table-item/index.js:29
-msgid "A column placed within the pricing table block."
+#: src/blocks/row/column/edit.js:90
+msgid "Add backround to column"
 msgstr ""
 
-#: src/blocks/row/column/index.js:22
-msgid "Column"
-msgstr ""
-
-#: src/blocks/row/column/index.js:36
+#: src/blocks/row/column/index.js:30
 msgid "An immediate child of a row."
 msgstr ""
 
-#: src/blocks/row/column/inspector.js:115
-msgid "Width"
-msgstr ""
-
-#: src/blocks/row/column/inspector.js:88
+#: src/blocks/row/column/inspector.js:108
 msgid "Column Settings"
 msgstr ""
 
-#: src/blocks/row/column/inspector.js:92
-#: src/blocks/row/inspector.js:191
+#: src/blocks/row/column/inspector.js:112
+#: src/blocks/row/inspector.js:158
 msgid "Space around the container."
 msgstr ""
 
-#: src/blocks/row/edit.js:122
+#: src/blocks/row/column/inspector.js:155
+msgid "Width"
+msgstr ""
+
+#: src/blocks/row/controls.js:70
+msgid "Change row block layout"
+msgstr ""
+
+#: src/blocks/row/edit.js:121
 msgid "one"
 msgstr ""
 
-#: src/blocks/row/edit.js:124
+#: src/blocks/row/edit.js:123
 msgid "two"
 msgstr ""
 
-#: src/blocks/row/edit.js:126
+#: src/blocks/row/edit.js:125
 msgid "three"
 msgstr ""
 
-#: src/blocks/row/edit.js:128
+#: src/blocks/row/edit.js:127
 msgid "four"
 msgstr ""
 
-#: src/blocks/row/edit.js:175
+#: src/blocks/row/edit.js:169
+msgid "Add backround to row"
+msgstr ""
+
+#: src/blocks/row/edit.js:174
 msgid "One Column"
 msgstr ""
 
-#: src/blocks/row/edit.js:176
+#: src/blocks/row/edit.js:175
 msgid "Two Columns"
 msgstr ""
 
-#: src/blocks/row/edit.js:177
+#: src/blocks/row/edit.js:176
 msgid "Three Columns"
 msgstr ""
 
-#: src/blocks/row/edit.js:178
+#: src/blocks/row/edit.js:177
 msgid "Four Columns"
 msgstr ""
 
-#: src/blocks/row/edit.js:203
+#: src/blocks/row/edit.js:202
 msgid "Row Layout"
 msgstr ""
 
-#: src/blocks/row/edit.js:203
-#: src/blocks/row/index.js:26
+#: src/blocks/row/edit.js:202
 msgid "Row"
 msgstr ""
 
-#: src/blocks/row/edit.js:204
+#. %s: 'one' 'two' 'three' and 'four'
+#: src/blocks/row/edit.js:205
 msgid "Now select a layout for this %s column row."
 msgstr ""
 
-#: src/blocks/row/edit.js:204
+#: src/blocks/row/edit.js:206
 msgid "Select the number of columns for this row."
 msgstr ""
 
-#: src/blocks/row/edit.js:208
+#: src/blocks/row/edit.js:211
 msgid "Select Row Columns"
 msgstr ""
 
-#: src/blocks/row/edit.js:233
-#: src/blocks/row/inspector.js:154
+#: src/blocks/row/edit.js:236
+#: src/blocks/row/inspector.js:121
 msgid "Select Row Layout"
 msgstr ""
 
-#: src/blocks/row/edit.js:243
+#: src/blocks/row/edit.js:246
 msgid "Back to Columns"
 msgstr ""
 
-#: src/blocks/row/index.js:40
+#: src/blocks/row/index.js:38
 msgid "Add a structured wrapper for column blocks, then add content blocks you’d like to the columns."
 msgstr ""
 
-#: src/blocks/row/index.js:42
-msgid "rows"
-msgstr ""
-
-#: src/blocks/row/index.js:42
-msgid "columns"
-msgstr ""
-
-#: src/blocks/row/index.js:42
-msgid "layouts"
-msgstr ""
-
-#: src/blocks/row/inspector.js:117
-#: src/components/grid-control/index.js:122
-msgid "Layout"
-msgstr ""
-
-#: src/blocks/row/inspector.js:186
+#: src/blocks/row/inspector.js:153
 msgid "Row Settings"
 msgstr ""
 
 #: src/blocks/row/inspector.js:98
-#: src/components/block-gallery/options/caption-options.js:12
 #: src/components/block-gallery/options/link-options.js:10
 #: src/components/dimensions-control/dimensions-select.js:10
-#: src/extensions/list-styles/index.js:21
 msgid "None"
+msgstr ""
+
+#: src/blocks/row/layouts.js:13
+msgid "Equal Split"
+msgstr ""
+
+#: src/blocks/row/layouts.js:14
+msgid "Two Thirds / One Third"
+msgstr ""
+
+#: src/blocks/row/layouts.js:15
+msgid "One Third / Two Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:16
+msgid "Three Quarters / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:17
+msgid "Quarter / Three Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:20
+msgid "Thirds"
+msgstr ""
+
+#: src/blocks/row/layouts.js:21
+msgid "Half / Quarter / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:22
+msgid "Quarter / Quarter/ Half"
+msgstr ""
+
+#: src/blocks/row/layouts.js:23
+msgid "Quarter / Half / Quarter"
+msgstr ""
+
+#: src/blocks/row/layouts.js:24
+msgid "One Fifth/ Three Fifths / One Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:27
+msgid "Quarters"
+msgstr ""
+
+#: src/blocks/row/layouts.js:28
+msgid "Two Fifths / Fifth / Fifth / Fifth"
+msgstr ""
+
+#: src/blocks/row/layouts.js:29
+msgid "Fifth / Fifth / Fifth / Two Fifths"
 msgstr ""
 
 #: src/blocks/services/edit.js:44
@@ -1728,16 +1624,8 @@ msgstr ""
 msgid "Circle"
 msgstr ""
 
-#: src/blocks/services/index.js:28
-msgid "Services"
-msgstr ""
-
-#: src/blocks/services/index.js:29
+#: src/blocks/services/index.js:27
 msgid "Add up to four columns of services to display."
-msgstr ""
-
-#: src/blocks/services/index.js:30
-msgid "features"
 msgstr ""
 
 #: src/blocks/services/inspector.js:67
@@ -1760,11 +1648,7 @@ msgstr ""
 msgid "Toggle to show call to action buttons."
 msgstr ""
 
-#: src/blocks/services/service/index.js:28
-msgid "Service"
-msgstr ""
-
-#: src/blocks/services/service/index.js:29
+#: src/blocks/services/service/index.js:27
 msgid "A single service item within a services block."
 msgstr ""
 
@@ -1785,149 +1669,138 @@ msgid "Toggle to show a call to action button."
 msgstr ""
 
 #: src/blocks/shape-divider/controls.js:28
-#: src/components/orientation/index.js:59
 msgid "Flip horiztonally"
 msgstr ""
 
 #: src/blocks/shape-divider/controls.js:33
-#: src/components/orientation/index.js:48
 msgid "Flip vertically"
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:23
-msgid "Shape Divider"
-msgstr ""
-
-#: src/blocks/shape-divider/index.js:30
+#: src/blocks/shape-divider/index.js:29
 msgid "Add a shape divider to visually distinquish page sections."
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:32
-msgid "separator"
-msgstr ""
-
-#: src/blocks/shape-divider/inspector.js:108
-msgid "Shape Color"
-msgstr ""
-
-#: src/blocks/shape-divider/inspector.js:56
+#: src/blocks/shape-divider/inspector.js:53
 msgid "Divider Settings"
 msgstr ""
 
-#: src/blocks/shape-divider/inspector.js:58
+#: src/blocks/shape-divider/inspector.js:55
 msgid "Shape Height in pixels"
 msgstr ""
 
-#: src/blocks/shape-divider/inspector.js:76
+#: src/blocks/shape-divider/inspector.js:73
 msgid "Background Height in pixels"
 msgstr ""
 
-#: src/blocks/shape-divider/inspector.js:94
-msgid "Orientation"
+#: src/blocks/shape-divider/inspector.js:98
+msgid "Shape Color"
 msgstr ""
 
-#: src/blocks/share/edit.js:102
+#: src/blocks/share/edit.js:113
 #: src/blocks/share/index.php:133
-msgid "Share on Twitter"
-msgstr ""
-
-#: src/blocks/share/edit.js:110
-#: src/blocks/share/index.php:137
 msgid "Share on Facebook"
 msgstr ""
 
-#: src/blocks/share/edit.js:118
+#: src/blocks/share/edit.js:121
+#: src/blocks/share/index.php:137
+msgid "Share on Twitter"
+msgstr ""
+
+#: src/blocks/share/edit.js:129
 #: src/blocks/share/index.php:141
 msgid "Share on Pinterest"
 msgstr ""
 
-#: src/blocks/share/edit.js:126
+#: src/blocks/share/edit.js:137
 msgid "Share on LinkedIn"
 msgstr ""
 
-#: src/blocks/share/edit.js:134
+#: src/blocks/share/edit.js:145
 #: src/blocks/share/index.php:149
 msgid "Share via Email"
 msgstr ""
 
-#: src/blocks/share/edit.js:142
+#: src/blocks/share/edit.js:153
 #: src/blocks/share/index.php:153
 msgid "Share on Tumblr"
 msgstr ""
 
-#: src/blocks/share/edit.js:150
+#: src/blocks/share/edit.js:161
 #: src/blocks/share/index.php:157
 msgid "Share on Google"
 msgstr ""
 
-#: src/blocks/share/edit.js:158
+#: src/blocks/share/edit.js:169
 #: src/blocks/share/index.php:161
 msgid "Share on Reddit"
 msgstr ""
 
-#: src/blocks/share/index.js:19
-msgid "Share"
-msgstr ""
-
-#: src/blocks/share/index.js:23
-msgid "social"
-msgstr ""
-
-#: src/blocks/share/index.js:28
+#: src/blocks/share/index.js:25
 msgid "Add social sharing links to help you get likes and shares."
 msgstr ""
 
-#: src/blocks/share/inspector.js:108
-#: src/blocks/social-profiles/inspector.js:120
+#: src/blocks/share/inspector.js:113
+#: src/blocks/social-profiles/inspector.js:117
+msgid "Social Colors"
+msgstr ""
+
+#: src/blocks/share/inspector.js:129
+#: src/blocks/social-profiles/inspector.js:133
 msgid "Icon Size"
 msgstr ""
 
-#: src/blocks/share/inspector.js:117
-#: src/blocks/social-profiles/inspector.js:129
+#: src/blocks/share/inspector.js:138
+#: src/blocks/social-profiles/inspector.js:142
 msgid "Circle Size"
 msgstr ""
 
-#: src/blocks/share/inspector.js:126
-#: src/blocks/social-profiles/inspector.js:138
+#: src/blocks/share/inspector.js:147
+#: src/blocks/social-profiles/inspector.js:151
 msgid "Button Size"
 msgstr ""
 
-#: src/blocks/share/inspector.js:134
+#: src/blocks/share/inspector.js:155
 msgid "Icons"
 msgstr ""
 
-#: src/blocks/share/inspector.js:136
-#: src/blocks/social-profiles/edit.js:196
+#: src/blocks/share/inspector.js:157
+#: src/blocks/social-profiles/edit.js:205
 #: src/blocks/social-profiles/index.php:72
 msgid "Twitter"
 msgstr ""
 
-#: src/blocks/share/inspector.js:141
-#: src/blocks/social-profiles/edit.js:150
+#: src/blocks/share/inspector.js:162
+#: src/blocks/social-profiles/edit.js:159
 #: src/blocks/social-profiles/index.php:68
 msgid "Facebook"
 msgstr ""
 
-#: src/blocks/share/inspector.js:146
-#: src/blocks/social-profiles/edit.js:290
+#: src/blocks/share/inspector.js:167
+#: src/blocks/social-profiles/edit.js:299
 #: src/blocks/social-profiles/index.php:80
 msgid "Pinterest"
 msgstr ""
 
-#: src/blocks/share/inspector.js:151
-#: src/blocks/social-profiles/edit.js:338
+#: src/blocks/share/inspector.js:172
+#: src/blocks/social-profiles/edit.js:347
 msgid "LinkedIn"
 msgstr ""
 
-#: src/blocks/share/inspector.js:161
+#: src/blocks/share/inspector.js:177
+#: includes/class-coblocks-form.php:210
+#: includes/class-coblocks-form.php:297
+msgid "Email"
+msgstr ""
+
+#: src/blocks/share/inspector.js:182
 msgid "Tumblr"
 msgstr ""
 
-#: src/blocks/share/inspector.js:166
+#: src/blocks/share/inspector.js:187
 msgid "Google"
 msgstr ""
 
-#: src/blocks/share/inspector.js:171
+#: src/blocks/share/inspector.js:192
 msgid "Reddit"
 msgstr ""
 
@@ -1941,108 +1814,95 @@ msgstr ""
 msgid "Toggle to use official colors from each social media platform."
 msgstr ""
 
-#: src/blocks/share/inspector.js:92
-#: src/blocks/social-profiles/inspector.js:104
-msgid "Social Colors"
-msgstr ""
-
-#: src/blocks/social-profiles/edit.js:133
+#: src/blocks/social-profiles/edit.js:142
 msgid "Add Facebook Profile"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:165
+#: src/blocks/social-profiles/edit.js:174
 msgid "https://facebook.com/"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:179
+#: src/blocks/social-profiles/edit.js:188
 msgid "Add Twitter Profile"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:211
+#: src/blocks/social-profiles/edit.js:220
 msgid "https://twitter.com/"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:225
+#: src/blocks/social-profiles/edit.js:234
 msgid "Add Instagram Profile"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:242
+#: src/blocks/social-profiles/edit.js:251
 #: src/blocks/social-profiles/index.php:76
 msgid "Instagram"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:257
+#: src/blocks/social-profiles/edit.js:266
 msgid "https://instagram.com/"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:273
+#: src/blocks/social-profiles/edit.js:282
 msgid "Add Pinterest Profile"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:305
+#: src/blocks/social-profiles/edit.js:314
 msgid "https://pinterest.com/"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:321
+#: src/blocks/social-profiles/edit.js:330
 msgid "Add LinkedIn Profile"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:353
+#: src/blocks/social-profiles/edit.js:362
 msgid "https://linkedin.com/"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:367
+#: src/blocks/social-profiles/edit.js:376
 msgid "Add YouTube Profile"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:384
+#: src/blocks/social-profiles/edit.js:393
 #: src/blocks/social-profiles/index.php:89
 msgid "YouTube"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:399
+#: src/blocks/social-profiles/edit.js:408
 msgid "https://youtube.com/"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:413
+#: src/blocks/social-profiles/edit.js:422
 msgid "Add Yelp Profile"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:430
+#: src/blocks/social-profiles/edit.js:439
 #: src/blocks/social-profiles/index.php:93
 msgid "Yelp"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:445
+#: src/blocks/social-profiles/edit.js:454
 msgid "https://yelp.com/"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:459
+#: src/blocks/social-profiles/edit.js:468
 msgid "Add Houzz Profile"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:476
+#: src/blocks/social-profiles/edit.js:485
 #: src/blocks/social-profiles/index.php:97
 msgid "Houzz"
 msgstr ""
 
-#: src/blocks/social-profiles/edit.js:491
+#: src/blocks/social-profiles/edit.js:500
 msgid "https://houzz.com/"
 msgstr ""
 
-#: src/blocks/social-profiles/index.js:19
-msgid "Social Profiles"
+#: src/blocks/social-profiles/index.js:25
+msgid "Grow your audience with links to social media profiles."
 msgstr ""
 
-#: src/blocks/social-profiles/index.js:23
-msgid "links"
-msgstr ""
-
-#: src/blocks/social-profiles/index.js:28
-msgid "Display links to social media profiles."
-msgstr ""
-
-#: src/blocks/social-profiles/inspector.js:146
+#: src/blocks/social-profiles/inspector.js:159
 msgid "Profile Links"
 msgstr ""
 
@@ -2056,18 +1916,6 @@ msgstr ""
 
 #: src/components/background/controls.js:96
 msgid "Background"
-msgstr ""
-
-#: src/components/background/panel.js:102
-msgid "Auto"
-msgstr ""
-
-#: src/components/background/panel.js:103
-msgid "Cover"
-msgstr ""
-
-#: src/components/background/panel.js:104
-msgid "Contain"
 msgstr ""
 
 #: src/components/background/panel.js:113
@@ -2126,18 +1974,6 @@ msgstr ""
 msgid "Remove "
 msgstr ""
 
-#: src/components/background/panel.js:95
-msgid "No Repeat"
-msgstr ""
-
-#: src/components/background/panel.js:97
-msgid "Repeat Horizontally"
-msgstr ""
-
-#: src/components/background/panel.js:98
-msgid "Repeat Vertically"
-msgstr ""
-
 #: src/components/block-gallery/gallery-image.js:189
 msgid "Move Image Backward"
 msgstr ""
@@ -2150,16 +1986,13 @@ msgstr ""
 msgid "Link To"
 msgstr ""
 
-#: src/components/block-gallery/gallery-placeholder.js:70
+#. %s: Type of gallery
+#: src/components/block-gallery/gallery-placeholder.js:71
 msgid "%s Gallery"
 msgstr ""
 
 #: src/components/block-gallery/gallery-uploader.js:53
 msgid "Upload an image"
-msgstr ""
-
-#: src/components/block-gallery/options/caption-options.js:11
-msgid "Light"
 msgstr ""
 
 #: src/components/block-gallery/options/link-options.js:11
@@ -2174,68 +2007,107 @@ msgstr ""
 msgid "Custom URL"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:408
-msgid "Pixel"
+#: src/components/crop-settings/index.js:275
+msgid "Crop settings image placeholder"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:412
-msgid "Em"
+#: src/components/crop-settings/index.js:304
+msgid "Image Orientation"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:416
-msgid "Percentage"
+#: src/components/crop-settings/index.js:310
+msgid "Rotate counter-clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:316
+msgid "Rotate clockwise"
+msgstr ""
+
+#: src/components/crop-settings/index.js:325
+msgid "Reset image cropping options"
+msgstr ""
+
+#: src/components/crop-settings/index.js:327
+msgid "Reset All"
 msgstr ""
 
 #: src/components/dimensions-control/index.js:461
 msgid "Select Units"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:470
+#. %s: values associated with CSS syntax, 'Pixel', 'Em', 'Percentage'
+#: src/components/dimensions-control/index.js:472
 msgid "%s Units"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:647
+#. %s: a texual label
+#: src/components/dimensions-control/index.js:487
+msgid "Turn off advanced %s settings"
+msgstr ""
+
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:659
 msgid "%s Top"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:657
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:670
 msgid "%s Right"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:667
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:681
 msgid "%s Bottom"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:677
+#. %s:  values associated with CSS syntax, 'Margin', 'Padding'
+#: src/components/dimensions-control/index.js:692
 msgid "%s Left"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Unsync"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:683
+#: src/components/dimensions-control/index.js:698
 msgid "Sync"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:686
+#: src/components/dimensions-control/index.js:701
 msgid "Sync Units"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:703
+#: src/components/dimensions-control/index.js:718
 msgid "Top"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:704
+#: src/components/dimensions-control/index.js:719
 msgid "Right"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:705
+#: src/components/dimensions-control/index.js:720
 msgid "Bottom"
 msgstr ""
 
-#: src/components/dimensions-control/index.js:706
+#: src/components/dimensions-control/index.js:721
 msgid "Left"
+msgstr ""
+
+#. %s:  a texual label
+#: src/components/dimensions-control/index.js:741
+msgid "Advanced %s settings"
+msgstr ""
+
+#: src/components/dimensions-control/index.js:744
+msgid "Advanced"
+msgstr ""
+
+#: src/components/font-family/index.js:16
+msgid "Default"
+msgstr ""
+
+#: src/components/grid-control/index.js:122
+msgid "Layout"
 msgstr ""
 
 #: src/components/grid-control/index.js:123
@@ -2254,7 +2126,7 @@ msgstr ""
 msgid "Toggle to enable fullscreen mode."
 msgstr ""
 
-# %s: heading level e.g: "1", "2", "3"
+#. %d: heading level e.g: "1", "2", "3"
 #: src/components/heading-toolbar/index.js:18
 msgid "Heading %d"
 msgstr ""
@@ -2263,43 +2135,15 @@ msgstr ""
 msgid "Custom color picker"
 msgstr ""
 
-#: src/components/media-filter-control/index.js:32
-msgid "Original"
-msgstr ""
-
-#: src/components/media-filter-control/index.js:40
-msgid "Grayscale"
-msgstr ""
-
-#: src/components/media-filter-control/index.js:48
-msgid "Sepia"
-msgstr ""
-
-#: src/components/media-filter-control/index.js:56
-msgid "Saturation"
-msgstr ""
-
-#: src/components/media-filter-control/index.js:64
-msgid "Dim"
-msgstr ""
-
-#: src/components/media-filter-control/index.js:72
-msgid "Vintage"
-msgstr ""
-
 #: src/components/media-filter-control/index.js:84
 msgid "Apply filter"
-msgstr ""
-
-#: src/components/orientation/index.js:47
-msgid "Select Orientation"
 msgstr ""
 
 #: src/components/responsive-base-control/index.js:68
 msgid "Height"
 msgstr ""
 
-# Control name
+#. %s:  values associated with CSS syntax, 'Width', 'Gutter', 'Height in pixels', 'Width'
 #: src/components/responsive-tabs-control/index.js:65
 msgid "Mobile %s"
 msgstr ""
@@ -2333,7 +2177,7 @@ msgid "Five Seconds"
 msgstr ""
 
 #: src/components/slider-panel/autoplay-options.js:15
-msgid "Six Second"
+msgid "Six Seconds"
 msgstr ""
 
 #: src/components/slider-panel/autoplay-options.js:16
@@ -2352,6 +2196,22 @@ msgstr ""
 msgid "Ten Seconds"
 msgstr ""
 
+#: src/components/slider-panel/index.js:102
+msgid "Free Scroll"
+msgstr ""
+
+#: src/components/slider-panel/index.js:108
+msgid "Arrow Navigation"
+msgstr ""
+
+#: src/components/slider-panel/index.js:114
+msgid "Dot Navigation"
+msgstr ""
+
+#: src/components/slider-panel/index.js:120
+msgid "Align Cells"
+msgstr ""
+
 #: src/components/slider-panel/index.js:24
 msgid "seconds"
 msgstr ""
@@ -2360,22 +2220,22 @@ msgstr ""
 msgid "second"
 msgstr ""
 
-# 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Advancing after %1$d %2$s."
 msgstr ""
 
-# 1. Speed of the slider, 2: Time until the slide advances
+#. 1. Speed of the slider, 2: Time until the slide advances
 #: src/components/slider-panel/index.js:27
 msgid "Automatically advance to the next slide."
 msgstr ""
 
 #: src/components/slider-panel/index.js:31
-msgid "Dragging and flicking enabled on desktop and mobile devices."
+msgid "Dragging and flicking enabled."
 msgstr ""
 
 #: src/components/slider-panel/index.js:31
-msgid "Toggle to enable drag functionality on desktop and mobile devices."
+msgid "Toggle to enable drag functionality."
 msgstr ""
 
 #: src/components/slider-panel/index.js:35
@@ -2387,43 +2247,55 @@ msgid "Toggle to show slide navigation arrows."
 msgstr ""
 
 #: src/components/slider-panel/index.js:39
-msgid "Showing dot navigation arrows."
+msgid "Showing dot navigation."
 msgstr ""
 
 #: src/components/slider-panel/index.js:39
 msgid "Toggle to show dot navigation."
 msgstr ""
 
-#: src/components/slider-panel/index.js:58
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the left."
+msgstr ""
+
+#: src/components/slider-panel/index.js:43
+msgid "Aligning slides to the center."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+msgid "Pausing autoplay when hovering."
+msgstr ""
+
+#: src/components/slider-panel/index.js:46
+msgid "Toggle to pause autoplay when hovered."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+msgid "Scrolling without fixed slides enabled."
+msgstr ""
+
+#: src/components/slider-panel/index.js:50
+msgid "Toggle to scroll without fixed slides."
+msgstr ""
+
+#: src/components/slider-panel/index.js:72
 msgid "Slider Settings"
 msgstr ""
 
-#: src/components/slider-panel/index.js:60
+#: src/components/slider-panel/index.js:74
 msgid "Autoplay"
 msgstr ""
 
-#: src/components/slider-panel/index.js:66
+#: src/components/slider-panel/index.js:81
 msgid "Transition Speed"
 msgstr ""
 
-#: src/components/slider-panel/index.js:73
+#: src/components/slider-panel/index.js:88
+msgid "Pause on Hover"
+msgstr ""
+
+#: src/components/slider-panel/index.js:96
 msgid "Draggable"
-msgstr ""
-
-#: src/components/slider-panel/index.js:79
-msgid "Arrow Navigation"
-msgstr ""
-
-#: src/components/slider-panel/index.js:85
-msgid "Dot Navigation"
-msgstr ""
-
-#: src/components/typography-controls/index.js:103
-msgid "Capitalize"
-msgstr ""
-
-#: src/components/typography-controls/index.js:107
-msgid "Normal"
 msgstr ""
 
 #: src/components/typography-controls/index.js:164
@@ -2458,19 +2330,6 @@ msgstr ""
 msgid "Change typography"
 msgstr ""
 
-#: src/components/typography-controls/index.js:84
-msgid "Bold"
-msgstr ""
-
-#: src/components/typography-controls/index.js:95
-#: src/formats/uppercase/index.js:36
-msgid "Uppercase"
-msgstr ""
-
-#: src/components/typography-controls/index.js:99
-msgid "Lowercase"
-msgstr ""
-
 #: src/extensions/advanced-controls/index.js:109
 msgid "Stack on Mobile"
 msgstr ""
@@ -2487,24 +2346,24 @@ msgstr ""
 msgid "Remove Top Spacing"
 msgstr ""
 
-#: src/extensions/advanced-controls/index.js:137
-msgid "Top margin is removed on this block."
+#: src/extensions/advanced-controls/index.js:135
+msgid "Toggle to add top margin back."
 msgstr ""
 
-#: src/extensions/advanced-controls/index.js:138
-msgid "Toggle to remove any margin applied to the top of this block."
+#: src/extensions/advanced-controls/index.js:135
+msgid "Toggle to remove any top margin."
 msgstr ""
 
-#: src/extensions/advanced-controls/index.js:146
+#: src/extensions/advanced-controls/index.js:140
 msgid "Remove Bottom Spacing"
 msgstr ""
 
-#: src/extensions/advanced-controls/index.js:171
-msgid "Bottom margin is removed on this block."
+#: src/extensions/advanced-controls/index.js:163
+msgid "Toggle to add bottom margin back."
 msgstr ""
 
-#: src/extensions/advanced-controls/index.js:172
-msgid "Toggle to remove any margin applied to the bottom of this block."
+#: src/extensions/advanced-controls/index.js:163
+msgid "Toggle to remove any bottom margin."
 msgstr ""
 
 #: src/extensions/button-controls/index.js:71
@@ -2519,20 +2378,12 @@ msgstr ""
 msgid "Toggle to display button as full width."
 msgstr ""
 
-#: src/extensions/button-styles/index.js:16
-msgid "Circular"
+#: src/extensions/image-crop/index.js:169
+msgid "Crop Settings"
 msgstr ""
 
-#: src/extensions/button-styles/index.js:22
-msgid "3D"
-msgstr ""
-
-#: src/extensions/button-styles/index.js:28
-msgid "Shadow"
-msgstr ""
-
-#: src/extensions/list-styles/index.js:27
-msgid "Checkbox"
+#: src/formats/uppercase/index.js:36
+msgid "Uppercase"
 msgstr ""
 
 #: src/sidebars/block-manager/components/modal.js:132
@@ -2559,107 +2410,696 @@ msgstr ""
 msgid "Disable all"
 msgstr ""
 
-#: src/sidebars/block-manager/components/options/disable-blocks.js:231
+#. %s: search text
+#: src/sidebars/block-manager/components/options/disable-blocks.js:233
 msgid "No \"%s\" blocks found."
 msgstr ""
 
-#: src/utils/block-category.js:20
+#. %s: Plugin title, i.e. CoBlocks
+#: src/utils/block-category.js:21
 msgid "%s Galleries"
 msgstr ""
 
-#: src/blocks/dynamic-separator/index.js:36
+#: src/blocks/accordion/accordion-item/controls.js:28
+msgctxt "Toggle label to display the accordion open"
+msgid "Display open"
+msgstr ""
+
+#: src/blocks/accordion/accordion-item/edit.js:67
+msgctxt "Accordion is the block name"
+msgid "Add accordion title..."
+msgstr ""
+
+#: src/blocks/accordion/accordion-item/index.js:26
+msgctxt "This is an inner block for the Accordion Block."
+msgid "Accordion Item"
+msgstr ""
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+msgctxt "block keyword"
+msgid "tabs"
+msgstr ""
+
+#: src/blocks/accordion/accordion-item/index.js:29
+#: src/blocks/accordion/index.js:30
+msgctxt "block keyword"
+msgid "faq"
+msgstr ""
+
+#: src/blocks/alert/index.js:31
+msgctxt "block keyword"
+msgid "notice"
+msgstr ""
+
+#: src/blocks/alert/index.js:31
+msgctxt "block keyword"
+msgid "message"
+msgstr ""
+
+#: src/blocks/author/index.js:31
+msgctxt "block keyword"
+msgid "biography"
+msgstr ""
+
+#: src/blocks/author/index.js:31
+msgctxt "block keyword"
+msgid "profile"
+msgstr ""
+
+#: src/blocks/buttons/index.js:31
+msgctxt "block keyword"
+msgid "link"
+msgstr ""
+
+#: src/blocks/buttons/index.js:31
+#: src/blocks/hero/index.js:43
+msgctxt "block keyword"
+msgid "cta"
+msgstr ""
+
+#: src/blocks/click-to-tweet/index.js:31
+#: src/blocks/social-profiles/index.js:28
+msgctxt "block keyword"
+msgid "share"
+msgstr ""
+
+#: src/blocks/click-to-tweet/index.js:31
+msgctxt "block keyword"
+msgid "twitter"
+msgstr ""
+
+#: src/blocks/dynamic-separator/index.js:30
+msgctxt "block keyword"
+msgid "spacer"
+msgstr ""
+
+#: src/blocks/features/index.js:37
+msgctxt "block keyword"
+msgid "services"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/index.js:29
+#: src/blocks/food-and-drinks/index.js:29
+msgctxt "block keyword"
+msgid "menu"
+msgstr ""
+
+#: src/blocks/food-and-drinks/index.js:29
+msgctxt "block keyword"
+msgid "restaurant"
+msgstr ""
+
+#: src/blocks/form/fields/email/index.js:22
+msgctxt "block keyword"
+msgid "e-mail"
+msgstr ""
+
+#: src/blocks/form/fields/email/index.js:22
+msgctxt "block keyword"
+msgid "mail"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "first name"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:22
+msgctxt "block keyword"
+msgid "last name"
+msgstr ""
+
+#: src/blocks/form/fields/textarea/index.js:22
+msgctxt "block keyword"
+msgid "Textarea"
+msgstr ""
+
+#: src/blocks/form/fields/textarea/index.js:22
+msgctxt "block keyword"
+msgid "Multiline text"
+msgstr ""
+
+#: src/blocks/form/index.js:29
+msgctxt "block keyword"
+msgid "email"
+msgstr ""
+
+#: src/blocks/form/index.js:29
+msgctxt "block keyword"
+msgid "about"
+msgstr ""
+
+#: src/blocks/form/index.js:29
+msgctxt "block keyword"
+msgid "contact"
+msgstr ""
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+msgctxt "block keyword"
+msgid "gallery"
+msgstr ""
+
+#: src/blocks/gallery-carousel/index.js:38
+#: src/blocks/gallery-collage/index.js:36
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+msgctxt "block keyword"
+msgid "photos"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:37
+#: src/blocks/gallery-stacked/index.js:37
+msgctxt "block keyword"
+msgid "lightbox"
+msgstr ""
+
+#: src/blocks/gif/index.js:29
+msgctxt "block keyword"
+msgid "animated"
+msgstr ""
+
+#: src/blocks/gist/index.js:31
+msgctxt "block keyword"
+msgid "code"
+msgstr ""
+
+#: src/blocks/hero/index.js:43
+msgctxt "block keyword"
+msgid "button"
+msgstr ""
+
+#: src/blocks/hero/index.js:43
+msgctxt "block keyword"
+msgid "call to action"
+msgstr ""
+
+#: src/blocks/highlight/index.js:30
+msgctxt "block keyword"
+msgid "text"
+msgstr ""
+
+#: src/blocks/highlight/index.js:30
+msgctxt "block keyword"
+msgid "paragraph"
+msgstr ""
+
+#: src/blocks/icon/index.js:35
+#: src/blocks/social-profiles/index.js:28
+msgctxt "block keyword"
+msgid "icons"
+msgstr ""
+
+#: src/blocks/logos/index.js:29
+msgctxt "block keyword"
+msgid "clients"
+msgstr ""
+
+#: src/blocks/logos/index.js:29
+msgctxt "block keyword"
+msgid "proof"
+msgstr ""
+
+#: src/blocks/logos/index.js:29
+msgctxt "block keyword"
+msgid "testimonials"
+msgstr ""
+
+#: src/blocks/map/index.js:30
+msgctxt "block keyword"
+msgid "address"
+msgstr ""
+
+#: src/blocks/map/index.js:30
+msgctxt "block keyword"
+msgid "maps"
+msgstr ""
+
+#: src/blocks/map/index.js:30
+msgctxt "block keyword"
+msgid "google"
+msgstr ""
+
+#: src/blocks/media-card/index.js:38
+msgctxt "block keyword"
+msgid "image"
+msgstr ""
+
+#: src/blocks/media-card/index.js:38
+msgctxt "block keyword"
+msgid "video"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "posts"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+msgctxt "block keyword"
+msgid "slider"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:29
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "latest"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "blog"
+msgstr ""
+
+#: src/blocks/posts/index.js:29
+msgctxt "block keyword"
+msgid "rss"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+msgctxt "block keyword"
+msgid "landing"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:31
+#: src/blocks/pricing-table/pricing-table-item/index.js:29
+msgctxt "block keyword"
+msgid "comparison"
+msgstr ""
+
+#: src/blocks/row/index.js:40
+msgctxt "block keyword"
+msgid "rows"
+msgstr ""
+
+#: src/blocks/row/index.js:40
+msgctxt "block keyword"
+msgid "columns"
+msgstr ""
+
+#: src/blocks/row/index.js:40
+msgctxt "block keyword"
+msgid "layouts"
+msgstr ""
+
+#: src/blocks/services/index.js:29
+msgctxt "block keyword"
+msgid "features"
+msgstr ""
+
+#: src/blocks/shape-divider/index.js:31
+msgctxt "block keyword"
+msgid "separator"
+msgstr ""
+
+#: src/blocks/share/index.js:28
+msgctxt "block keyword"
+msgid "social"
+msgstr ""
+
+#: src/blocks/social-profiles/index.js:28
+msgctxt "block keyword"
+msgid "links"
+msgstr ""
+
+#: src/blocks/accordion/accordion-item/inspector.js:65
+msgctxt "Visually display open as opposed to closed."
+msgid "Display Open"
+msgstr ""
+
+#: src/blocks/accordion/edit.js:74
+msgctxt "Add a child element for the Accordion block"
+msgid "Add Accordion Item"
+msgstr ""
+
+#: src/blocks/accordion/index.js:27
+msgctxt "block title"
+msgid "Accordion"
+msgstr ""
+
+#: src/blocks/alert/edit.js:102
+msgctxt "Placeholder text for input box"
+msgid "Write text..."
+msgstr ""
+
+#: src/blocks/alert/edit.js:94
+msgctxt "Placeholder text for input box"
+msgid "Write title..."
+msgstr ""
+
+#: src/blocks/alert/index.js:28
+msgctxt "block name"
+msgid "Alert"
+msgstr ""
+
+#: src/blocks/author/index.js:28
+msgctxt "block name"
+msgid "Author"
+msgstr ""
+
+#: src/blocks/buttons/index.js:28
+msgctxt "block name"
+msgid "Buttons"
+msgstr ""
+
+#: src/blocks/click-to-tweet/index.js:28
+msgctxt "block name"
+msgid "Click to Tweet"
+msgstr ""
+
+#: src/blocks/dynamic-separator/index.js:27
+msgctxt "block name"
+msgid "Dynamic HR"
+msgstr ""
+
+#: src/blocks/features/feature/index.js:28
+msgctxt "block name"
+msgid "Feature"
+msgstr ""
+
+#: src/blocks/features/index.js:34
+msgctxt "block name"
+msgid "Features"
+msgstr ""
+
+#: src/blocks/food-and-drinks/food-item/index.js:26
+msgctxt "block name"
+msgid "Food Item"
+msgstr ""
+
+#: src/blocks/food-and-drinks/index.js:26
+msgctxt "block name"
+msgid "Food & Drinks"
+msgstr ""
+
+#: src/blocks/form/fields/email/index.js:19
+msgctxt "block name"
+msgid "Email"
+msgstr ""
+
+#: src/blocks/form/fields/name/index.js:19
+msgctxt "block name"
+msgid "Name"
+msgstr ""
+
+#: src/blocks/form/fields/textarea/index.js:19
+msgctxt "block name"
+msgid "Message"
+msgstr ""
+
+#: src/blocks/form/index.js:26
+msgctxt "block name"
+msgid "Form"
+msgstr ""
+
+#: src/blocks/gallery-carousel/index.js:34
+msgctxt "block name"
+msgid "Carousel"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:33
+msgctxt "block name"
+msgid "Collage"
+msgstr ""
+
+#: src/blocks/gallery-masonry/index.js:34
+msgctxt "block name"
+msgid "Masonry"
+msgstr ""
+
+#: src/blocks/gallery-stacked/index.js:34
+msgctxt "block name"
+msgid "Stacked"
+msgstr ""
+
+#: src/blocks/gif/index.js:26
+msgctxt "block name"
+msgid "Gif"
+msgstr ""
+
+#: src/blocks/gist/index.js:28
+msgctxt "block name"
+msgid "Gist"
+msgstr ""
+
+#: src/blocks/hero/index.js:40
+msgctxt "block name"
+msgid "Hero"
+msgstr ""
+
+#: src/blocks/highlight/index.js:27
+msgctxt "block name"
+msgid "Highlight"
+msgstr ""
+
+#: src/blocks/icon/index.js:32
+msgctxt "block name"
+msgid "Icon"
+msgstr ""
+
+#: src/blocks/logos/index.js:26
+msgctxt "block name"
+msgid "Logos & Badges"
+msgstr ""
+
+#: src/blocks/map/index.js:27
+msgctxt "block name"
+msgid "Map"
+msgstr ""
+
+#: src/blocks/media-card/index.js:35
+msgctxt "block name"
+msgid "Media Card"
+msgstr ""
+
+#: src/blocks/post-carousel/index.js:26
+msgctxt "block name"
+msgid "Post Carousel"
+msgstr ""
+
+#: src/blocks/posts/index.js:26
+msgctxt "block name"
+msgid "Posts"
+msgstr ""
+
+#: src/blocks/pricing-table/index.js:28
+msgctxt "block name"
+msgid "Pricing Table"
+msgstr ""
+
+#: src/blocks/pricing-table/pricing-table-item/index.js:26
+msgctxt "block name"
+msgid "Pricing Table Item"
+msgstr ""
+
+#: src/blocks/row/column/index.js:29
+msgctxt "block name"
+msgid "Column"
+msgstr ""
+
+#: src/blocks/row/index.js:37
+msgctxt "block name"
+msgid "Row"
+msgstr ""
+
+#: src/blocks/services/index.js:26
+msgctxt "block name"
+msgid "Services"
+msgstr ""
+
+#: src/blocks/services/service/index.js:26
+msgctxt "block name"
+msgid "Service"
+msgstr ""
+
+#: src/blocks/shape-divider/index.js:28
+msgctxt "block name"
+msgid "Shape Divider"
+msgstr ""
+
+#: src/blocks/share/index.js:24
+msgctxt "block name"
+msgid "Share"
+msgstr ""
+
+#: src/blocks/social-profiles/index.js:24
+msgctxt "block name"
+msgid "Social Profiles"
+msgstr ""
+
+#: src/blocks/alert/index.js:33
+msgctxt "block style"
+msgid "Info"
+msgstr ""
+
+#: src/blocks/alert/index.js:34
+msgctxt "block style"
+msgid "Success"
+msgstr ""
+
+#: src/blocks/alert/index.js:35
+msgctxt "block style"
+msgid "Warning"
+msgstr ""
+
+#: src/blocks/alert/index.js:36
+msgctxt "block style"
+msgid "Error"
+msgstr ""
+
+#: src/blocks/dynamic-separator/index.js:32
 msgctxt "block style"
 msgid "Dot"
 msgstr ""
 
-#: src/blocks/dynamic-separator/index.js:37
+#: src/blocks/dynamic-separator/index.js:33
 msgctxt "block style"
 msgid "Line"
 msgstr ""
 
-#: src/blocks/dynamic-separator/index.js:38
+#: src/blocks/dynamic-separator/index.js:34
 msgctxt "block style"
 msgid "Fullwidth"
 msgstr ""
 
-#: src/blocks/icon/index.js:41
+#: src/blocks/food-and-drinks/edit.js:35
+msgctxt "block style"
+msgid "Grid"
+msgstr ""
+
+#: src/blocks/food-and-drinks/edit.js:42
+msgctxt "block style"
+msgid "List"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:40
+#: src/extensions/image-styles/index.js:15
+msgctxt "block style"
+msgid "Default"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:45
+msgctxt "block style"
+msgid "Tiled"
+msgstr ""
+
+#: src/blocks/gallery-collage/index.js:49
+msgctxt "block style"
+msgid "Layered"
+msgstr ""
+
+#: src/blocks/icon/index.js:37
 msgctxt "block style"
 msgid "Outlined"
 msgstr ""
 
-#: src/blocks/icon/index.js:42
+#: src/blocks/icon/index.js:38
 msgctxt "block style"
 msgid "Filled"
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:43
+#: src/blocks/posts/edit.js:49
+msgctxt "block style"
+msgid "Stacked"
+msgstr ""
+
+#: src/blocks/posts/edit.js:55
+msgctxt "block style"
+msgid "Horizontal"
+msgstr ""
+
+#: src/blocks/shape-divider/index.js:38
 msgctxt "block style"
 msgid "Wavy"
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:44
+#: src/blocks/shape-divider/index.js:39
 msgctxt "block style"
 msgid "Hills"
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:45
+#: src/blocks/shape-divider/index.js:40
 msgctxt "block style"
 msgid "Waves"
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:46
+#: src/blocks/shape-divider/index.js:41
 msgctxt "block style"
 msgid "Angled"
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:47
+#: src/blocks/shape-divider/index.js:42
 msgctxt "block style"
 msgid "Sloped"
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:48
+#: src/blocks/shape-divider/index.js:43
 msgctxt "block style"
 msgid "Rounded"
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:49
+#: src/blocks/shape-divider/index.js:44
 msgctxt "block style"
 msgid "Triangle"
 msgstr ""
 
-#: src/blocks/shape-divider/index.js:50
+#: src/blocks/shape-divider/index.js:45
 msgctxt "block style"
 msgid "Pointed"
+msgstr ""
+
+#: src/blocks/share/index.js:30
+#: src/blocks/social-profiles/index.js:30
+msgctxt "block style"
+msgid "Mask"
+msgstr ""
+
+#: src/blocks/share/index.js:31
+#: src/blocks/social-profiles/index.js:31
+msgctxt "block style"
+msgid "Icon"
+msgstr ""
+
+#: src/blocks/share/index.js:32
+#: src/blocks/social-profiles/index.js:32
+msgctxt "block style"
+msgid "Text"
 msgstr ""
 
 #: src/blocks/share/index.js:33
 #: src/blocks/social-profiles/index.js:33
 msgctxt "block style"
-msgid "Mask"
+msgid "Icon & Text"
 msgstr ""
 
 #: src/blocks/share/index.js:34
 #: src/blocks/social-profiles/index.js:34
 msgctxt "block style"
-msgid "Icon"
-msgstr ""
-
-#: src/blocks/share/index.js:35
-#: src/blocks/social-profiles/index.js:35
-msgctxt "block style"
-msgid "Text"
-msgstr ""
-
-#: src/blocks/share/index.js:36
-#: src/blocks/social-profiles/index.js:36
-msgctxt "block style"
-msgid "Icon & Text"
-msgstr ""
-
-#: src/blocks/share/index.js:37
-#: src/blocks/social-profiles/index.js:37
-msgctxt "block style"
 msgid "Circular"
+msgstr ""
+
+#: src/extensions/image-styles/index.js:21
+msgctxt "block style"
+msgid "Bottom Wave"
+msgstr ""
+
+#: src/extensions/image-styles/index.js:27
+msgctxt "block style"
+msgid "Top Wave"
+msgstr ""
+
+#: src/blocks/author/edit.js:63
+msgctxt "image to represent the post author"
+msgid "Drop to upload as avatar"
+msgstr ""
+
+#: src/blocks/author/edit.js:149
+msgctxt "content placeholder"
+msgid "Author link…"
 msgstr ""
 
 #: src/blocks/features/feature/edit.js:31
@@ -2682,24 +3122,24 @@ msgctxt "content placeholder"
 msgid "This is a feature block that you can use to highlight features."
 msgstr ""
 
-#: src/blocks/hero/edit.js:36
+#: src/blocks/hero/edit.js:35
 msgctxt "content placeholder"
-msgid "Add hero heading..."
+msgid "Add hero heading…"
 msgstr ""
 
-#: src/blocks/hero/edit.js:37
+#: src/blocks/hero/edit.js:36
 msgctxt "content placeholder"
 msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
 msgstr ""
 
-#: src/blocks/hero/edit.js:40
+#: src/blocks/hero/edit.js:39
 msgctxt "content placeholder"
-msgid "Add primary action..."
+msgid "Primary button…"
 msgstr ""
 
-#: src/blocks/hero/edit.js:41
+#: src/blocks/hero/edit.js:40
 msgctxt "content placeholder"
-msgid "Add secondary action..."
+msgid "Secondary button…"
 msgstr ""
 
 #: src/blocks/media-card/edit.js:46
@@ -2722,24 +3162,107 @@ msgctxt "content placeholder"
 msgid "Replace this text with descriptive copy to go along with the card image. Then add more blocks to this card, such as buttons, lists or images."
 msgstr ""
 
-#: src/blocks/services/service/edit.js:194
+#: src/blocks/services/service/edit.js:204
 msgctxt "content placeholder"
 msgid "Write title..."
 msgstr ""
 
-#: src/blocks/services/service/edit.js:200
+#: src/blocks/services/service/edit.js:210
 msgctxt "content placeholder"
 msgid "Write description..."
 msgstr ""
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Normal"
+#: src/blocks/buttons/inspector.js:28
+msgctxt "block settings"
+msgid "Buttons Settings"
 msgstr ""
 
-#: src/blocks/icon/inspector.js:223
-msgctxt "size name"
-msgid "Custom"
+#: src/blocks/buttons/inspector.js:43
+msgctxt "visually stack buttons one on top of another"
+msgid "Stack on mobile"
+msgstr ""
+
+#: src/blocks/dynamic-separator/inspector.js:43
+msgctxt "hr is html markup - horizonal rule"
+msgid "Dynamic HR Settings"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:55
+msgctxt "label for no gutter option"
+msgid "None"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:84
+msgctxt "abbreviation for \"Short\" size"
+msgid "None"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:60
+msgctxt "label for small gutter option"
+msgid "Small"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:89
+#: src/blocks/posts/inspector.js:58
+msgctxt "abbreviation for \"Small\" size"
+msgid "S"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:65
+msgctxt "label for medium gutter option"
+msgid "Medium"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:94
+#: src/blocks/posts/inspector.js:63
+msgctxt "abbreviation for \"Medium\" size"
+msgid "M"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:70
+msgctxt "label for large gutter option"
+msgid "Large"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:99
+#: src/blocks/posts/inspector.js:68
+msgctxt "abbreviation for \"Large\" size"
+msgid "L"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:73
+msgctxt "abbreviation for \"Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:75
+msgctxt "label for extra large gutter option"
+msgid "Extra Large"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:76
+msgctxt "abbreviation for \"Extra Large\" size"
+msgid "XL"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:83
+msgctxt "label for no shadow option"
+msgid "None"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:88
+msgctxt "label for small shadow option"
+msgid "Small"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:93
+msgctxt "label for medium shadow option"
+msgid "Medium"
+msgstr ""
+
+#: src/blocks/gallery-collage/inspector.js:98
+msgctxt "label for large shadow option"
+msgid "Large"
 msgstr ""
 
 #: src/blocks/icon/svgs.js:102
@@ -3302,12 +3825,294 @@ msgctxt "tags"
 msgid "palette design colors artist creative media paint paintbrush"
 msgstr ""
 
+#: src/blocks/map/styles.js:12
+msgctxt "block styles"
+msgid "Standard"
+msgstr ""
+
+#: src/blocks/map/styles.js:16
+msgctxt "block styles"
+msgid "Silver"
+msgstr ""
+
+#: src/blocks/map/styles.js:20
+msgctxt "block styles"
+msgid "Retro"
+msgstr ""
+
+#: src/blocks/map/styles.js:24
+msgctxt "block styles"
+msgid "Dark"
+msgstr ""
+
+#: src/blocks/map/styles.js:28
+msgctxt "block styles"
+msgid "Night"
+msgstr ""
+
+#: src/blocks/map/styles.js:32
+msgctxt "block styles"
+msgid "Aubergine"
+msgstr ""
+
+#: src/extensions/button-styles/index.js:16
+msgctxt "block styles"
+msgid "Circular"
+msgstr ""
+
+#: src/extensions/button-styles/index.js:22
+msgctxt "block styles"
+msgid "3D"
+msgstr ""
+
+#: src/extensions/button-styles/index.js:28
+msgctxt "block styles"
+msgid "Shadow"
+msgstr ""
+
+#: src/extensions/list-styles/index.js:15
+msgctxt "block styles"
+msgid "Default"
+msgstr ""
+
+#: src/extensions/list-styles/index.js:21
+msgctxt "block styles"
+msgid "None"
+msgstr ""
+
+#: src/extensions/list-styles/index.js:27
+msgctxt "block styles"
+msgid "Checkbox"
+msgstr ""
+
+#: src/blocks/post-carousel/edit.js:302
+#: src/blocks/posts/edit.js:437
+#: src/blocks/post-carousel/index.php:185
+#: src/blocks/posts/index.php:202
+msgctxt "placeholder when a post has no title"
+msgid "(no title)"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:57
+msgctxt "label for small size option"
+msgid "Small"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:62
+msgctxt "label for medium size option"
+msgid "Medium"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:67
+msgctxt "label for large size option"
+msgid "Large"
+msgstr ""
+
+#: src/blocks/posts/inspector.js:72
+msgctxt "label for large size option"
+msgid "Extra Large"
+msgstr ""
+
+#: src/components/background/panel.js:102
+msgctxt "block layout"
+msgid "Auto"
+msgstr ""
+
+#: src/components/background/panel.js:103
+msgctxt "block layout"
+msgid "Cover"
+msgstr ""
+
+#: src/components/background/panel.js:104
+msgctxt "block layout"
+msgid "Contain"
+msgstr ""
+
+#: src/components/background/panel.js:83
+#: src/components/grid-control/index.js:35
+msgctxt "block layout"
+msgid "Top Left"
+msgstr ""
+
+#: src/components/background/panel.js:84
+#: src/components/grid-control/index.js:36
+msgctxt "block layout"
+msgid "Top Center"
+msgstr ""
+
+#: src/components/background/panel.js:85
+#: src/components/grid-control/index.js:37
+msgctxt "block layout"
+msgid "Top Right"
+msgstr ""
+
+#: src/components/background/panel.js:86
+#: src/components/grid-control/index.js:48
+msgctxt "block layout"
+msgid "Center Left"
+msgstr ""
+
+#: src/components/background/panel.js:87
+#: src/components/grid-control/index.js:49
+msgctxt "block layout"
+msgid "Center Center"
+msgstr ""
+
+#: src/components/background/panel.js:88
+#: src/components/grid-control/index.js:50
+msgctxt "block layout"
+msgid "Center Right"
+msgstr ""
+
+#: src/components/background/panel.js:89
+#: src/components/grid-control/index.js:41
+msgctxt "block layout"
+msgid "Bottom Left"
+msgstr ""
+
+#: src/components/background/panel.js:90
+#: src/components/grid-control/index.js:42
+msgctxt "block layout"
+msgid "Bottom Center"
+msgstr ""
+
+#: src/components/background/panel.js:91
+#: src/components/grid-control/index.js:43
+msgctxt "block layout"
+msgid "Bottom Right"
+msgstr ""
+
+#: src/components/background/panel.js:95
+msgctxt "block layout"
+msgid "No Repeat"
+msgstr ""
+
+#: src/components/background/panel.js:96
+msgctxt "block layout"
+msgid "Repeat"
+msgstr ""
+
+#: src/components/background/panel.js:97
+msgctxt "block layout"
+msgid "Repeat Horizontally"
+msgstr ""
+
+#: src/components/background/panel.js:98
+msgctxt "block layout"
+msgid "Repeat Vertically"
+msgstr ""
+
+#: src/components/block-gallery/gallery-link-settings.js:80
+msgctxt "HTML attribute that specifies the a relationship between the two pages."
+msgid "Link Rel"
+msgstr ""
+
+#: src/components/block-gallery/options/caption-options.js:10
+msgctxt "visual style option"
+msgid "Dark"
+msgstr ""
+
+#: src/components/block-gallery/options/caption-options.js:11
+msgctxt "visual style option"
+msgid "Light"
+msgstr ""
+
+#: src/components/block-gallery/options/caption-options.js:12
+msgctxt "visual style option"
+msgid "None"
+msgstr ""
+
+#: src/components/crop-settings/index.js:280
+msgctxt "label for horizontal positioning input"
+msgid "Horizontal Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:288
+msgctxt "label for vertical positioning input"
+msgid "Vertical Pos."
+msgstr ""
+
+#: src/components/crop-settings/index.js:297
+msgctxt "label for the control that allows zooming in on the image"
+msgid "Image Zoom"
+msgstr ""
+
+#: src/components/dimensions-control/index.js:408
+msgctxt "A size unit for CSS markup"
+msgid "Pixel"
+msgstr ""
+
+#: src/components/dimensions-control/index.js:412
+msgctxt "A size unit for CSS markup"
+msgid "Em"
+msgstr ""
+
+#: src/components/dimensions-control/index.js:416
+msgctxt "A size unit for CSS markup"
+msgid "Percentage"
+msgstr ""
+
+#: src/components/media-filter-control/index.js:31
+msgctxt "image styles"
+msgid "Original"
+msgstr ""
+
+#: src/components/media-filter-control/index.js:39
+msgctxt "image styles"
+msgid "Grayscale Filter"
+msgstr ""
+
+#: src/components/media-filter-control/index.js:47
+msgctxt "image styles"
+msgid "Sepia Filter"
+msgstr ""
+
+#: src/components/media-filter-control/index.js:55
+msgctxt "image styles"
+msgid "Saturation Filter"
+msgstr ""
+
+#: src/components/media-filter-control/index.js:63
+msgctxt "image styles"
+msgid "Dim Filter"
+msgstr ""
+
+#: src/components/media-filter-control/index.js:71
+msgctxt "image styles"
+msgid "Vintage Filter"
+msgstr ""
+
+#: src/components/typography-controls/index.js:103
+msgctxt "typography styles"
+msgid "Capitalize"
+msgstr ""
+
+#: src/components/typography-controls/index.js:107
+msgctxt "typography styles"
+msgid "Normal"
+msgstr ""
+
+#: src/components/typography-controls/index.js:84
+msgctxt "typography styles"
+msgid "Bold"
+msgstr ""
+
+#: src/components/typography-controls/index.js:91
+msgctxt "typography styles"
+msgid "Default"
+msgstr ""
+
+#: src/components/typography-controls/index.js:95
+msgctxt "typography styles"
+msgid "Uppercase"
+msgstr ""
+
+#: src/components/typography-controls/index.js:99
+msgctxt "typography styles"
+msgid "Lowercase"
+msgstr ""
+
 #. Plugin Name of the plugin
-#: includes/admin/class-coblocks-feedback.php:311
-#: includes/admin/class-coblocks-getting-started-page.php:46
-#: includes/admin/class-coblocks-getting-started-page.php:47
-#: includes/admin/class-coblocks-getting-started-page.php:58
-#: includes/admin/class-coblocks-getting-started-page.php:59
 msgid "CoBlocks"
 msgstr ""
 
@@ -3332,131 +4137,132 @@ msgstr ""
 msgid "Cheating huh?"
 msgstr ""
 
-#. translators: Number of years
+#: includes/admin/class-coblocks-action-links.php:41
+msgid "Review CoBlocks on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-coblocks-action-links.php:41
+#: includes/admin/class-coblocks-feedback.php:282
+msgid "Leave a Review"
+msgstr ""
+
+#. translators: %d: Number of years
 #: includes/admin/class-coblocks-feedback.php:92
-msgid "%s years"
+msgid "%d years"
 msgstr ""
 
 #: includes/admin/class-coblocks-feedback.php:94
 msgid "a year"
 msgstr ""
 
-#. translators: Number of weeks
+#. translators: %d: Number of weeks
 #: includes/admin/class-coblocks-feedback.php:101
-msgid "%s weeks"
+msgid "%d weeks"
 msgstr ""
 
 #: includes/admin/class-coblocks-feedback.php:103
 msgid "a week"
 msgstr ""
 
-#. translators: Number of days
+#. translators: %d: Number of days
 #: includes/admin/class-coblocks-feedback.php:110
-msgid "%s days"
+msgid "%d days"
 msgstr ""
 
 #: includes/admin/class-coblocks-feedback.php:112
 msgid "a day"
 msgstr ""
 
-#. translators: Number of hours
+#. translators: %d: Number of hours
 #: includes/admin/class-coblocks-feedback.php:119
-msgid "%s hours"
+msgid "%d hours"
 msgstr ""
 
 #: includes/admin/class-coblocks-feedback.php:121
 msgid "an hour"
 msgstr ""
 
-#. translators: Number of minutes
+#. translators: %d: Number of minutes
 #: includes/admin/class-coblocks-feedback.php:128
-msgid "%s minutes"
+msgid "%d minutes"
 msgstr ""
 
 #: includes/admin/class-coblocks-feedback.php:130
 msgid "a minute"
 msgstr ""
 
-#. translators: Number of seconds
+#. translators: %d: Number of seconds
 #: includes/admin/class-coblocks-feedback.php:137
-msgid "%s seconds"
+msgid "%d seconds"
 msgstr ""
 
 #: includes/admin/class-coblocks-feedback.php:139
 msgid "a second"
 msgstr ""
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:271
 msgid "%s WordPress Plugin"
 msgstr ""
 
-#. translators: 1. Name
+#. translators: %s: Plugin Name
 #: includes/admin/class-coblocks-feedback.php:275
 msgid "Are you enjoying %s?"
 msgstr ""
 
-#. translators: 1. Name, 2. Time
+#. translators: %s: Plugin Name, 2. Time which the plugin has been in use for
 #: includes/admin/class-coblocks-feedback.php:278
 msgid "You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We'd really appreciate it!"
-msgstr ""
-
-#: includes/admin/class-coblocks-feedback.php:282
-msgid "Leave a Review"
 msgstr ""
 
 #: includes/admin/class-coblocks-feedback.php:283
 msgid "No thanks / I already have"
 msgstr ""
 
-#: includes/admin/class-coblocks-getting-started-page.php:122
+#: includes/admin/class-coblocks-getting-started-page.php:121
 msgid "Thanks for choosing CoBlocks, the premier page builder for the new WordPress block editor."
 msgstr ""
 
 #. translators: 1: Opening <strong> tag, 2: Closing </strong> tag
-#: includes/admin/class-coblocks-getting-started-page.php:128
+#: includes/admin/class-coblocks-getting-started-page.php:127
 msgid "You've just added lots of useful blocks and a new page builder toolkit to the WordPress editor. CoBlocks gives you a game-changing set of features: %1$s tens of blocks%2$s, a %1$s page-builder experience %2$s and %1$s custom typography controls%2$s."
 msgstr ""
 
-#: includes/admin/class-coblocks-getting-started-page.php:135
+#: includes/admin/class-coblocks-getting-started-page.php:134
 msgid "Here are a few videos to help you get started:"
 msgstr ""
 
 #. translators: CoBlocks plugin name
-#: includes/admin/class-coblocks-getting-started-page.php:139
+#: includes/admin/class-coblocks-getting-started-page.php:138
 msgid "Watch how to create your first page with %s"
 msgstr ""
 
-#: includes/admin/class-coblocks-getting-started-page.php:140
+#: includes/admin/class-coblocks-getting-started-page.php:139
 msgid "Watch how to create your first page"
 msgstr ""
 
+#: includes/admin/class-coblocks-getting-started-page.php:141
 #: includes/admin/class-coblocks-getting-started-page.php:142
-#: includes/admin/class-coblocks-getting-started-page.php:143
 msgid "Watch how to use the Row and Shape Divider blocks"
 msgstr ""
 
+#: includes/admin/class-coblocks-getting-started-page.php:144
 #: includes/admin/class-coblocks-getting-started-page.php:145
-#: includes/admin/class-coblocks-getting-started-page.php:146
 msgid "Watch how to use the Media Card block"
 msgstr ""
 
 #. translators: 1: Opening <a> tag to the CoBlocks YouTube channel, 2: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:154
+#: includes/admin/class-coblocks-getting-started-page.php:153
 msgid "Like what you see? %1$sSubscribe to our YouTube channel%2$s and we'll let you know when new video tutorials are released."
 msgstr ""
 
 #. translators: 1: Opening <a> tag to the CoBlocks Twitter account, 2: Opening <a> tag to the CoBlocks Facebook group, 3: Opening <a> tag to the CoBlocks newsletter,  4: Closing </a> tag
-#: includes/admin/class-coblocks-getting-started-page.php:165
+#: includes/admin/class-coblocks-getting-started-page.php:164
 msgid "If you have any questions or feedback, let us know on %1$sTwitter%4$s or our %2$sFacebook group %4$s. Also, %3$ssubscribe to our newsletter%4$s if you want to stay up to date with what's new and upcoming at CoBlocks."
 msgstr ""
 
-#: includes/admin/class-coblocks-getting-started-page.php:174
+#: includes/admin/class-coblocks-getting-started-page.php:173
 msgid "Enjoy!"
-msgstr ""
-
-#: includes/admin/class-coblocks-getting-started-page.php:207
-msgid "Get started with CoBlocks here:"
 msgstr ""
 
 #: includes/class-coblocks-block-settings.php:80
@@ -3471,11 +4277,27 @@ msgstr ""
 msgid "Google reCaptcha secret key for form spam protection"
 msgstr ""
 
+#: includes/class-coblocks-form.php:244
+msgid "Name"
+msgstr ""
+
+#: includes/class-coblocks-form.php:248
+msgid "First"
+msgstr ""
+
+#: includes/class-coblocks-form.php:249
+msgid "Last"
+msgstr ""
+
+#: includes/class-coblocks-form.php:325
+msgid "Message"
+msgstr ""
+
 #: includes/class-coblocks-form.php:390
 msgid "Submit"
 msgstr ""
 
-#: includes/class-coblocks-form.php:561
+#: includes/class-coblocks-form.php:598
 msgid "Your message was sent:"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"makepot": "wp i18n make-pot . --merge=languages/coblocks-js.pot --skip-audit --exclude=build,dist --headers='{\"Last-Translator\":\"plugins@godaddy.com\",\"Report-Msgid-Bugs-To\":\"https://github.com/godaddy/coblocks/issues\"}' --file-comment='Copyright (c) 2019 GoDaddy Operating Company, LLC. All Rights Reserved.' && rm -f languages/coblocks-js.pot && .dev/bin/update-po.sh",
 		"babel": "babel src --ignore src/blocks/gist/components/gist.js",
 		"babel:json": "wp i18n make-json languages",
-		"babel:build": "npm run babel && npm run babel:json && npm run makepot",
+		"babel:build": "npm run babel && npm run makepot",
 		"test": "jest --config .dev/tests/jest/jest.config.js --silent --noStackTrace",
 		"deploy-i18n": "./node_modules/.bin/cypress run -s './.dev/tests/cypress/integration/deploy-translations.js'"
 	},

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"scripts": {
 		"start": "node .dev/scripts/start.js",
 		"build": "node .dev/scripts/build.js",
-		"version": "grunt version && git add -A .",
+		"version": "grunt version && npm run babel:build && git add -A .",
 		"postversion": "git push && git push --tags",
 		"makepot": "wp i18n make-pot . --merge=languages/coblocks-js.pot --skip-audit --exclude=build,dist --headers='{\"Last-Translator\":\"plugins@godaddy.com\",\"Report-Msgid-Bugs-To\":\"https://github.com/godaddy/coblocks/issues\"}' --file-comment='Copyright (c) 2019 GoDaddy Operating Company, LLC. All Rights Reserved.' && rm -f languages/coblocks-js.pot && .dev/bin/update-po.sh",
 		"babel": "babel src --ignore src/blocks/gist/components/gist.js",


### PR DESCRIPTION
- Rebuild the translations.
- Remove `npm run babel:json` since the generated `.json` files were not used.
- Run `npm run babel:build` when we tag a new version to Github (`npm version major|minor|patch`). This will generate a new .pot file, merge the changes into each .po file and commit them back up to Github.