### PR TITLE
Fix image links being erased when a Gallery block is updated

### DIFF
--- a/src/blocks/gallery-carousel/controls.js
+++ b/src/blocks/gallery-carousel/controls.js
@@ -24,7 +24,7 @@ class Controls extends Component {
 
 	onSelectImages( images ) {
 		this.props.setAttributes( {
-			images: images.map( ( image ) => helper.pickRelevantMediaFiles( image ) ),
+			images: images.map( ( image ) => helper.pickRelevantMediaFiles( image, this.props.attributes.images ) ),
 		} );
 	}
 

--- a/src/blocks/gallery-collage/controls.js
+++ b/src/blocks/gallery-collage/controls.js
@@ -18,7 +18,7 @@ class Controls extends Component {
 
 	onSelectImages( images ) {
 		this.props.setAttributes( {
-			images: images.map( ( image ) => helper.pickRelevantMediaFiles( image ) ),
+			images: images.map( ( image ) => helper.pickRelevantMediaFiles( image, this.props.attributes.images ) ),
 		} );
 	}
 

--- a/src/blocks/gallery-masonry/controls.js
+++ b/src/blocks/gallery-masonry/controls.js
@@ -24,7 +24,7 @@ class Controls extends Component {
 
 	onSelectImages( images ) {
 		this.props.setAttributes( {
-			images: images.map( ( image ) => helper.pickRelevantMediaFiles( image ) ),
+			images: images.map( ( image ) => helper.pickRelevantMediaFiles( image, this.props.attributes.images ) ),
 		} );
 	}
 

--- a/src/blocks/gallery-stacked/controls.js
+++ b/src/blocks/gallery-stacked/controls.js
@@ -24,7 +24,7 @@ class Controls extends Component {
 
 	onSelectImages( images ) {
 		this.props.setAttributes( {
-			images: images.map( ( image ) => helper.pickRelevantMediaFiles( image ) ),
+			images: images.map( ( image ) => helper.pickRelevantMediaFiles( image, this.props.attributes.images ) ),
 		} );
 	}
 

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -3,6 +3,7 @@
  */
 import pick from 'lodash/pick';
 import get from 'lodash/get';
+import findIndex from 'lodash/findIndex';
 
 // Set dim ratio.
 export function overlayToClass( ratio ) {
@@ -12,9 +13,13 @@ export function overlayToClass( ratio ) {
 }
 
 // Pick image media attributes.
-export const pickRelevantMediaFiles = ( image ) => {
+export const pickRelevantMediaFiles = ( image, images ) => {
 	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption', 'imgLink' ] );
 	imageProps.url = get( image, [ 'sizes', 'large', 'url' ] ) || get( image, [ 'media_details', 'sizes', 'large', 'source_url' ] ) || image.url;
+	const imgKey = findIndex( images, function( img ) {
+		return img.url === imageProps.url;
+	} );
+	imageProps.imgLink = imgKey >= 0 ? images[ imgKey ].imgLink : '';
 	return imageProps;
 };
 


### PR DESCRIPTION
Resolves #983 

Fixes image URLs getting stripped when a gallery is updated.