### PR TITLE
Resolve PHP warnings with WordPress 5.3 Beta

### DIFF
--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -46,7 +46,8 @@ class CoBlocks_Getting_Started_Page {
 				'CoBlocks',
 				apply_filters( 'coblocks_getting_started_screen_capability', 'manage_options' ),
 				'coblocks-getting-started',
-				array( $this, 'content' )
+				array( $this, 'content' ),
+				4
 			);
 
 			return;
@@ -59,7 +60,7 @@ class CoBlocks_Getting_Started_Page {
 			apply_filters( 'coblocks_getting_started_screen_capability', 'manage_options' ),
 			'coblocks-getting-started',
 			array( $this, 'content' ),
-			'data:image/svg+xml;base64,' . base64_encode( $svg )
+			4,
 		);
 	}
 

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -60,7 +60,7 @@ class CoBlocks_Getting_Started_Page {
 			apply_filters( 'coblocks_getting_started_screen_capability', 'manage_options' ),
 			'coblocks-getting-started',
 			array( $this, 'content' ),
-			4,
+			4
 		);
 	}
 

--- a/includes/admin/class-coblocks-getting-started-page.php
+++ b/includes/admin/class-coblocks-getting-started-page.php
@@ -46,8 +46,7 @@ class CoBlocks_Getting_Started_Page {
 				'CoBlocks',
 				apply_filters( 'coblocks_getting_started_screen_capability', 'manage_options' ),
 				'coblocks-getting-started',
-				array( $this, 'content' ),
-				4
+				array( $this, 'content' )
 			);
 
 			return;
@@ -59,8 +58,7 @@ class CoBlocks_Getting_Started_Page {
 			'CoBlocks',
 			apply_filters( 'coblocks_getting_started_screen_capability', 'manage_options' ),
 			'coblocks-getting-started',
-			array( $this, 'content' ),
-			4
+			array( $this, 'content' )
 		);
 	}
 


### PR DESCRIPTION
In 5.3 Beta, WordPress core has introduced a new parameter to be used when adding menu pages. Warnings were thrown until a parameter was properly passed into this function. 

Works on 5.2.3 and 5.3 Beta. Works with and without Gutenberg.

Resolves WordPress.org support requests:
https://wordpress.org/support/topic/add_submenu_page-call-uses-a-string-for-position/
https://wordpress.org/support/topic/activating-the-plugin-on-5-3-beta3-produces-php-warnings/
