### PR TITLE
Resolve missing text format controls because of missing script dependencies

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -104,9 +104,8 @@ class CoBlocks_Block_Assets {
 		wp_register_script(
 			$this->_slug . '-editor',
 			$this->_url . '/dist/blocks.build.js',
-			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-plugins', 'wp-components', 'wp-edit-post', 'wp-api' ),
-			time(),
-			true
+			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-plugins', 'wp-components', 'wp-edit-post', 'wp-api', 'wp-rich-text', 'wp-editor' ),
+			time()
 		);
 
 		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -24,7 +24,7 @@ import './extensions/image-styles';
 import './extensions/image-crop';
 
 // Formats
-import './formats/';
+import './formats';
 
 // Sidebars
 import './sidebars/block-manager';
@@ -137,4 +137,5 @@ export const registerCoBlocksBlocks = () => {
 		stacked,
 	].forEach( registerBlock );
 };
+
 registerCoBlocksBlocks();

--- a/src/formats/index.js
+++ b/src/formats/index.js
@@ -1,16 +1,19 @@
 /**
  * Internal dependencies
  */
-import { uppercase } from './uppercase';
+import * as uppercase from './uppercase';
 
 /**
  * WordPress dependencies
  */
 import { registerFormatType } from '@wordpress/rich-text';
 
-function registerFormats() {
+export default function registerCoBlocksFormats() {
 	[
 		uppercase,
-	].forEach( ( { name, ...settings } ) => registerFormatType( name, settings ) );
+	].forEach( ( { name, settings } ) => {
+		registerFormatType( name, settings );
+	} );
 }
-registerFormats();
+
+registerCoBlocksFormats();

--- a/src/formats/uppercase/index.js
+++ b/src/formats/uppercase/index.js
@@ -16,12 +16,11 @@ import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/block-editor
  */
 const name = 'coblocks/uppercase';
 
-export const uppercase = {
-	name,
+const settings = {
 	title: __( 'Uppercase' ),
 	tagName: 'span',
 	className: 'uppercase',
-	edit( { isActive, value, onChange } ) {
+	edit: ( { isActive, value, onChange } ) => {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 
 		return (
@@ -43,3 +42,5 @@ export const uppercase = {
 		);
 	},
 };
+
+export { name, settings };


### PR DESCRIPTION
Resolves #980.

Works with and without Gutenberg active. Setting `in_footer` to `false` and adding `wp-editor` and `wp-rich-text` as dependencies to the `dist/blocks.build.js` registered script solved it.