### PR TITLE
Fix deprecation for the CoBlocks Block Manager

### DIFF
--- a/src/sidebars/block-manager/components/modal.js
+++ b/src/sidebars/block-manager/components/modal.js
@@ -68,7 +68,7 @@ class ModalSettings extends Component {
 					optionSettings = JSON.parse( optionSettings );
 
 					//get current blocks
-					const currentBlocks = wp.data.select( 'core/editor' ).getBlocks();
+					const currentBlocks = wp.data.select( 'core/block-editor' ).getBlocks();
 					const blockNames = MapInnerBlocks( currentBlocks );
 
 					map( optionSettings, ( visible, block ) => {

--- a/src/sidebars/block-manager/components/options/disable-blocks.js
+++ b/src/sidebars/block-manager/components/options/disable-blocks.js
@@ -61,7 +61,7 @@ class DisableBlocks extends Component {
 		const settingsState = this.state.settings;
 
 		//get current blocks
-		const currentBlocks = wp.data.select( 'core/editor' ).getBlocks();
+		const currentBlocks = wp.data.select( 'core/block-editor' ).getBlocks();
 		const blockNames = MapInnerBlocks( currentBlocks );
 
 		//check block for editor match first

--- a/src/sidebars/block-manager/deprecated.js
+++ b/src/sidebars/block-manager/deprecated.js
@@ -29,7 +29,7 @@ function deprecateBlockManager() {
 				optionSettings = JSON.parse( optionSettings );
 
 				if ( typeof optionSettings.deprecated === 'undefined' ) {
-					const currentBlocks = wp.data.select( 'core/editor' ).getBlocks();
+					const currentBlocks = wp.data.select( 'core/block-editor' ).getBlocks();
 					const blockNames = MapInnerBlocks( currentBlocks );
 					const hideBlockTypes = [];
 


### PR DESCRIPTION
This PR updates the soon to be deprecated `wp.data.select( 'core/editor' ).getBlocks()` to `wp.data.select( 'core/block-editor' ).getBlocks()` that's within the CoBlocks Block Manager.