### PR TITLE
Do not show layout styles toolbar until a layout is selected

### DIFF
--- a/src/blocks/row/controls.js
+++ b/src/blocks/row/controls.js
@@ -60,6 +60,10 @@ class Controls extends Component {
 			selectedRows = parseInt( columns.toString().split( '-' ) );
 		}
 
+		if ( ! layout ) {
+			return null;
+		}
+
 		return (
 			<Fragment>
 				<BlockControls>


### PR DESCRIPTION
Resolves #898 

![row-block-bug](https://user-images.githubusercontent.com/5321364/66759120-a0e94980-ee6d-11e9-9ee1-cc43c35aaad0.gif)
