### PR TITLE
Fix the block validation error when the Hero block background color is removed

### DIFF
--- a/src/blocks/hero/block.json
+++ b/src/blocks/hero/block.json
@@ -48,8 +48,7 @@
 			"default": 60
 		},
 		"customBackgroundColor": {
-			"type": "string",
-			"default": "#f3f3f3"
+			"type": "string"
 		},
 		"height": {
 			"type": "number",

--- a/src/blocks/hero/deprecated.js
+++ b/src/blocks/hero/deprecated.js
@@ -73,7 +73,8 @@ const deprecated = [
 					[ backgroundClass ]: backgroundClass,
 					[ `has-${ contentAlign }-content` ]: contentAlign,
 					'is-fullscreen': fullscreen,
-				} );
+				}
+			);
 
 			const innerStyles = {
 				backgroundColor: backgroundClass ? undefined : customBackgroundColor,
@@ -89,6 +90,83 @@ const deprecated = [
 						{ BackgroundVideo( attributes ) }
 						<div className="wp-block-coblocks-hero__box" style={ { maxWidth: maxWidth ? maxWidth + 'px' : undefined } }>
 							<InnerBlocks.Content />
+						</div>
+					</div>
+				</div>
+			);
+		},
+	},
+	{
+		attributes: {
+			...attributes,
+			customBackgroundColor: {
+				type: 'string',
+				default: '#f3f3f3',
+			},
+		},
+		save: ( { attributes } ) => {
+			const {
+				coblocks,
+				layout,
+				fullscreen,
+				maxWidth,
+				backgroundImg,
+				backgroundType,
+				paddingSize,
+				backgroundColor,
+				customBackgroundColor,
+				customTextColor,
+				textColor,
+				contentAlign,
+				focalPoint,
+				hasParallax,
+				height,
+			} = attributes;
+
+			const textClass = getColorClassName( 'color', textColor );
+			const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+
+			let classes = classnames( {
+				'has-text-color': textColor || customTextColor,
+				[ textClass ]: textClass,
+			} );
+
+			if ( coblocks && ( typeof coblocks.id !== 'undefined' ) ) {
+				classes = classnames( classnames, `coblocks-hero-${ coblocks.id }` );
+			}
+
+			const styles = {
+				color: textClass ? undefined : customTextColor,
+			};
+
+			const innerClasses = classnames(
+				'wp-block-coblocks-hero__inner',
+				...BackgroundClasses( attributes ), {
+					[ `hero-${ layout }-align` ]: layout,
+					'has-text-color': textColor && textColor.color,
+					'has-padding': paddingSize && paddingSize !== 'no',
+					[ `has-${ paddingSize }-padding` ]: paddingSize && paddingSize !== 'advanced',
+					[ backgroundClass ]: backgroundClass,
+					[ `has-${ contentAlign }-content` ]: contentAlign,
+					'is-fullscreen': fullscreen,
+				} );
+
+			const innerStyles = {
+				backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+				backgroundImage: backgroundImg && backgroundType === 'image' ? `url(${ backgroundImg })` : undefined,
+				color: textColor ? textColor.color : undefined,
+				backgroundPosition: focalPoint && ! hasParallax ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : undefined,
+				minHeight: fullscreen ? undefined : height,
+			};
+
+			return (
+				<div className={ classes } style={ styles } >
+					<div className={ innerClasses } style={ innerStyles }>
+						{ BackgroundVideo( attributes ) }
+						<div className="wp-block-coblocks-hero__content-wrapper">
+							<div className="wp-block-coblocks-hero__content" style={ { maxWidth: maxWidth ? maxWidth + 'px' : undefined } }>
+								<InnerBlocks.Content />
+							</div>
 						</div>
 					</div>
 				</div>

--- a/src/blocks/hero/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/hero/test/__snapshots__/save.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`coblocks/hero should render 1`] = `
 "<!-- wp:coblocks/hero -->
-<div class=\\"wp-block-coblocks-hero alignfull\\"><div class=\\"wp-block-coblocks-hero__inner has-background hero-center-left-align has-padding has-huge-padding\\" style=\\"background-color:#f3f3f3;min-height:500px\\"><div class=\\"wp-block-coblocks-hero__content-wrapper\\"><div class=\\"wp-block-coblocks-hero__content\\" style=\\"max-width:560px\\"></div></div></div></div>
+<div class=\\"wp-block-coblocks-hero alignfull\\"><div class=\\"wp-block-coblocks-hero__inner hero-center-left-align has-padding has-huge-padding\\" style=\\"min-height:500px\\"><div class=\\"wp-block-coblocks-hero__content-wrapper\\"><div class=\\"wp-block-coblocks-hero__content\\" style=\\"max-width:560px\\"></div></div></div></div>
 <!-- /wp:coblocks/hero -->"
 `;


### PR DESCRIPTION
Resolves #729 

Removing the default value for the hero is the simplest approach to resolving #729 . When you clear a color value, it's set to `undefined`. During the save routine, in core, if the value is `undefined` and a `default` setting exists, it falls back to that.

Without introducing additional login and checks, removing the default value from the background color for the hero block is the easiest approach. @richtabor @jrtashjian @paranoia1906 Do you think this is our best approach?