### PR TITLE
Ensure style previews of the Icon block display the selected icon

### DIFF
--- a/src/blocks/icon/block.json
+++ b/src/blocks/icon/block.json
@@ -4,7 +4,7 @@
 	"attributes": {
 		"icon": {
 			"type": "string",
-			"default" : "heart"
+			"default" : ""
 		},
 		"iconSize": {
 			"type": "string",

--- a/src/blocks/icon/block.json
+++ b/src/blocks/icon/block.json
@@ -4,11 +4,7 @@
 	"attributes": {
 		"icon": {
 			"type": "string",
-			"default": "heart"
-		},
-		"iconRand": {
-			"type": "boolean",
-			"default": true
+			"default" : "heart"
 		},
 		"iconSize": {
 			"type": "string",

--- a/src/blocks/icon/block.json
+++ b/src/blocks/icon/block.json
@@ -4,7 +4,7 @@
 	"attributes": {
 		"icon": {
 			"type": "string",
-			"default" : ""
+			"default": ""
 		},
 		"iconSize": {
 			"type": "string",

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -27,18 +27,19 @@ const MAX_ICON_SIZE = 400;
 
 export { MIN_ICON_SIZE, MAX_ICON_SIZE };
 
-/**
- * Block edit function
- */
 class Edit extends Component {
-	componentDidMount() {
-		// Randomized the default icon when first added.
-		const defaultIcons = [ 'aperture', 'gesture', 'scatter_plot', 'waves', 'blocks', 'coblocks', 'drafts', 'device_hub', 'marker' ];
-		const rand = defaultIcons[ Math.floor( Math.random() * defaultIcons.length ) ];
+	isStylePreview() {
+		return ( $( `#block-${ this.props.clientId }` ).parent().parent().hasClass( 'block-editor-block-preview__content' ) );
+	}
 
-		// CHeck if the icon is the default.
-		if ( this.props.attributes.iconRand === true ) {
-			this.props.setAttributes( { icon: rand, iconRand: false } );
+	componentDidMount() {
+		if ( this.isStylePreview() ) {
+			this.props.setAttributes( { icon: 'aperture' } );
+		} else {
+			// Randomized the default icon when first added.
+			const defaultIcons = [ 'aperture', 'gesture', 'scatter_plot', 'waves', 'blocks', 'coblocks', 'drafts', 'device_hub', 'marker' ];
+			const rand = defaultIcons[ Math.floor( Math.random() * defaultIcons.length ) ];
+			this.props.setAttributes( { icon: rand } );
 		}
 	}
 

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -35,7 +35,7 @@ class Edit extends Component {
 	componentDidMount() {
 		if ( this.isStylePreview() ) {
 			this.props.setAttributes( { icon: 'aperture' } );
-		} else {
+		} else if ( this.props.attributes.icon === '' ) {
 			// Randomized the default icon when first added.
 			const defaultIcons = [ 'aperture', 'gesture', 'scatter_plot', 'waves', 'blocks', 'coblocks', 'drafts', 'device_hub', 'marker' ];
 			const rand = defaultIcons[ Math.floor( Math.random() * defaultIcons.length ) ];

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -28,14 +28,9 @@ const MAX_ICON_SIZE = 400;
 export { MIN_ICON_SIZE, MAX_ICON_SIZE };
 
 class Edit extends Component {
-	isStylePreview() {
-		return ( $( `#block-${ this.props.clientId }` ).parent().parent().hasClass( 'block-editor-block-preview__content' ) );
-	}
-
 	componentDidMount() {
-		if ( this.isStylePreview() ) {
-			this.props.setAttributes( { icon: 'aperture' } );
-		} else if ( this.props.attributes.icon === '' ) {
+		// Check if the icon is the default.
+		if ( this.props.attributes.icon === '' ) {
 			// Randomized the default icon when first added.
 			const defaultIcons = [ 'aperture', 'gesture', 'scatter_plot', 'waves', 'blocks', 'coblocks', 'drafts', 'device_hub', 'marker' ];
 			const rand = defaultIcons[ Math.floor( Math.random() * defaultIcons.length ) ];

--- a/src/blocks/icon/index.js
+++ b/src/blocks/icon/index.js
@@ -37,11 +37,6 @@ const settings = {
 		{ name: 'outlined', label: _x( 'Outlined', 'block style' ), isDefault: true },
 		{ name: 'filled', label: _x( 'Filled', 'block style' ) },
 	],
-	example: {
-		attributes: {
-			width: 260,
-		},
-	},
 	attributes,
 	edit,
 	save,

--- a/src/blocks/icon/inspector.js
+++ b/src/blocks/icon/inspector.js
@@ -245,7 +245,7 @@ class Inspector extends Component {
 											} }
 										>
 											<span className="editor-block-types-list__item-icon">
-												{ svg[ iconStyle ][ icon ].icon }
+												{ icon && svg[ iconStyle ][ icon ].icon }
 											</span>
 										</Button>
 									</li> :
@@ -268,7 +268,7 @@ class Inspector extends Component {
 														} }
 													>
 														<span className="editor-block-types-list__item-icon">
-															{ svg[ iconStyle ][ keyName ].icon }
+															{ icon && svg[ iconStyle ][ keyName ].icon }
 														</span>
 													</Button>
 												</Tooltip>


### PR DESCRIPTION
- Closes #899 
- Removed `iconRand` attribute.
- Set icon default to `''` (unset).
- Static icon used for style previews.
  * I chose aperture because this style shows the difference between filled and outlined well. 
- No deprecation needed from my testing.

![iconsStaticStylePreviews](https://user-images.githubusercontent.com/30462574/66772816-7352cf00-ee72-11e9-8599-74c286858213.gif)
