### PR TITLE
Improve Gif block stability through block validation testing

### DIFF
--- a/src/blocks/gif/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/gif/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/gif should render 1`] = `
+"<!-- wp:coblocks/gif -->
+<figure class=\\"wp-block-coblocks-gif\\"><img src=\\"https://wordpress.com/wp-content/uploads/1234/56/image-1.gif\\" alt=\\"\\"/></figure>
+<!-- /wp:coblocks/gif -->"
+`;

--- a/src/blocks/gif/test/save.spec.js
+++ b/src/blocks/gif/test/save.spec.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		block.attributes.url = 'https://wordpress.com/wp-content/uploads/1234/56/image-1.gif';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'https://wordpress.com/wp-content/uploads/1234/56/image-1.gif' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This block did not have deprecations. Instead I added a basic test on the save function to detect when we need to write a deprecation. Related to #865.

```
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        1.75s, estimated 2s
```