### PR TITLE
Improve Gist block stability through block validation testing

### DIFF
--- a/src/blocks/gist/deprecated.js
+++ b/src/blocks/gist/deprecated.js
@@ -4,12 +4,18 @@
 import classnames from 'classnames';
 
 /**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 
 const deprecated = [
 	{
+		attributes: metadata.attributes,
 		save( { attributes } ) {
 			const { url, file, meta } = attributes;
 

--- a/src/blocks/gist/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/gist/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/gist should render 1`] = `
+"<!-- wp:coblocks/gist {\\"url\\":\\"https://gist.github.com/someuser/a04f4e14e3cd3b6d48157ea0706114f7\\"} -->
+<div class=\\"wp-block-coblocks-gist\\"><script src=\\"https://gist.github.com/someuser/a04f4e14e3cd3b6d48157ea0706114f7.js\\"></script><noscript><a href=\\"https://gist.github.com/someuser/a04f4e14e3cd3b6d48157ea0706114f7\\">View this gist on GitHub</a></noscript></div>
+<!-- /wp:coblocks/gist -->"
+`;

--- a/src/blocks/gist/test/deprecated.spec.js
+++ b/src/blocks/gist/test/deprecated.spec.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	className: [ undefined, '', 'random classes' ],
+	align: [ '', 'wide', 'full', 'left', 'center', 'right' ],
+	url: [ undefined, '', 'https://gist.github.com/someuser/a04f4e14e3cd3b6d48157ea0706114f7' ],
+	file: [ undefined, '', 'file.js' ],
+	meta: [ true, false ],
+	caption: [ undefined, '', 'caption' ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/gist/test/save.spec.js
+++ b/src/blocks/gist/test/save.spec.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		block.attributes.url = 'https://gist.github.com/someuser/a04f4e14e3cd3b6d48157ea0706114f7';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'https://gist.github.com/someuser/a04f4e14e3cd3b6d48157ea0706114f7' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Gist block as part of #866.

```
Test Suites: 2 passed, 2 total
Tests:       28 passed, 28 total
Snapshots:   1 passed, 1 total
Time:        2.708s
```