### PR TITLE
Improve Logos block stability through block validation testing

### DIFF
--- a/src/blocks/logos/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/logos/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/logos should render 1`] = `
+"<!-- wp:coblocks/logos -->
+<div class=\\"wp-block-coblocks-logos\\"><div class=\\"wp-block-coblocks-logos__row\\"><div style=\\"width:100%\\"><img src=\\"https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg\\" data-id=\\"1\\" data-width=\\"100%\\"/></div></div></div>
+<!-- /wp:coblocks/logos -->"
+`;

--- a/src/blocks/logos/test/save.spec.js
+++ b/src/blocks/logos/test/save.spec.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		block.attributes.images = [
+			{ url: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', id: 1 },
+		];
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg' );
+		expect( serializedBlock ).toContain( 'data-id="1"' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This block did not have deprecations. Instead I added a basic test on the save function to detect when we need to write a deprecation. Related to #868.

```
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        2.85s, estimated 3s
```