### PR TITLE
Improve Map block stability through block validation testing

### DIFF
--- a/src/blocks/map/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/map/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/map should render 1`] = `
+"<!-- wp:coblocks/map {\\"address\\":\\"New York\\"} -->
+<div style=\\"min-height:400px\\" data-map-attr=\\"/qaddress/q:/qNew York/q||/qlat/q:/qundefined/q||/qlng/q:/qundefined/q||/qskin/q:/qstandard/q||/qzoom/q:/q12/q||/qiconSize/q:/q36/q||/qmapTypeControl/q:/qtrue/q||/qzoomControl/q:/qtrue/q||/qstreetViewControl/q:/qtrue/q||/qfullscreenControl/q:/qtrue/q\\" class=\\"wp-block-coblocks-map\\"><iframe title=\\"Google Map\\" frameborder=\\"0\\" style=\\"width:100%;min-height:400px\\" src=\\"https://www.google.com/maps?q=New%20York&amp;output=embed&amp;hl=&amp;z=12\\"></iframe></div>
+<!-- /wp:coblocks/map -->"
+`;

--- a/src/blocks/map/test/deprecated.spec.js
+++ b/src/blocks/map/test/deprecated.spec.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	address: [],
+	lat: [],
+	lng: [],
+	hasApiKey: [ undefined, true, false ],
+	pinned: [ undefined, true, false ],
+	height: [ 0, 400 ],
+	skin: [ 'standard' ],
+	zoom: [ 0, 12, 20 ],
+	iconSize: [ 0, 36 ],
+	mapTypeControl: [ true, false ],
+	zoomControl: [ true, false ],
+	streetViewControl: [ true, false ],
+	fullscreenControl: [ true, false ],
+	controls: [ true, false ],
+	hasError: [ undefined, '', 'some error' ],
+	align: [ '', 'wide', 'full', 'left', 'right', 'center' ],
+	className: [ undefined, '', 'random classes' ],
+	noBottomMargin: [ undefined, true, false ],
+	noTopMargin: [ undefined, true, false ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/map/test/save.spec.js
+++ b/src/blocks/map/test/save.spec.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		block.attributes.address = 'New York';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'q=New%20York' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Map block as part of #869.

```
Test Suites: 2 passed, 2 total
Tests:       125 passed, 125 total
Snapshots:   1 passed, 1 total
Time:        3.111s
```