### PR TITLE
Improve Media Card block stability through block validation testing

### DIFF
--- a/src/blocks/media-card/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/media-card/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/media-card should render 1`] = `
+"<!-- wp:coblocks/media-card -->
+<div class=\\"wp-block-coblocks-media-card alignwide is-style-left has-no-media\\"><div class=\\"wp-block-coblocks-media-card__inner has-no-padding\\"><div class=\\"wp-block-coblocks-media-card__wrapper\\"><figure class=\\"wp-block-coblocks-media-card__media\\"></figure><div class=\\"wp-block-coblocks-media-card__content\\"></div></div></div></div>
+<!-- /wp:coblocks/media-card -->"
+`;

--- a/src/blocks/media-card/test/save.spec.js
+++ b/src/blocks/media-card/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This block did not have deprecations. Instead I added a basic test on the save function to detect when we need to write a deprecation. Related to #870.

```
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        2.962s, estimated 3s
```