### PR TITLE
Improve Pricing Table block stability through block validation testing

### DIFF
--- a/src/blocks/pricing-table/pricing-table-item/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/pricing-table/pricing-table-item/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/pricing-table-item should render with content 1`] = `
+"<!-- wp:coblocks/pricing-table-item -->
+<div class=\\"wp-block-coblocks-pricing-table-item\\"><span class=\\"wp-block-coblocks-pricing-table-item__title\\">Plan Title</span><div class=\\"wp-block-coblocks-pricing-table-item__price-wrapper\\"><span class=\\"wp-block-coblocks-pricing-table-item__amount\\">49</span></div></div>
+<!-- /wp:coblocks/pricing-table-item -->"
+`;

--- a/src/blocks/pricing-table/pricing-table-item/test/save.spec.js
+++ b/src/blocks/pricing-table/pricing-table-item/test/save.spec.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render with content', () => {
+		block.attributes.title = 'Plan Title';
+		block.attributes.amount = '49';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'Plan Title' );
+		expect( serializedBlock ).toContain( '49' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+
+	it( 'should not render without content', () => {
+		serializedBlock = serialize( createBlock( name ) );
+		expect( serializedBlock ).toEqual( `<!-- wp:${ name } /-->` );
+	} );
+} );

--- a/src/blocks/pricing-table/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/pricing-table/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/pricing-table should render 1`] = `
+"<!-- wp:coblocks/pricing-table -->
+<div class=\\"wp-block-coblocks-pricing-table has-2-columns has-text-align-center\\"><div class=\\"wp-block-coblocks-pricing-table__inner\\"></div></div>
+<!-- /wp:coblocks/pricing-table -->"
+`;

--- a/src/blocks/pricing-table/test/deprecated.spec.js
+++ b/src/blocks/pricing-table/test/deprecated.spec.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+import googleFonts from '../../../components/font-family/fonts';
+
+const variations = {
+	count: [ 1, 2, 3, 4 ],
+	contentAlign: [ '', 'left', 'center', 'right' ],
+	align: [ '', 'wide', 'full', 'left', 'center', 'right' ],
+	className: [ undefined, '', 'random classes' ],
+	fontSize: [ undefined, 'small', 'large' ],
+	customFontSize: [ undefined, 0, 16, 100 ],
+	fontFamily: [ undefined, ...Object.keys( googleFonts ) ],
+	textColor: [ undefined, 'primary' ],
+	customTextColor: [ undefined, '#123456' ],
+	lineHeight: [ undefined, 0, 3, 2.5 ],
+	letterSpacing: [ undefined, 0, 3, -1, 2.5 ],
+	fontWeight: [ undefined, '', 'normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900' ],
+	textTransform: [ undefined, '', 'uppercase', 'lowercase', 'capitalize', 'initial' ],
+	noBottomSpacing: [ undefined, true, false ],
+	noTopSpacing: [ undefined, true, false ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/pricing-table/test/save.spec.js
+++ b/src/blocks/pricing-table/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Pricing Table block as part of #870.

```
Test Suites: 3 passed, 3 total
Tests:       110 passed, 110 total
Snapshots:   2 passed, 2 total
Time:        2.795s, estimated 3s
```