### PR TITLE
Fix typos of "background"

### DIFF
--- a/languages/coblocks-da_DK.po
+++ b/languages/coblocks-da_DK.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Tilføj baggrund til %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Tilføj helteoverskrift ..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Tilføj heltemateriale, som typisk er et introduktionsafsnit på en side "
+"sammen med én eller to opfordringer til handling."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -794,10 +824,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Skift layout"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Tilføj baggrund til %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2373,19 +2399,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "Dette er en fremhævelsesblok du kan bruge til at fremhæve indhold."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Tilføj helteoverskrift ..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Tilføj heltemateriale, som typisk er et introduktionsafsnit på en side "
-#~ "sammen med én eller to opfordringer til handling."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-de_DE.po
+++ b/languages/coblocks-de_DE.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Hintergrund zu %s hinzufügen"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Hero-Überschrift hinzufügen…"
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Füge Hero-Inhalt hinzu. Normalerweise handelt es sich dabei um einen "
+"einleitenden Bereich für deiner Seite, der mit ein oder zwei "
+"Handlungsaufforderungen verknüpft ist."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -806,10 +837,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Layout ändern"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Hintergrund zu %s hinzufügen"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2408,20 +2435,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "Dies ist ein Feature-Block, mit dem du Merkmale hervorheben kannst."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Hero-Überschrift hinzufügen…"
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Füge Hero-Inhalt hinzu. Normalerweise handelt es sich dabei um einen "
-#~ "einleitenden Bereich für deiner Seite, der mit ein oder zwei "
-#~ "Handlungsaufforderungen verknüpft ist."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-el.po
+++ b/languages/coblocks-el.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Προσθήκη φόντου στο %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Προσθήκη επικεφαλίδας-ήρωα..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Προσθήκη περιεχομένου-ήρωα, που συνήθως είναι ένας χώρος εισαγωγής μιας "
+"σελίδας που συνοδεύεται από μια ή δύο κλήσεις προς ενέργεια."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -808,10 +838,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Αλλαγή διάταξης"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Προσθήκη φόντου στο %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2410,19 +2436,6 @@ msgstr "Houzz"
 #~ msgstr ""
 #~ "Αυτό είναι ένα μπλοκ χαρακτηριστικών με το οποίο μπορείτε να επισημάνετε "
 #~ "τα χαρακτηριστικά."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Προσθήκη επικεφαλίδας-ήρωα..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Προσθήκη περιεχομένου-ήρωα, που συνήθως είναι ένας χώρος εισαγωγής μιας "
-#~ "σελίδας που συνοδεύεται από μια ή δύο κλήσεις προς ενέργεια."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-es_ES.po
+++ b/languages/coblocks-es_ES.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Agregar fondo a %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Agregar encabezado hero..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Agregar encabezado hero, que típicamente es un área introductoria de una "
+"página acompañada por un llamado a la acción o dos."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -802,10 +832,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Cambiar el diseño"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Agregar fondo a %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2395,19 +2421,6 @@ msgstr "Houzz"
 #~ msgstr ""
 #~ "Este es un bloque de característica que puedes usar para destacar "
 #~ "características."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Agregar encabezado hero..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Agregar encabezado hero, que típicamente es un área introductoria de una "
-#~ "página acompañada por un llamado a la acción o dos."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-fi.po
+++ b/languages/coblocks-fi.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Lisää tausta: %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Lisää sankariosion otsikko..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Lisää sankarisisältö. Tällä tarkoitetaan näkyvällä tavalla esillä olevaa "
+"sivun esittelyosiota, johon sisältyy usein mukaan myös jokin toimintakehote."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -805,10 +835,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Muuta asettelua"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Lisää tausta: %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2412,20 +2438,6 @@ msgstr "Houzz"
 #~ msgstr ""
 #~ "Tämä on ominaisuuslohko, jonka avulla voit tuoda esille haluamiasi "
 #~ "ominaisuuksia."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Lisää sankariosion otsikko..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Lisää sankarisisältö. Tällä tarkoitetaan näkyvällä tavalla esillä olevaa "
-#~ "sivun esittelyosiota, johon sisältyy usein mukaan myös jokin "
-#~ "toimintakehote."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-fr_FR.po
+++ b/languages/coblocks-fr_FR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Ajouter le fond à %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Ajouter le titre Hero..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Ajoutez un contenu Hero, qui correspond normalement à une zone "
+"d’introduction d’une page accompagnée d’un ou deux appels à l’action."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -808,10 +838,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Modifier la mise en page"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Ajouter le fond à %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2404,19 +2430,6 @@ msgstr "Houzz"
 #~ msgstr ""
 #~ "Il s’agit d’un bloc de fonctionnalités que vous pouvez utiliser pour "
 #~ "mettre des fonctionnalités en surbrillance."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Ajouter le titre Hero..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Ajoutez un contenu Hero, qui correspond normalement à une zone "
-#~ "d’introduction d’une page accompagnée d’un ou deux appels à l’action."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-hi_IN.po
+++ b/languages/coblocks-hi_IN.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "%s में पृष्ठभूमि जोड़ें"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "हीरो शीर्षक जोड़ें..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"ऐसी हीरो सामग्री जोड़ें, जो आमतौर पर कार्रवाई के लिए कॉल करें या दो के साथ पेज का "
+"परिचयात्मक क्षेत्र है."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -781,10 +811,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "लेआउट बदलें"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "%s में पृष्ठभूमि जोड़ें"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2352,19 +2378,6 @@ msgstr "Houzz"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr ""
 #~ "यह ऐसी फ़ीचर ब्लॉक है जिसका उपयोग आप सुविधाओं को हाइलाइट करने के लिए कर सकते हैं."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "हीरो शीर्षक जोड़ें..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "ऐसी हीरो सामग्री जोड़ें, जो आमतौर पर कार्रवाई के लिए कॉल करें या दो के साथ पेज का "
-#~ "परिचयात्मक क्षेत्र है."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-id_ID.po
+++ b/languages/coblocks-id_ID.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Tambahkan latar belakang ke %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Tambahkan judul hero..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Tambahkan konten hero, yang umumnya adalah area pendahuluan halaman yang "
+"disertai satu atau beberapa seruan bertindak."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -793,10 +823,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Ubah tata letak"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Tambahkan latar belakang ke %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2374,19 +2400,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "Ini adalah blok fitur yang bisa Anda gunakan untuk menyorot fitur."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Tambahkan judul hero..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Tambahkan konten hero, yang umumnya adalah area pendahuluan halaman yang "
-#~ "disertai satu atau beberapa seruan bertindak."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-it_IT.po
+++ b/languages/coblocks-it_IT.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Aggiungi sfondo a %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Aggiungi intestazione hero..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Aggiungi il contenuto hero, che in genere corrisponde a un’area introduttiva "
+"della pagina accompagnata da uno o due inviti all’azione."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -806,10 +836,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Cambia layout"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Aggiungi sfondo a %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2403,19 +2429,6 @@ msgstr "Houzz"
 #~ msgstr ""
 #~ "Questo blocco caratteristiche può essere utilizzato per evidenziare delle "
 #~ "caratteristiche."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Aggiungi intestazione hero..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Aggiungi il contenuto hero, che in genere corrisponde a un’area "
-#~ "introduttiva della pagina accompagnata da uno o due inviti all’azione."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-ja.po
+++ b/languages/coblocks-ja.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "%sに背景を追加"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "ヒーローの見出しを追加..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"通常、CTAなどをともなうページの導入エリアとして使用されるヒーローのコンテンツ"
+"を追加します。"
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -787,10 +817,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "レイアウトを変更"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "%sに背景を追加"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2359,19 +2385,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "特集を強調するために使用する特集ブロックです。"
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "ヒーローの見出しを追加..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "通常、CTAなどをともなうページの導入エリアとして使用されるヒーローのコンテ"
-#~ "ンツを追加します。"
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-ko_KR.po
+++ b/languages/coblocks-ko_KR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "%s에 배경 추가"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Hero 머리글 추가..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"일반적으로 한 두 가지의 콜투액션이 수반되는 페이지의 소개 영역인 Hero 콘텐츠"
+"를 추가합니다."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -790,10 +820,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "레이아웃 변경"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "%s에 배경 추가"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2359,19 +2385,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "기능을 강조 표시할 때 사용할 수 있는 기능 블록입니다."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Hero 머리글 추가..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "일반적으로 한 두 가지의 콜투액션이 수반되는 페이지의 소개 영역인 Hero 콘텐"
-#~ "츠를 추가합니다."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-mr.po
+++ b/languages/coblocks-mr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "%s च्या पार्श्वभूमीत जोडा"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "हिरो शीर्षक जोडा..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"कॉल टू अॅक्शन किंवा दोघांसह विशिष्टरित्या पृष्‍ठाचा परिचयात्मक भाग असलेली हिरो सामग्री "
+"जोडा."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -793,10 +823,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "लेआउट बदला"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "%s च्या पार्श्वभूमीत जोडा"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2416,19 +2442,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "हा वैशिष्ट्य ब्लॉक आहे तो आपण वैशिष्ट्ये हायलाइट करण्यासाठी वापरू शकता."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "हिरो शीर्षक जोडा..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "कॉल टू अॅक्शन किंवा दोघांसह विशिष्टरित्या पृष्‍ठाचा परिचयात्मक भाग असलेली हिरो सामग्री "
-#~ "जोडा."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-nb_NO.po
+++ b/languages/coblocks-nb_NO.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Legg til bakgrunn til %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Legg til hovedbanner-overskrift ..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Legg til hovedbanner-innhold, som vanligvis er et introduksjonsområde på en "
+"side ledsaget av en handlingsoppfordring eller to."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -801,10 +831,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Endre oppsett"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Legg til bakgrunn til %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2384,19 +2410,6 @@ msgstr "Houzz"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr ""
 #~ "Dette er en funksjonsblokk som du kan bruke til å utheve funksjoner."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Legg til hovedbanner-overskrift ..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Legg til hovedbanner-innhold, som vanligvis er et introduksjonsområde på "
-#~ "en side ledsaget av en handlingsoppfordring eller to."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-nl_NL.po
+++ b/languages/coblocks-nl_NL.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Achtergrond toevoegen aan %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Herokop toevoegen..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Voeg herocontent toe, hetgeen meestal een inleidend onderdeel van een pagina "
+"is samen met een of twee call-to-actions."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -802,10 +832,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Lay-out wijzigen"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Achtergrond toevoegen aan %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2395,19 +2421,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "Dit is een functieblok waarmee je functies kunt uitlichten."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Herokop toevoegen..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Voeg herocontent toe, hetgeen meestal een inleidend onderdeel van een "
-#~ "pagina is samen met een of twee call-to-actions."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-pl_PL.po
+++ b/languages/coblocks-pl_PL.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Dodaj tło do %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Dodaj nagłówek frontalny..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Dodaj zawartość frontalną, która zwykle stanowi obszar wprowadzenia strony "
+"wraz z jednym lub dwoma wezwaniami do działania."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -794,10 +824,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Zmień układ"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Dodaj tło do %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2379,19 +2405,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "To jest blok funkcji, za pomocą którego można wyróżniać funkcje."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Dodaj nagłówek frontalny..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Dodaj zawartość frontalną, która zwykle stanowi obszar wprowadzenia "
-#~ "strony wraz z jednym lub dwoma wezwaniami do działania."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-pt_BR.po
+++ b/languages/coblocks-pt_BR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Adicionar plano de fundo a %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Adicione o cabeçalho principal..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Adicione o conteúdo principal, que normalmente é uma área introdutória de "
+"uma página, acompanhada por uma ou duas chamadas para ação."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -795,10 +825,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Alterar layout"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Adicionar plano de fundo a %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2387,19 +2413,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "Este é um bloco que pode ser usado para destacar recursos."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Adicione o cabeçalho principal..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Adicione o conteúdo principal, que normalmente é uma área introdutória de "
-#~ "uma página, acompanhada por uma ou duas chamadas para ação."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-pt_PT.po
+++ b/languages/coblocks-pt_PT.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Adicionar fundo a %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Adicionar título de herói..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Adicione conteúdo de herói, o qual consiste normalmente numa área de "
+"apresentação de uma página acompanhada por um apelo à ação ou dois."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -799,10 +829,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Alterar esquema"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Adicionar fundo a %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2391,19 +2417,6 @@ msgstr "Houzz"
 #~ msgstr ""
 #~ "Este é um bloco de funcionalidades que pode utilizar para destacar "
 #~ "funcionalidades."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Adicionar título de herói..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Adicione conteúdo de herói, o qual consiste normalmente numa área de "
-#~ "apresentação de uma página acompanhada por um apelo à ação ou dois."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-ru_RU.po
+++ b/languages/coblocks-ru_RU.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Добавить фон для %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Добавить заголовок блока героев..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Добавьте контент блока героев, который обычно является вводным текстом "
+"страницы с одним или двумя призывами к действию."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -808,10 +838,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Изменить макет"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Добавить фон для %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2411,19 +2437,6 @@ msgstr "Houzz"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr ""
 #~ "Этот функциональный блок вы можете использовать для выделения функций."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Добавить заголовок блока героев..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Добавьте контент блока героев, который обычно является вводным текстом "
-#~ "страницы с одним или двумя призывами к действию."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-sv_SE.po
+++ b/languages/coblocks-sv_SE.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Lägg till bakgrund till %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Lägg till herobannerrubrik..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Lägg till herobannerinnehåll, som brukar vara ett introduktionsområde på en "
+"sida, följt av en uppmaning till handling eller två."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -794,10 +824,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Ändra layout"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Lägg till bakgrund till %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2374,19 +2400,6 @@ msgstr "Houzz"
 #~ msgstr ""
 #~ "Det här är ett funktionsblock som du kan använda för att markera "
 #~ "funktioner."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Lägg till herobannerrubrik..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Lägg till herobannerinnehåll, som brukar vara ett introduktionsområde på "
-#~ "en sida, följt av en uppmaning till handling eller två."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-th.po
+++ b/languages/coblocks-th.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "เพิ่มพื้นหลังให้ %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "เพิ่มหัวเรื่องแบบฮีโร่..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"เพิ่มเนื้อหาแบบฮีโร่ ซึ่งปกติจะเป็นพื้นที่แนะนำหน้าหรือสองหน้าที่มาพร้อมกับการกระตุ้นให้ดำเนินการ"
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -778,10 +807,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "เปลี่ยนเค้าโครง"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "เพิ่มพื้นหลังให้ %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2343,18 +2368,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "นี่เป็นบล็อคคุณลักษณะที่คุณสามารถใช้เพื่อเน้นคุณลักษณะได้"
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "เพิ่มหัวเรื่องแบบฮีโร่..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "เพิ่มเนื้อหาแบบฮีโร่ ซึ่งปกติจะเป็นพื้นที่แนะนำหน้าหรือสองหน้าที่มาพร้อมกับการกระตุ้นให้ดำเนินการ"
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-tr_TR.po
+++ b/languages/coblocks-tr_TR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "%s sayfasına arkaplan ekle"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Ana site başlığı ekleyin..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Genellikle bir veya iki eylem çağrısıyla birlikte sayfanın giriş kısmını "
+"oluşturan ana site içeriğini ekleyin."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -800,10 +830,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Sayfa düzenini değiştir"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "%s sayfasına arkaplan ekle"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2393,19 +2419,6 @@ msgstr "Houzz"
 #~ msgstr ""
 #~ "Bu blok, özellikleri vurgulamak için kullanabileceğiniz bir özellik "
 #~ "blokudur."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Ana site başlığı ekleyin..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Genellikle bir veya iki eylem çağrısıyla birlikte sayfanın giriş kısmını "
-#~ "oluşturan ana site içeriğini ekleyin."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-uk.po
+++ b/languages/coblocks-uk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Додати тло до %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Додайте заголовок hero..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Додайте вміст hero, зазвичай це вступна частина сторінки, яка "
+"супроводжується одним чи двома закликами до дії."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -799,10 +829,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Змінити макет"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Додати тло до %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2391,19 +2417,6 @@ msgstr "Houzz"
 #~ msgstr ""
 #~ "Це блок особливості, який можна використовувати для виокремлення "
 #~ "особливостей."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Додайте заголовок hero..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Додайте вміст hero, зазвичай це вступна частина сторінки, яка "
-#~ "супроводжується одним чи двома закликами до дії."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-vi.po
+++ b/languages/coblocks-vi.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "Thêm nền cho %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "Thêm đầu trang chính..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr ""
+"Thêm nội dung chính mà thường là phần giới thiệu của trang, kèm theo là một "
+"hay hai kêu gọi thao tác."
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -790,10 +820,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "Thay đổi bố cục"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "Thêm nền cho %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2365,19 +2391,6 @@ msgstr "Houzz"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr ""
 #~ "Đây là khối tính năng mà bạn có thể sử dụng để làm nổi bật các tính năng."
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "Thêm đầu trang chính..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr ""
-#~ "Thêm nội dung chính mà thường là phần giới thiệu của trang, kèm theo là "
-#~ "một hay hai kêu gọi thao tác."
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-zh_CN.po
+++ b/languages/coblocks-zh_CN.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,34 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "将背景添加到 %s"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "添加首页标题..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr "添加首页内容，通常是页面的介绍性区域，配有行动号召或两个。"
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -777,10 +805,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "更改布局"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "将背景添加到 %s"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2341,17 +2365,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "这是可用来突出显示功能的功能块。"
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "添加首页标题..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr "添加首页内容，通常是页面的介绍性区域，配有行动号召或两个。"
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks-zh_TW.po
+++ b/languages/coblocks-zh_TW.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoBlocks 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/godaddy/coblocks/issues\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: plugins@godaddy.com\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,34 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+#, fuzzy
+msgid "Add background to hero"
+msgstr "為 %s 新增背景"
+
+#: src/blocks/hero/edit.js:35
+#, fuzzy
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr "新增主頁標題..."
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid ""
+"Add hero content, which is typically an introductory area of a page "
+"accompanied by call to action or two."
+msgstr "新增主頁內容，此區域一般用來介紹頁面，通常也會附上些許行動呼籲。"
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"
@@ -779,10 +807,6 @@ msgstr "Houzz"
 
 #~ msgid "Change layout"
 #~ msgstr "變更版面"
-
-#, fuzzy
-#~ msgid "Add backround to hero"
-#~ msgstr "為 %s 新增背景"
 
 #~ msgid ""
 #~ "An introductory area of a page accompanied by a small amount of text and "
@@ -2343,17 +2367,6 @@ msgstr "Houzz"
 #~ msgctxt "content placeholder"
 #~ msgid "This is a feature block that you can use to highlight features."
 #~ msgstr "您可以透過此功能區塊強調功能。"
-
-#, fuzzy
-#~ msgctxt "content placeholder"
-#~ msgid "Add hero heading…"
-#~ msgstr "新增主頁標題..."
-
-#~ msgctxt "content placeholder"
-#~ msgid ""
-#~ "Add hero content, which is typically an introductory area of a page "
-#~ "accompanied by call to action or two."
-#~ msgstr "新增主頁內容，此區域一般用來介紹頁面，通常也會附上些許行動呼籲。"
 
 #~ msgctxt "content placeholder"
 #~ msgid "Add heading..."

--- a/languages/coblocks.pot
+++ b/languages/coblocks.pot
@@ -8,10 +8,34 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-10-15T15:15:23+00:00\n"
+"POT-Creation-Date: 2019-10-15T20:39:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: coblocks\n"
+
+#: src/blocks/hero/edit.js:152
+msgid "Add background to hero"
+msgstr ""
+
+#: src/blocks/hero/edit.js:35
+msgctxt "content placeholder"
+msgid "Add hero heading…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:36
+msgctxt "content placeholder"
+msgid "Add hero content, which is typically an introductory area of a page accompanied by call to action or two."
+msgstr ""
+
+#: src/blocks/hero/edit.js:39
+msgctxt "content placeholder"
+msgid "Primary button…"
+msgstr ""
+
+#: src/blocks/hero/edit.js:40
+msgctxt "content placeholder"
+msgid "Secondary button…"
+msgstr ""
 
 #. Plugin Name of the plugin
 msgid "CoBlocks"

--- a/src/blocks/features/edit.js
+++ b/src/blocks/features/edit.js
@@ -75,7 +75,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundDropZone
 				{ ...this.props }
-				label={ __( 'Add as backround' ) }
+				label={ __( 'Add as background' ) }
 			/>
 		);
 

--- a/src/blocks/features/feature/edit.js
+++ b/src/blocks/features/feature/edit.js
@@ -60,7 +60,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundDropZone
 				{ ...this.props }
-				label={ __( 'Add as backround' ) }
+				label={ __( 'Add as background' ) }
 			/>
 		);
 

--- a/src/blocks/hero/edit.js
+++ b/src/blocks/hero/edit.js
@@ -149,7 +149,7 @@ export class Edit extends Component {
 		const dropZone = (
 			<BackgroundDropZone
 				{ ...this.props }
-				label={ __( 'Add backround to hero' ) }
+				label={ __( 'Add background to hero' ) }
 			/>
 		);
 

--- a/src/blocks/media-card/edit.js
+++ b/src/blocks/media-card/edit.js
@@ -170,7 +170,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundDropZone
 				{ ...this.props }
-				label={ __( 'Add as backround' ) }
+				label={ __( 'Add as background' ) }
 			/>
 		);
 

--- a/src/blocks/row/column/edit.js
+++ b/src/blocks/row/column/edit.js
@@ -87,7 +87,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundDropZone
 				{ ...this.props }
-				label={ __( 'Add backround to column' ) }
+				label={ __( 'Add background to column' ) }
 			/>
 		);
 

--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -166,7 +166,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundDropZone
 				{ ...this.props }
-				label={ __( 'Add backround to row' ) }
+				label={ __( 'Add background to row' ) }
 			/>
 		);
 

--- a/src/blocks/share/index.php
+++ b/src/blocks/share/index.php
@@ -96,7 +96,7 @@ function coblocks_render_share_block( $attributes ) {
 	$border_radius    = is_array( $attributes ) && isset( $attributes['borderRadius'] ) ? "border-radius: {$attributes['borderRadius']}px;" : '';
 	$has_padding      = is_array( $attributes ) && isset( $attributes['padding'] ) ? 'has-padding' : '';
 
-	$has_background           = '';
+	$has_background          = '';
 	$background_color_class  = '';
 	$custom_background_color = '';
 	$has_color               = '';
@@ -106,11 +106,11 @@ function coblocks_render_share_block( $attributes ) {
 	$padding                 = '';
 
 	if ( isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-mask' ) !== false ) {
-		$has_background           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( $attributes['backgroundColor'] || $attributes['customBackgroundColor'] ) ) ? 'has-text-color' : '';
+		$has_background          = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( $attributes['backgroundColor'] || $attributes['customBackgroundColor'] ) ) ? 'has-text-color' : '';
 		$background_color_class  = is_array( $attributes ) && isset( $attributes['backgroundColor'] ) ? "has-{$attributes['backgroundColor']}-color" : false;
 		$custom_background_color = is_array( $attributes ) && isset( $attributes['customBackgroundColor'] ) && isset( $attributes['hasColors'] ) && ( ! $attributes['hasColors'] && ! isset( $attributes['backgroundColor'] ) ) ? "color: {$attributes['customBackgroundColor']};" : '';
 	} else {
-		$has_background           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( isset( $attributes['backgroundColor'] ) || $attributes['customBackgroundColor'] ) ) ? 'has-background' : '';
+		$has_background          = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( isset( $attributes['backgroundColor'] ) || $attributes['customBackgroundColor'] ) ) ? 'has-background' : '';
 		$background_color_class  = is_array( $attributes ) && isset( $attributes['backgroundColor'] ) ? "has-{$attributes['backgroundColor']}-background-color" : false;
 		$custom_background_color = is_array( $attributes ) && isset( $attributes['customBackgroundColor'] ) && isset( $attributes['hasColors'] ) && ( ! $attributes['hasColors'] && ! isset( $attributes['backgroundColor'] ) ) ? "background-color: {$attributes['customBackgroundColor']};" : '';
 

--- a/src/blocks/share/index.php
+++ b/src/blocks/share/index.php
@@ -96,7 +96,7 @@ function coblocks_render_share_block( $attributes ) {
 	$border_radius    = is_array( $attributes ) && isset( $attributes['borderRadius'] ) ? "border-radius: {$attributes['borderRadius']}px;" : '';
 	$has_padding      = is_array( $attributes ) && isset( $attributes['padding'] ) ? 'has-padding' : '';
 
-	$has_backround           = '';
+	$has_background           = '';
 	$background_color_class  = '';
 	$custom_background_color = '';
 	$has_color               = '';
@@ -106,11 +106,11 @@ function coblocks_render_share_block( $attributes ) {
 	$padding                 = '';
 
 	if ( isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-mask' ) !== false ) {
-		$has_backround           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( $attributes['backgroundColor'] || $attributes['customBackgroundColor'] ) ) ? 'has-text-color' : '';
+		$has_background           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( $attributes['backgroundColor'] || $attributes['customBackgroundColor'] ) ) ? 'has-text-color' : '';
 		$background_color_class  = is_array( $attributes ) && isset( $attributes['backgroundColor'] ) ? "has-{$attributes['backgroundColor']}-color" : false;
 		$custom_background_color = is_array( $attributes ) && isset( $attributes['customBackgroundColor'] ) && isset( $attributes['hasColors'] ) && ( ! $attributes['hasColors'] && ! isset( $attributes['backgroundColor'] ) ) ? "color: {$attributes['customBackgroundColor']};" : '';
 	} else {
-		$has_backround           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( isset( $attributes['backgroundColor'] ) || $attributes['customBackgroundColor'] ) ) ? 'has-background' : '';
+		$has_background           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( isset( $attributes['backgroundColor'] ) || $attributes['customBackgroundColor'] ) ) ? 'has-background' : '';
 		$background_color_class  = is_array( $attributes ) && isset( $attributes['backgroundColor'] ) ? "has-{$attributes['backgroundColor']}-background-color" : false;
 		$custom_background_color = is_array( $attributes ) && isset( $attributes['customBackgroundColor'] ) && isset( $attributes['hasColors'] ) && ( ! $attributes['hasColors'] && ! isset( $attributes['backgroundColor'] ) ) ? "background-color: {$attributes['customBackgroundColor']};" : '';
 
@@ -178,7 +178,7 @@ function coblocks_render_share_block( $attributes ) {
 				</li>',
 				esc_url( $platform['url'] ),
 				esc_html( $platform['text'] ),
-				esc_attr( $has_backround ),
+				esc_attr( $has_background ),
 				esc_attr( $border_radius ),
 				esc_attr( $icon_size ),
 				esc_attr( $custom_background_color ),

--- a/src/blocks/social-profiles/index.php
+++ b/src/blocks/social-profiles/index.php
@@ -30,7 +30,7 @@ function coblocks_render_social_profiles_block( $attributes ) {
 	$border_radius          = is_array( $attributes ) && isset( $attributes['borderRadius'] ) ? "border-radius: {$attributes['borderRadius']}px;" : '';
 	$has_padding            = is_array( $attributes ) && isset( $attributes['padding'] ) ? 'has-padding' : '';
 
-	$has_background           = '';
+	$has_background          = '';
 	$background_color_class  = '';
 	$custom_background_color = '';
 	$has_color               = '';
@@ -40,11 +40,11 @@ function coblocks_render_social_profiles_block( $attributes ) {
 	$padding                 = '';
 
 	if ( isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-mask' ) !== false ) {
-		$has_background           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( $attributes['backgroundColor'] || $attributes['customBackgroundColor'] ) ) ? 'has-text-color' : '';
+		$has_background          = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( $attributes['backgroundColor'] || $attributes['customBackgroundColor'] ) ) ? 'has-text-color' : '';
 		$background_color_class  = is_array( $attributes ) && isset( $attributes['backgroundColor'] ) ? "has-{$attributes['backgroundColor']}-color" : false;
 		$custom_background_color = is_array( $attributes ) && isset( $attributes['customBackgroundColor'] ) && isset( $attributes['hasColors'] ) && ( ! $attributes['hasColors'] && ! isset( $attributes['backgroundColor'] ) ) ? "color: {$attributes['customBackgroundColor']};" : '';
 	} else {
-		$has_background           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( isset( $attributes['backgroundColor'] ) || $attributes['customBackgroundColor'] ) ) ? 'has-background' : '';
+		$has_background          = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( isset( $attributes['backgroundColor'] ) || $attributes['customBackgroundColor'] ) ) ? 'has-background' : '';
 		$background_color_class  = is_array( $attributes ) && isset( $attributes['backgroundColor'] ) ? "has-{$attributes['backgroundColor']}-background-color" : false;
 		$custom_background_color = is_array( $attributes ) && isset( $attributes['customBackgroundColor'] ) && isset( $attributes['hasColors'] ) && ( ! $attributes['hasColors'] && ! isset( $attributes['backgroundColor'] ) ) ? "background-color: {$attributes['customBackgroundColor']};" : '';
 

--- a/src/blocks/social-profiles/index.php
+++ b/src/blocks/social-profiles/index.php
@@ -30,7 +30,7 @@ function coblocks_render_social_profiles_block( $attributes ) {
 	$border_radius          = is_array( $attributes ) && isset( $attributes['borderRadius'] ) ? "border-radius: {$attributes['borderRadius']}px;" : '';
 	$has_padding            = is_array( $attributes ) && isset( $attributes['padding'] ) ? 'has-padding' : '';
 
-	$has_backround           = '';
+	$has_background           = '';
 	$background_color_class  = '';
 	$custom_background_color = '';
 	$has_color               = '';
@@ -40,11 +40,11 @@ function coblocks_render_social_profiles_block( $attributes ) {
 	$padding                 = '';
 
 	if ( isset( $attributes['className'] ) && strpos( $attributes['className'], 'is-style-mask' ) !== false ) {
-		$has_backround           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( $attributes['backgroundColor'] || $attributes['customBackgroundColor'] ) ) ? 'has-text-color' : '';
+		$has_background           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( $attributes['backgroundColor'] || $attributes['customBackgroundColor'] ) ) ? 'has-text-color' : '';
 		$background_color_class  = is_array( $attributes ) && isset( $attributes['backgroundColor'] ) ? "has-{$attributes['backgroundColor']}-color" : false;
 		$custom_background_color = is_array( $attributes ) && isset( $attributes['customBackgroundColor'] ) && isset( $attributes['hasColors'] ) && ( ! $attributes['hasColors'] && ! isset( $attributes['backgroundColor'] ) ) ? "color: {$attributes['customBackgroundColor']};" : '';
 	} else {
-		$has_backround           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( isset( $attributes['backgroundColor'] ) || $attributes['customBackgroundColor'] ) ) ? 'has-background' : '';
+		$has_background           = is_array( $attributes ) && isset( $attributes['hasColors'] ) && ( isset( $attributes['backgroundColor'] ) || isset( $attributes['customBackgroundColor'] ) ) && ( $attributes['hasColors'] || ( isset( $attributes['backgroundColor'] ) || $attributes['customBackgroundColor'] ) ) ? 'has-background' : '';
 		$background_color_class  = is_array( $attributes ) && isset( $attributes['backgroundColor'] ) ? "has-{$attributes['backgroundColor']}-background-color" : false;
 		$custom_background_color = is_array( $attributes ) && isset( $attributes['customBackgroundColor'] ) && isset( $attributes['hasColors'] ) && ( ! $attributes['hasColors'] && ! isset( $attributes['backgroundColor'] ) ) ? "background-color: {$attributes['customBackgroundColor']};" : '';
 
@@ -114,7 +114,7 @@ function coblocks_render_social_profiles_block( $attributes ) {
 				</li>',
 				esc_url( $platform['url'] ),
 				esc_html( $platform['text'] ),
-				esc_attr( $has_backround ),
+				esc_attr( $has_background ),
 				esc_attr( $border_radius ),
 				esc_attr( $icon_size ),
 				esc_attr( $custom_background_color ),


### PR DESCRIPTION
Some strings and variables were written as `backround` instead of `background`. This PR fixes it and regenerates the POT/PO files.