### PR TITLE
Ensure image placeholders maintain aspect ratio of the selected style

### DIFF
--- a/src/blocks/services/service/edit.js
+++ b/src/blocks/services/service/edit.js
@@ -183,6 +183,7 @@ class Edit extends Component {
 		const { setAttributes } = this.props;
 		return (
 			<MediaPlaceholder
+				className="wp-block-coblocks-service__figure"
 				allowedTypes={ [ 'image' ] }
 				multiple={ false }
 				icon="format-image"

--- a/src/blocks/services/service/styles/editor.scss
+++ b/src/blocks/services/service/styles/editor.scss
@@ -29,18 +29,13 @@
 	display: block;
 	flex: 1 100%;
 
-	.editor-media-placeholder {
-		min-height: unset;
-		padding: calc(9 / 16 * 100%) 0 0 0;
-		position: relative;
+	.block-editor-media-placeholder {
+		background: $dark-opacity-light-200;
+		min-height: inherit;
+		border: 1px dashed $dark-gray-150;
 
-		.is-style-circle & {
-			border-radius: 100%;
-			padding-top: 100%;
-		}
-
-		.is-style-square & {
-			padding-top: 100%;
+		&:hover {
+			border-color: $dark-gray-500;
 		}
 
 		.components-placeholder__label,
@@ -49,6 +44,7 @@
 		}
 
 		.components-placeholder__fieldset {
+			align-content: center;
 			align-items: center;
 			height: 100%;
 			left: 0;

--- a/src/blocks/services/service/styles/style.scss
+++ b/src/blocks/services/service/styles/style.scss
@@ -10,7 +10,7 @@
 	&__figure {
 		display: flex;
 		margin: 0 0 1.5em;
-		padding-top: calc(3 / 4 * 100%);
+		padding: calc(3 / 4 * 100%) 0 0;
 		position: relative;
 		width: 100%;
 


### PR DESCRIPTION
Resolves #847.

We were missing a className on the `MediaPlaceholder` component which prevented styles being shared between the placeholder and the actual `figure` markup. An additional padding override was necessary as well.

**After**

![Screen Shot 2019-10-16 at 4 55 00 PM](https://user-images.githubusercontent.com/375788/66958256-c923a480-f035-11e9-87fc-b8c51ff0ff31.png)

![Screen Shot 2019-10-16 at 4 55 15 PM](https://user-images.githubusercontent.com/375788/66958259-cb85fe80-f035-11e9-9692-aeda2b5537c7.png)

![Screen Shot 2019-10-16 at 4 55 53 PM](https://user-images.githubusercontent.com/375788/66958276-d476d000-f035-11e9-9274-f026390e4a01.png)
