### PR TITLE
Remove excess padding from Services placeholders

### DIFF
--- a/src/blocks/services/styles/editor.scss
+++ b/src/blocks/services/styles/editor.scss
@@ -35,6 +35,12 @@ $gutter: 0.3em;
 		width: 100%;
 	}
 
+	.block-editor-media-placeholder {
+		padding-bottom: 0;
+		padding-left: 0;
+		padding-right: 0;
+	}
+
 	.block-editor-block-list__layout {
 		@include break-small() {
 			display: flex;


### PR DESCRIPTION
This PR removes the excess padding on the Services block image placeholders, which is added by Gutenberg.

**Before:** 
<img width="646" alt="Screen Shot 2019-10-17 at 1 43 44 PM" src="https://user-images.githubusercontent.com/1813435/67033616-29711f80-f0e4-11e9-9b54-10e90186cd73.png">

**After:**
<img width="603" alt="Screen Shot 2019-10-17 at 1 39 51 PM" src="https://user-images.githubusercontent.com/1813435/67033575-13635f00-f0e4-11e9-9c12-ade69d3323ae.png">
