### PR TITLE
Ensure thumbnail nav matches Carousel block

### DIFF
--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import filter from 'lodash/filter';
+import Flickity from 'react-flickity-component';
 
 /**
  * Internal dependencies
@@ -34,6 +35,7 @@ class GalleryCarouselEdit extends Component {
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.onFocusCaption = this.onFocusCaption.bind( this );
 		this.onItemClick = this.onItemClick.bind( this );
+		this.onThumbnailClick = this.onThumbnailClick.bind( this );
 
 		this.state = {
 			selectedImage: null,
@@ -138,6 +140,13 @@ class GalleryCarouselEdit extends Component {
 		}
 	}
 
+	onThumbnailClick( e ) {
+		console.log( e );
+		// this.flkty.on( 'settle', () => {
+		// 	console.log( `current index is ${ this.flkty.selectedIndex }` );
+		// } );
+	}
+
 	render() {
 		const {
 			attributes,
@@ -223,11 +232,11 @@ class GalleryCarouselEdit extends Component {
 		const navOptions = {
 			asNavFor: '.has-carousel',
 			draggable: false,
-			pageDots: true,
+			pageDots: false,
 			prevNextButtons: false,
 			wrapAround: true,
 			autoPlay: false,
-			thumbnails: false,
+			thumbnails: true,
 			cellAlign: 'left',
 		};
 
@@ -355,21 +364,25 @@ class GalleryCarouselEdit extends Component {
 				{ thumbnails ?
 					<div className={ className }>
 						<div className={ innerClasses }>
-							<div
+							<Flickity
 								className={ navClasses }
 								style={ navStyles }
+								disableImagesLoaded={ true }
+								options={ navOptions }
+								reloadOnUpdate={ true }
+								updateOnEachImageLoad={ true }
 								data-flickity={ JSON.stringify( navOptions ) }
 							>
 								{ images.map( ( image ) => {
 									return (
-										<div className="coblocks--item-thumbnail" key={ image.id || image.url }>
+										<div className="coblocks--item-thumbnail" key={ image.id || image.url } onClick={ ( e ) => this.onThumbnailClick( e ) } >
 											<figure className={ navFigureClasses }>
 												<img src={ image.url } alt={ image.alt } data-link={ image.link } data-id={ image.id } className={ image.id ? `wp-image-${ image.id }` : null } />
 											</figure>
 										</div>
 									);
 								} ) }
-							</div>
+							</Flickity>
 						</div>
 					</div> : null
 				}

--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -142,9 +142,7 @@ class GalleryCarouselEdit extends Component {
 
 	onThumbnailClick( e ) {
 		console.log( e );
-		// this.flkty.on( 'settle', () => {
-		// 	console.log( `current index is ${ this.flkty.selectedIndex }` );
-		// } );
+		// might be able to control the selected element by tracking the clicked image.
 	}
 
 	render() {
@@ -256,12 +254,6 @@ class GalleryCarouselEdit extends Component {
 		const flickityStyles = {
 			height: height ? height + 'px' : undefined,
 		};
-
-		// const classes = classnames(
-		// 	className, {
-		// 		'has-responsive-height': responsiveHeight,
-		// 	}
-		// );
 
 		if ( ! hasImages ) {
 			return (

--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -3,7 +3,6 @@
  */
 import classnames from 'classnames';
 import filter from 'lodash/filter';
-import Flickity from 'react-flickity-component';
 
 /**
  * Internal dependencies
@@ -236,6 +235,11 @@ class GalleryCarouselEdit extends Component {
 			marginTop: gutter > 0 && ! responsiveHeight ? ( gutter / 2 ) + 'px' : undefined,
 		};
 
+		const captionClasses = classnames(
+			'coblocks-gallery--caption',
+			'coblocks-gallery--primary-caption', {}
+		);
+
 		const navFigureClasses = classnames(
 			'coblocks--figure', {
 				[ `has-margin-left-${ gutter }` ]: gutter > 0,
@@ -244,6 +248,16 @@ class GalleryCarouselEdit extends Component {
 				[ `has-margin-right-mobile-${ gutterMobile }` ]: gutterMobile > 0,
 			}
 		);
+
+		const flickityStyles = {
+			height: height ? height + 'px' : undefined,
+		};
+
+		// const classes = classnames(
+		// 	className, {
+		// 		'has-responsive-height': responsiveHeight,
+		// 	}
+		// );
 
 		if ( ! hasImages ) {
 			return (
@@ -297,13 +311,10 @@ class GalleryCarouselEdit extends Component {
 					{ dropZone }
 					<div className={ className }>
 						<div className={ innerClasses }>
-							<Flickity
+							<div
 								className={ flickityClasses }
-								disableImagesLoaded={ false }
-								flickityRef={ c => this.flkty = c }
-								options={ flickityOptions }
-								reloadOnUpdate={ true }
-								updateOnEachImageLoad={ true }
+								style={ responsiveHeight ? undefined : flickityStyles }
+								data-flickity={ JSON.stringify( flickityOptions ) }
 							>
 								{ images.map( ( img, index ) => {
 									// translators: %1$d is the order number of the image, %2$d is the total number of images
@@ -341,48 +352,35 @@ class GalleryCarouselEdit extends Component {
 										/>
 									</div>
 								) }
-							</Flickity>
+							</div>
 						</div>
 					</div>
 				</ResizableBox>
-				<div className={ className }>
-					<div
-						className={ innerClasses }
-						style={ navStyles }
-					>
-						<Flickity
-							className={ navClasses }
-							options={ navOptions }
-							disableImagesLoaded={ false }
-							reloadOnUpdate={ true }
-							flickityRef={ c => this.flkty = c }
-							updateOnEachImageLoad={ true }
-						>
-							{ images.map( ( image ) => {
-								return (
-									<div className="coblocks--item-thumbnail" key={ image.id || image.url }>
-										<figure className={ navFigureClasses }>
-											<img src={ image.url } alt={ image.alt } data-link={ image.link } data-id={ image.id } className={ image.id ? `wp-image-${ image.id }` : null } />
-										</figure>
-									</div>
-								);
-							} ) }
-						</Flickity>
-					</div>
-				</div>
-				{ ( ! RichText.isEmpty( primaryCaption ) || isSelected ) && (
-					<RichText
-						tagName="figcaption"
-						placeholder={ __( 'Write caption…' ) }
-						value={ primaryCaption }
-						className="coblocks-gallery--caption coblocks-gallery--primary-caption"
-						unstableOnFocus={ this.onFocusCaption }
-						onChange={ ( value ) => setAttributes( { primaryCaption: value } ) }
-						isSelected={ this.state.captionFocused }
-						keepPlaceholderOnFocus
-						inlineToolbar
-					/>
-				) }
+
+				{ thumbnails ?
+					<div className={ className }>
+						<div className={ innerClasses }>
+							<div
+								className={ navClasses }
+								style={ navStyles }
+								data-flickity={ JSON.stringify( navOptions ) }
+							>
+								{ images.map( ( image ) => {
+									return (
+										<div className="coblocks--item-thumbnail" key={ image.id || image.url }>
+											<figure className={ navFigureClasses }>
+												<img src={ image.url } alt={ image.alt } data-link={ image.link } data-id={ image.id } className={ image.id ? `wp-image-${ image.id }` : null } />
+											</figure>
+										</div>
+									);
+								} ) }
+							</div>
+						</div>
+					</div> : null
+				}
+
+				{ ! RichText.isEmpty( primaryCaption ) && <RichText.Content tagName="figcaption" className={ captionClasses } value={ primaryCaption } /> }
+
 			</Fragment>
 		);
 	}

--- a/src/blocks/gallery-carousel/edit.js
+++ b/src/blocks/gallery-carousel/edit.js
@@ -235,11 +235,6 @@ class GalleryCarouselEdit extends Component {
 			marginTop: gutter > 0 && ! responsiveHeight ? ( gutter / 2 ) + 'px' : undefined,
 		};
 
-		const captionClasses = classnames(
-			'coblocks-gallery--caption',
-			'coblocks-gallery--primary-caption', {}
-		);
-
 		const navFigureClasses = classnames(
 			'coblocks--figure', {
 				[ `has-margin-left-${ gutter }` ]: gutter > 0,
@@ -379,8 +374,19 @@ class GalleryCarouselEdit extends Component {
 					</div> : null
 				}
 
-				{ ! RichText.isEmpty( primaryCaption ) && <RichText.Content tagName="figcaption" className={ captionClasses } value={ primaryCaption } /> }
-
+				{ ( ! RichText.isEmpty( primaryCaption ) || isSelected ) && (
+					<RichText
+						tagName="figcaption"
+						placeholder={ __( 'Write caption…' ) }
+						value={ primaryCaption }
+						className="coblocks-gallery--caption coblocks-gallery--primary-caption"
+						unstableOnFocus={ this.onFocusCaption }
+						onChange={ ( value ) => setAttributes( { primaryCaption: value } ) }
+						isSelected={ this.state.captionFocused }
+						keepPlaceholderOnFocus
+						inlineToolbar
+					/>
+				) }
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
# Summary of Pull Request
- Closes #1022 
- Need to get the Thumbnail styles right.
- Need to get the placeholder to render in the correct location.
- The behavior reported in issue #1010 occurs when using the `Flickity` react component. 
  * If Initialized with HTML, focus is treated as expected. 

**Focus Example**
![carouselFocusedElement](https://user-images.githubusercontent.com/30462574/67122369-84694c00-f1a2-11e9-8f20-c00e1f82938b.gif)

**Placeholder Example**
![image](https://user-images.githubusercontent.com/30462574/67123304-c98e7d80-f1a4-11e9-8295-7ba5927d21c4.png)


## Example of React Component behaviors
**Nav Broken & Media Placeholder In Correct Spot**
![carouselNavBroken](https://user-images.githubusercontent.com/30462574/67122907-b4fdb580-f1a3-11e9-83d1-0b131a6638fc.gif)
 **Carousel Component Type**

| Main Carousel  | Nav Carousel |
| --- | --- |
| Setup with HTML  | Setup with React Component  |

## Example of HTML initialized  behaviors


**Nav Semi-functional  & Media Placeholder In Wrong Spot**
![carouselMatchingNav](https://user-images.githubusercontent.com/30462574/67114497-e15c0680-f190-11e9-97f8-465ec9b59c17.gif)
**Carousel Component Type**

| Main Carousel  | Nav Carousel |
| --- | --- |
| Setup with HTML  | Setup with HTML |
