### PR TITLE
Use defined version constant for script version param

### DIFF
--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -97,7 +97,7 @@ class CoBlocks_Block_Assets {
 			$this->slug . '-editor',
 			$this->url . '/dist/blocks.build.js',
 			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-plugins', 'wp-components', 'wp-edit-post', 'wp-api', 'wp-rich-text', 'wp-editor' ),
-			time(),
+			COBLOCKS_VERSION,
 			false
 		);
 


### PR DESCRIPTION
Update `$version` param of `wp_register_script` to `COBLOCKS_VERSION`.