### PR TITLE
Improve Services block stability through block validation testing

### DIFF
--- a/src/blocks/services/service/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/services/service/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/service should render 1`] = `
+"<!-- wp:coblocks/service -->
+<div class=\\"wp-block-coblocks-service\\"><figure class=\\"wp-block-coblocks-service__figure\\"><img src=\\"https://website.com/wp-content/uploads/1234/56/image.jpg\\" alt=\\"alt text\\"/></figure><div class=\\"wp-block-coblocks-service__content\\"></div></div>
+<!-- /wp:coblocks/service -->"
+`;

--- a/src/blocks/services/service/test/save.spec.js
+++ b/src/blocks/services/service/test/save.spec.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		block.attributes.imageUrl = 'https://website.com/wp-content/uploads/1234/56/image.jpg';
+		block.attributes.imageAlt = 'alt text';
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'src="https://website.com/wp-content/uploads/1234/56/image.jpg"' );
+		expect( serializedBlock ).toContain( 'alt="alt text"' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );

--- a/src/blocks/services/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/services/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/services should render 1`] = `
+"<!-- wp:coblocks/services -->
+<div class=\\"wp-block-coblocks-services\\" data-columns=\\"2\\"></div>
+<!-- /wp:coblocks/services -->"
+`;

--- a/src/blocks/services/test/save.spec.js
+++ b/src/blocks/services/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This block did not have deprecations. Instead I added a basic test on the save function to detect when we need to write a deprecation. Related to #873.

```
Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   1 written, 1 passed, 2 total
Time:        2.812s, estimated 3s
```