### PR TITLE
Posts block: Scope column styles to the Posts block.

### DIFF
--- a/src/styles/style/_columns.scss
+++ b/src/styles/style/_columns.scss
@@ -1,4 +1,4 @@
-.columns {
+.wp-block-coblocks-posts .columns {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;


### PR DESCRIPTION
This PR scopes recent `.column` styles to the CoBlocks block that needs them, avoiding possible layout changes in theme markup.

This seems the simplest approach for a fix; was the greedy selector intentional because of future plans for other blocks maybe? In that case, something else may be more appropriate.

Fixes: #1033 