### PR TITLE
Use the jQuery global to avoid script conflicts with Gif block

### DIFF
--- a/src/blocks/gif/edit.js
+++ b/src/blocks/gif/edit.js
@@ -113,7 +113,7 @@ class Edit extends Component {
 
 			setAttributes( { fetching: true } );
 
-			$.getJSON( GIPHY_URL + encodeURI( search ) )
+			jQuery.getJSON( GIPHY_URL + encodeURI( search ) )
 				.success( function fetchSuccess( data ) {
 					setAttributes( { fetching: false, matches: data.data } );
 				} )

--- a/src/blocks/gif/edit.js
+++ b/src/blocks/gif/edit.js
@@ -1,4 +1,4 @@
-/*global $*/
+/*global jQuery*/
 
 /**
  * External dependencies


### PR DESCRIPTION
While testing WP 5.3 RC I found that the Gif block references `$` variable to access `jQuery`. At time of testing 5.3 RC has removed `$` from `window` while `jQuery` variable remains. This change would allow compatibility **with** and **without** WordPress 5.3 and would also follow the best practice that is already used by CoBlocks to reference the `jQuery` variable. 
