### PR TITLE
Replace "Cheating Huh?" with a less insulting message

### DIFF
--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -81,7 +81,7 @@ if ( ! class_exists( 'CoBlocks' ) ) :
 		 */
 		public function __clone() {
 			// Cloning instances of the class is forbidden.
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheating huh?', 'coblocks' ), '1.0' );
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'You don’t have permission to do this.', 'coblocks' ), '1.0' );
 		}
 
 		/**
@@ -93,7 +93,7 @@ if ( ! class_exists( 'CoBlocks' ) ) :
 		 */
 		public function __wakeup() {
 			// Unserializing instances of the class is forbidden.
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheating huh?', 'coblocks' ), '1.0' );
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'You don’t have permission to do this.', 'coblocks' ), '1.0' );
 		}
 
 		/**

--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -81,7 +81,7 @@ if ( ! class_exists( 'CoBlocks' ) ) :
 		 */
 		public function __clone() {
 			// Cloning instances of the class is forbidden.
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'You don’t have permission to do this.', 'coblocks' ), '1.0' );
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'Something went wrong.', 'coblocks' ), '1.0' );
 		}
 
 		/**
@@ -93,7 +93,7 @@ if ( ! class_exists( 'CoBlocks' ) ) :
 		 */
 		public function __wakeup() {
 			// Unserializing instances of the class is forbidden.
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'You don’t have permission to do this.', 'coblocks' ), '1.0' );
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'Something went wrong.', 'coblocks' ), '1.0' );
 		}
 
 		/**


### PR DESCRIPTION
This PR replaces the "Cheating Huh?" with a less insulting message: "_Something went wrong._" This follows [this change in WordPress](https://core.trac.wordpress.org/ticket/38332) ([trac](https://core.trac.wordpress.org/changeset/42719)). 