### PR TITLE
Allow theme colors in Row block placeholder

### DIFF
--- a/src/components/visual-dropdown/styles/editor.scss
+++ b/src/components/visual-dropdown/styles/editor.scss
@@ -31,14 +31,8 @@
 		margin: 0;
 		padding: 4px;
 
-		&:hover {
-			background: $light-gray-200;
-			color: $dark-gray-900;
-		}
-
 		&:focus {
 			box-shadow: 0 0 0 2px theme(primary);
-			color: $dark-gray-900;
 			outline: 2px solid transparent;
 			outline-offset: -2px;
 		}
@@ -47,7 +41,6 @@
 	& &__button.components-button.is-default {
 		align-items: center;
 		background: $white;
-		border: 1px solid rgba(25, 30, 35, 0.2);
 		border-radius: 4px !important;
 		box-shadow: none;
 		display: flex;
@@ -61,13 +54,8 @@
 		text-align: center;
 		width: 90px;
 
-		svg {
-			fill: $dark-gray-500;
-		}
-
 		&:focus {
 			box-shadow: 0 0 0 4px $light-gray-200, 0 0 0 6px theme(toggle);
-			color: $dark-gray-900;
 			outline: 2px solid transparent;
 			outline-offset: -2px;
 		}

--- a/src/components/visual-dropdown/styles/editor.scss
+++ b/src/components/visual-dropdown/styles/editor.scss
@@ -140,14 +140,6 @@
 		.components-coblocks-visual-dropdown__button.components-button {
 			margin-bottom: 0;
 			width: 100% !important;
-
-			&:focus {
-				box-shadow: 0 0 0 4px $white, 0 0 0 6px theme(toggle);
-			}
-
-			&:active:enabled {
-				box-shadow: 0 0 0 4px $white, 0 0 0 6px theme(toggle);
-			}
 		}
 	}
 }
@@ -160,6 +152,23 @@
 // Make the column width numer input wider to accommodate two decimal places.
 .components-panel__body--column-settings .components-range-control__number {
 	width: 63px;
+}
+
+.components-coblocks-visual-dropdown__popover { 
+	
+	.components-coblocks-visual-dropdown__button-wrapper:hover {
+		background: $light-gray-200;
+		color: $dark-gray-900;
+		border: 1px solid rgba(25, 30, 35, 0.2);
+	}
+	
+	.components-coblocks-visual-dropdown__button-wrapper {
+		border: 1px solid rgba(25, 30, 35, 0.2);
+
+		&.is-selected {
+			border: 1px solid rgba(25, 30, 35, 0.2);
+		}
+	}
 }
 
 .components-coblocks-visual-dropdown__popover:not(.is-mobile) {

--- a/src/components/visual-dropdown/styles/editor.scss
+++ b/src/components/visual-dropdown/styles/editor.scss
@@ -66,14 +66,7 @@
 	}
 
 	&__back.components-icon-button {
-		// background: $white;
-		// border: 1px solid rgba(25, 30, 35, 0.2);
 		margin-right: 4px;
-
-		&:hover {
-			// box-shadow: 0 0 0 4px $dark-opacity-light-200 !important;
-			// color: $dark-gray-900;
-		}
 	}
 
 	// Inspector control for the layout selector.

--- a/src/components/visual-dropdown/styles/editor.scss
+++ b/src/components/visual-dropdown/styles/editor.scss
@@ -41,6 +41,7 @@
 	& &__button.components-button.is-default {
 		align-items: center;
 		background: $white;
+		border: 1px solid theme(primary);
 		border-radius: 4px !important;
 		box-shadow: none;
 		display: flex;
@@ -53,6 +54,10 @@
 		padding: 0;
 		text-align: center;
 		width: 90px;
+
+		svg {
+			fill: theme(primary);
+		}
 
 		&:focus {
 			box-shadow: 0 0 0 4px $light-gray-200, 0 0 0 6px theme(toggle);

--- a/src/components/visual-dropdown/styles/editor.scss
+++ b/src/components/visual-dropdown/styles/editor.scss
@@ -32,7 +32,6 @@
 		padding: 4px;
 
 		&:focus {
-			box-shadow: 0 0 0 2px theme(primary);
 			outline: 2px solid transparent;
 			outline-offset: -2px;
 		}
@@ -41,7 +40,7 @@
 	& &__button.components-button.is-default {
 		align-items: center;
 		background: $white;
-		border: 1px solid theme(primary);
+		border: 1px solid;
 		border-radius: 4px !important;
 		box-shadow: none;
 		display: flex;
@@ -55,20 +54,9 @@
 		text-align: center;
 		width: 90px;
 
-		svg {
-			fill: theme(primary);
-		}
-
 		&:focus {
-			box-shadow: 0 0 0 4px $light-gray-200, 0 0 0 6px theme(toggle);
 			outline: 2px solid transparent;
 			outline-offset: -2px;
-		}
-
-		&:active:enabled {
-			background: $white;
-			border-color: rgba(25, 30, 35, 0.3);
-			box-shadow: 0 0 0 4px $light-gray-200, 0 0 0 6px theme(toggle);
 		}
 	}
 
@@ -78,13 +66,13 @@
 	}
 
 	&__back.components-icon-button {
-		background: $white;
-		border: 1px solid rgba(25, 30, 35, 0.2);
+		// background: $white;
+		// border: 1px solid rgba(25, 30, 35, 0.2);
 		margin-right: 4px;
 
 		&:hover {
-			box-shadow: 0 0 0 4px $dark-opacity-light-200 !important;
-			color: $dark-gray-900;
+			// box-shadow: 0 0 0 4px $dark-opacity-light-200 !important;
+			// color: $dark-gray-900;
 		}
 	}
 
@@ -106,8 +94,6 @@
 				&:focus,
 				&:active,
 				&.is-selected {
-					box-shadow: 0 0 0 2px theme(toggle);
-					color: $dark-gray-900;
 					outline: 2px solid transparent;
 					outline-offset: -2px;
 
@@ -125,14 +111,11 @@
 				width: 100%;
 
 				&:active:enabled {
-					background: $white;
-					border-color: none;
 					box-shadow: none !important;
 				}
 
 				&:focus {
 					box-shadow: none;
-					color: $dark-gray-900;
 					outline: 2px solid transparent;
 					outline-offset: -2px;
 				}
@@ -186,29 +169,13 @@
 	width: 63px;
 }
 
-.components-coblocks-visual-dropdown__popover {
-	.components-coblocks-visual-dropdown__button-wrapper:hover {
-		background: $light-gray-200;
-		color: $dark-gray-900;
-	}
-}
-
 .components-coblocks-visual-dropdown__popover:not(.is-mobile) {
 	.components-popover__content {
 		max-width: 340px;
 
 		.editor-block-styles__item-label {
-			color: $dark-gray-500;
 			margin-top: 4px;
 			text-align: center;
-		}
-
-		.components-coblocks-visual-dropdown__button-wrapper:hover {
-			background: $light-gray-200;
-
-			.editor-block-styles__item-label {
-				color: $dark-gray-900;
-			}
 		}
 	}
 }


### PR DESCRIPTION
I have two commits on this branch and am looking for design feedback.

Commit `2f15c96` accomplishes a similar look to WP 5.3. This route give the placeholder a typical look in the editor when viewing in 5.2.4. 

**WP 5.3**
https://prnt.sc/pmpsyk

**WP 5.2.4**
https://prnt.sc/pmpt84


Commit `9b8962b` is using `theme(primary)` to set SVG and border colors for button. This route accomplishes a similar look to WP 5.3  but effects 5.2.4 as well. 

**How it looks in 5.3 and 5.2.4**
https://prnt.sc/pmpsit
