### PR TITLE
Improve Shape Divider block stability through block validation testing

### DIFF
--- a/src/blocks/shape-divider/deprecated.js
+++ b/src/blocks/shape-divider/deprecated.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { getDividerFromStyle } from './utils';
+import metadata from './block.json';
 
 /**
  * WordPress dependencies
@@ -15,6 +16,9 @@ import { getColorClassName } from '@wordpress/block-editor';
 
 const deprecated = [
 	{
+		attributes: {
+			...metadata.attributes,
+		},
 		save( { attributes, className } ) {
 			const {
 				backgroundColor,

--- a/src/blocks/shape-divider/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/shape-divider/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/shape-divider should render 1`] = `
+"<!-- wp:coblocks/shape-divider -->
+<div class=\\"wp-block-coblocks-shape-divider alignfull\\" style=\\"color:#111\\" aria-hidden=\\"true\\"><div class=\\"wp-block-coblocks-shape-divider__svg-wrapper\\" style=\\"min-height:100px\\"><svg class=\\"divider--wavy\\" height=\\"100%\\" viewbox=\\"0 0 100 10\\" width=\\"100%\\" xmlns=\\"http://www.w3.org/2000/svg\\" preserveaspectratio=\\"none\\"><path d=\\"m42.19.65c2.26-.25 5.15.04 7.55.53 2.36.49 7.09 2.35 10.05 3.57 7.58 3.22 13.37 4.45 19.26 4.97 2.36.21 4.87.35 10.34-.25s10.62-2.56 10.62-2.56v-6.91h-100.01v3.03s7.2 3.26 15.84 3.05c3.92-.07 9.28-.67 13.4-2.24 2.12-.81 5.22-1.82 7.97-2.42 2.72-.63 3.95-.67 4.98-.77z\\" fillrule=\\"evenodd\\" transform=\\"matrix(1 0 0 -1 0 10)\\"></path></svg></div><div class=\\"wp-block-coblocks-shape-divider__alt-wrapper\\" style=\\"min-height:50px\\"></div></div>
+<!-- /wp:coblocks/shape-divider -->"
+`;

--- a/src/blocks/shape-divider/test/deprecated.spec.js
+++ b/src/blocks/shape-divider/test/deprecated.spec.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies.
+ */
+import * as helpers from '../../../../.dev/tests/jest/helpers';
+import { name, settings } from '../index';
+
+const variations = {
+	coblocks: [ undefined, {}, { id: undefined }, { id: 'testing' } ],
+	className: [ undefined, '', 'random classes' ],
+	align: [ '', 'wide', 'full', 'left', 'right', 'center' ],
+	height: [ undefined, 0, 100 ],
+	heightTablet: [ undefined, 0, 100 ],
+	heightMobile: [ undefined, 0, 100 ],
+	shapeHeight: [ 0, 100 ],
+	shapeHeightTablet: [ undefined, 0, 100 ],
+	backgroundHeight: [ 0, 100 ],
+	backgroundHeightTablet: [ undefined, 0, 100 ],
+	backgroundHeightMobile: [ undefined, 0, 100 ],
+	syncHeight: [ undefined, true, false ],
+	syncHeightAlt: [ undefined, true, false ],
+	verticalFlip: [ undefined, true, false ],
+	horizontalFlip: [ undefined, true, false ],
+	color: [ undefined, 'primary' ],
+	customColor: [ '', '#123456' ],
+	backgroundColor: [ undefined, 'primary' ],
+	customBackgroundColor: [ undefined, '#123456' ],
+	justAdded: [ undefined, true, false ],
+	noBottomMargin: [ true, false ],
+	noTopMargin: [ true, false ],
+};
+
+helpers.testDeprecatedBlockVariations( name, settings, variations );

--- a/src/blocks/shape-divider/test/save.spec.js
+++ b/src/blocks/shape-divider/test/save.spec.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render', () => {
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Provides deprecation tests for the Shape Divider block as part of #874.

```
Test Suites: 2 passed, 2 total
Tests:       86 passed, 86 total
Snapshots:   1 passed, 1 total
Time:        2.879s, estimated 3s
```