### PR TITLE
Bump WordPress Core support to 5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "CoBlocks",
 	"description": "CoBlocks is a suite of professional page building blocks for the WordPress Gutenberg block editor.",
 	"version": "1.16.1",
-	"tested_up_to": "5.2.2",
+	"tested_up_to": "5.3",
 	"author": "GoDaddy",
 	"license": "GPL-2.0",
 	"repository": "godaddy/coblocks",


### PR DESCRIPTION
Looks like grunt references this version for the find/replace actions. This change is part of the 5.3 compatibility testing. 