### PR TITLE
Fix code display styles of the Gist block with the TwentyTwenty theme

### DIFF
--- a/src/blocks/gist/styles/style.scss
+++ b/src/blocks/gist/styles/style.scss
@@ -57,4 +57,8 @@
 		margin-top: 0.5em;
 		text-align: center;
 	}
+
+	table {
+		table-layout: auto;
+	}
 }


### PR DESCRIPTION
Closes #1064.

We can accomplish this by setting the `table-layout` explicit auto. This allows the gist table to render correctly in TwentyTwenty, TwentyNineteen, TwentyEighteen, SoHo, and Barebones theme (underscores). 
