### PR TITLE
Fix Collage Block layouts for the TwentyTwenty theme

### DIFF
--- a/src/blocks/gallery-collage/styles/editor.scss
+++ b/src/blocks/gallery-collage/styles/editor.scss
@@ -26,6 +26,8 @@
 .wp-block[data-type="coblocks/gallery-collage"] {
 	ul {
 		list-style-type: none;
+		margin: 0;
+		padding: 0;
 	}
 
 	&[data-align="full"] .wp-block-coblocks-gallery-collage ul {

--- a/src/blocks/gallery-collage/styles/style.scss
+++ b/src/blocks/gallery-collage/styles/style.scss
@@ -12,10 +12,10 @@
 		list-style-type: none;
 		margin: 0;
 		padding: 0;
+	}
 
-		li {
-			margin: inherit;
-		}
+	li {
+		margin: 0;
 	}
 
 	&__item {

--- a/src/blocks/gallery-collage/styles/style.scss
+++ b/src/blocks/gallery-collage/styles/style.scss
@@ -6,16 +6,18 @@
 		}
 	}
 
+	&:not(.is-style-layered) {
+		ul li {
+			margin: 0 !important;
+		}
+	}
+
 	ul {
 		display: flex;
 		flex-wrap: wrap;
 		list-style-type: none;
 		margin: 0;
 		padding: 0;
-	}
-
-	li {
-		margin: 0;
 	}
 
 	&__item {

--- a/src/blocks/gallery-collage/styles/style.scss
+++ b/src/blocks/gallery-collage/styles/style.scss
@@ -12,6 +12,10 @@
 		list-style-type: none;
 		margin: 0;
 		padding: 0;
+
+		li {
+			margin: inherit;
+		}
 	}
 
 	&__item {

--- a/src/blocks/gallery-collage/styles/style.scss
+++ b/src/blocks/gallery-collage/styles/style.scss
@@ -7,8 +7,8 @@
 	}
 
 	&:not(.is-style-layered) {
-		ul li {
-			margin: 0 !important;
+		li {
+			margin: 0;
 		}
 	}
 
@@ -38,7 +38,7 @@
 
 		&:nth-child(2) {
 			align-self: flex-end;
-			margin-right: auto;
+			margin-right: auto !important;
 			width: 25%;
 
 			figure,
@@ -49,7 +49,7 @@
 
 		&:nth-child(3) {
 			align-self: flex-start;
-			margin-left: auto;
+			margin-left: auto !important;
 			width: 25%;
 
 			figure,
@@ -105,7 +105,7 @@
 		align-self: flex-start;
 
 		&:nth-child(1) {
-			margin-left: calc(150 / 890 * 100%);
+			margin-left: calc(150 / 890 * 100%) !important;
 			width: calc(358 / 890 * 100%);
 			z-index: 4;
 
@@ -116,8 +116,8 @@
 		}
 
 		&:nth-child(2) {
-			margin-left: calc(175 / 850 * 100%);
-			margin-top: calc(117 / 990 * 100%);
+			margin-left: calc(175 / 850 * 100%) !important;
+			margin-top: calc(117 / 990 * 100%) !important;
 			width: calc(198 / 890 * 100%);
 			z-index: 2;
 
@@ -128,8 +128,8 @@
 		}
 
 		&:nth-child(3) {
-			margin-left: calc(328 / 890 * 100%);
-			margin-top: calc(249 / 890 * 100% * -1);
+			margin-left: calc(328 / 890 * 100%) !important;
+			margin-top: calc(249 / 890 * 100% * -1) !important;
 			width: calc(492 / 890 * 100%);
 			z-index: 3;
 
@@ -140,7 +140,7 @@
 		}
 
 		&:nth-child(4) {
-			margin-top: calc(189 / 890 * 100% * -1);
+			margin-top: calc(189 / 890 * 100% * -1) !important;
 			width: calc(492 / 890 * 100%);
 			z-index: 1;
 


### PR DESCRIPTION
Closes #1062.

Pull request add `margin: inherit` to `li` elements scoped for collage block. This change allows correct display in TwentyTwenty. This change still looks correct in TwentyNineteen, TwentySeventeen and Barebones theme (underscores). 

