### PR TITLE
ISBAT use Dynamic HR block in TwentyTwenty theme

### DIFF
--- a/src/blocks/dynamic-separator/styles/style.scss
+++ b/src/blocks/dynamic-separator/styles/style.scss
@@ -22,6 +22,17 @@
 		text-align: center;
 		top: calc(50% - 18px);
 	}
+	
+	&::after {
+		background: none;
+		content: inherit;
+		display: inherit;
+		height: 100%;
+		position: inherit;
+		top: inherit;
+		transform: none;
+		width: 100%;
+	}
 
 	&.is-style-line::before,
 	&.is-style-fullwidth::before {


### PR DESCRIPTION
Closes #1063.

Three rules are causing unexpected behavior with the Dynamic HR block. These are the specific changes from TwentyTwenty that cause the behavior.

https://github.com/WordPress/twentytwenty/blob/f257dfff755c415dadc56a2c70a412421f39aad7/style.css#L427

https://github.com/WordPress/twentytwenty/blob/f257dfff755c415dadc56a2c70a412421f39aad7/style.css#L444

https://github.com/WordPress/twentytwenty/blob/f257dfff755c415dadc56a2c70a412421f39aad7/style.css#L439

When these lines are commented out, the block renders correctly. Looking for advice on how to properly override these styles. I am finding this is not a trivial step.
