### PR TITLE
Improve Collage Gallery block stability through block validation testing

### DIFF
--- a/src/blocks/gallery-collage/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/gallery-collage/test/__snapshots__/save.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`coblocks/gallery-collage should render with images 1`] = `
+"<!-- wp:coblocks/gallery-collage -->
+<div class=\\"wp-block-coblocks-gallery-collage has-caption-style-dark\\"><ul><li class=\\"wp-block-coblocks-gallery-collage__item pb-2 sm:pb-2 lg:pb-2\\"><figure class=\\"wp-block-coblocks-gallery-collage__figure\\"><img src=\\"https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg\\" data-id=\\"1\\" class=\\"wp-image-1\\"/></figure></li></ul></div>
+<!-- /wp:coblocks/gallery-collage -->"
+`;

--- a/src/blocks/gallery-collage/test/save.spec.js
+++ b/src/blocks/gallery-collage/test/save.spec.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { registerBlockType, createBlock, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { name, settings } from '../index';
+
+// Make variables accessible for all tests.
+let block;
+let serializedBlock;
+
+describe( name, () => {
+	beforeAll( () => {
+		// Register the block.
+		registerBlockType( name, { category: 'common', ...settings } );
+	} );
+
+	beforeEach( () => {
+		// Create the block with the minimum attributes.
+		block = createBlock( name );
+
+		// Reset the reused variables.
+		serializedBlock = '';
+	} );
+
+	it( 'should render with images', () => {
+		block.attributes.images = [
+			{ url: 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg', id: 1 },
+		];
+
+		serializedBlock = serialize( block );
+
+		expect( serializedBlock ).toBeDefined();
+		expect( serializedBlock ).toContain( 'https://wordpress.com/wp-content/uploads/1234/56/image-1.jpg' );
+		expect( serializedBlock ).toContain( 'data-id="1"' );
+		expect( serializedBlock ).toContain( 'wp-image-1' );
+		expect( serializedBlock ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This block did not have deprecations. Instead I added a basic test on the save function to detect when we need to write a deprecation. Related to #1031.

```
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        2.601s, estimated 3s
```