### PR TITLE
Add keepPlaceholderOnFocus prop to Author block text placeholders

### DIFF
--- a/src/blocks/author/edit.js
+++ b/src/blocks/author/edit.js
@@ -130,6 +130,7 @@ class AuthorEdit extends Component {
 							onChange={ ( nextName ) => {
 								setAttributes( { name: nextName } );
 							} }
+							keepPlaceholderOnFocus={ true }
 						/>
 						<RichText
 							identifier="biography"
@@ -144,6 +145,7 @@ class AuthorEdit extends Component {
 							onChange={ ( nextBio ) => {
 								setAttributes( { biography: nextBio } );
 							} }
+							keepPlaceholderOnFocus={ true }
 						/>
 						<InnerBlocks
 							template={ [ [ 'core/button', { placeholder: _x( 'Author link…', 'content placeholder', 'coblocks' ) } ] ] }


### PR DESCRIPTION
Closes #1049 

![AuthorBlockTextPlaceholders](https://user-images.githubusercontent.com/30462574/67518278-4e701000-f659-11e9-95c0-6517272c178d.gif)


Unable to pass `keepPlaceholderOnFocus` prop to `core/button` so the button does not share the behavior. How do we feel about possibly converting to a RichText component instead? Other ideas?
