### PR TITLE
Remove block preview example for Shape Divider block

### DIFF
--- a/src/blocks/shape-divider/index.js
+++ b/src/blocks/shape-divider/index.js
@@ -44,11 +44,6 @@ const settings = {
 		{ name: 'triangle', label: _x( 'Triangle', 'block style', 'coblocks' ) },
 		{ name: 'pointed', label: _x( 'Pointed', 'block style', 'coblocks' ) },
 	],
-	example: {
-		attributes: {
-			height: 100,
-		},
-	},
 	attributes,
 	transforms,
 	edit,


### PR DESCRIPTION
Closes #1043 

Removes the example set for Shape Divider block. 

![ShapeDividerExamplesMatching](https://user-images.githubusercontent.com/30462574/67524088-e6bfc200-f664-11e9-8cad-0c5d5d180823.gif)
