### PR TITLE
Add Twenty Twenty as an auto-generated theme classes

### DIFF
--- a/.dev/tests/phpunit/includes/test-coblocks-body-classes.php
+++ b/.dev/tests/phpunit/includes/test-coblocks-body-classes.php
@@ -66,6 +66,7 @@ class CoBlocks_Body_Classes_Tests extends WP_UnitTestCase {
 	public function test_themes() {
 
 		$expected = [
+			'twentytwenty',
 			'twentynineteen',
 			'twentyseventeen',
 			'twentysixteen',
@@ -86,6 +87,7 @@ class CoBlocks_Body_Classes_Tests extends WP_UnitTestCase {
 	public function test_filtered_themes() {
 
 		$expected = [
+			'twentytwenty',
 			'twentynineteen',
 			'twentyseventeen',
 			'twentysixteen',

--- a/includes/class-coblocks-body-classes.php
+++ b/includes/class-coblocks-body-classes.php
@@ -44,6 +44,7 @@ class CoBlocks_Body_Classes {
 	 */
 	public function themes() {
 		$themes = array(
+			'twentytwenty',
 			'twentynineteen',
 			'twentyseventeen',
 			'twentysixteen',


### PR DESCRIPTION
This PR adds a the Twenty Twenty default theme to the list of theme names that get appended to the body class if active. This way we can add theme-specific support for default themes. 