### PR TITLE
Fix Dynamic HR block display on TwentyTwenty

### DIFF
--- a/src/blocks/dynamic-separator/deprecated.js
+++ b/src/blocks/dynamic-separator/deprecated.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { attributes } from './block.json';
+
+/**
+ * WordPress dependencies
+ */
+import { getColorClassName } from '@wordpress/block-editor';
+
+const deprecatedClassBlockSeparator = ( { attributes } ) => {
+	const {
+		color,
+		customColor,
+		height,
+		className,
+	} = attributes;
+
+	const colorClass = getColorClassName( 'color', color );
+
+	const classes = classnames(
+		className, {
+			'has-text-color': color || customColor,
+			[ colorClass ]: colorClass,
+		} );
+
+	const styles = {
+		color: colorClass ? undefined : customColor,
+		height: height ? height + 'px' : undefined,
+	};
+
+	return (
+		<hr className={ classes } style={ styles }></hr>
+	);
+};
+
+const deprecated = [ {
+	attributes,
+	save: deprecatedClassBlockSeparator,
+} ];
+
+export default deprecated;

--- a/src/blocks/dynamic-separator/edit.js
+++ b/src/blocks/dynamic-separator/edit.js
@@ -35,7 +35,7 @@ class DynamicSeparatorEdit extends Component {
 			<Fragment>
 				{ isSelected && <Inspector { ...this.props } /> }
 				<ResizableBox
-					className={ classnames( className, {
+					className={ classnames( className, 'wp-block-separator', {
 						'is-selected': isSelected,
 						'has-text-color': color.color,
 						[ color.class ]: color.class,
@@ -47,6 +47,7 @@ class DynamicSeparatorEdit extends Component {
 						height,
 					} }
 					minHeight="20"
+					minWidth="100%"
 					enable={ {
 						top: false,
 						right: false,

--- a/src/blocks/dynamic-separator/edit.js
+++ b/src/blocks/dynamic-separator/edit.js
@@ -31,15 +31,18 @@ class DynamicSeparatorEdit extends Component {
 
 		const { height } = attributes;
 
+		const hrClasses = classnames( className, 'wp-block-separator', {
+			'is-selected': isSelected,
+			'has-text-color': color.color,
+			[ color.class ]: color.class,
+			'is-style-dots': ! className.includes( 'is-style-line' ) && ! className.includes( 'is-style-fullwidth' ) && ! className.includes( 'is-style-dots' ),
+		} );
+
 		return (
 			<Fragment>
 				{ isSelected && <Inspector { ...this.props } /> }
 				<ResizableBox
-					className={ classnames( className, 'wp-block-separator', {
-						'is-selected': isSelected,
-						'has-text-color': color.color,
-						[ color.class ]: color.class,
-					} ) }
+					className={ hrClasses }
 					style={ {
 						color: color.color,
 					} }

--- a/src/blocks/dynamic-separator/index.js
+++ b/src/blocks/dynamic-separator/index.js
@@ -12,6 +12,7 @@ import icon from './icon';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import deprecated from './deprecated';
 
 /**
  * WordPress dependencies
@@ -39,6 +40,7 @@ const settings = {
 		},
 	},
 	attributes,
+	deprecated,
 	transforms,
 	edit,
 	save,

--- a/src/blocks/dynamic-separator/save.js
+++ b/src/blocks/dynamic-separator/save.js
@@ -18,7 +18,8 @@ const save = ( { attributes, className } ) => {
 	const colorClass = getColorClassName( 'color', color );
 
 	const classes = classnames(
-		className, {
+		className,
+		'wp-block-separator', {
 			'has-text-color': color || customColor,
 			[ colorClass ]: colorClass,
 		} );

--- a/src/blocks/dynamic-separator/save.js
+++ b/src/blocks/dynamic-separator/save.js
@@ -23,20 +23,17 @@ const save = ( { attributes } ) => {
 		height: height ? height + 'px' : undefined,
 	};
 
-	let hrClasses = classnames(
-		className,
-		'wp-block-separator', {
-			'has-text-color': color || customColor,
-			[ colorClass ]: colorClass,
-		} );
+	let divClasses = classnames(	className, 'wp-block-separator',
+		{ 'has-text-color': color || customColor,
+			[ colorClass ]: colorClass } );
 
 	// Set class for default style
-	hrClasses = classnames( hrClasses, {
-		'is-style-dots': ! hrClasses.includes( 'is-style-line' ) && ! hrClasses.includes( 'is-style-fullwidth' ) && ! hrClasses.includes( 'is-style-dots' ),
+	divClasses = classnames( divClasses, {
+		'is-style-dots': ! divClasses.includes( 'is-style-line' ) && ! divClasses.includes( 'is-style-fullwidth' ) && ! divClasses.includes( 'is-style-dots' ),
 	} );
 
 	return (
-		<hr className={ hrClasses } style={ styles }></hr>
+		<div className={ divClasses } style={ styles } />
 	);
 };
 

--- a/src/blocks/dynamic-separator/save.js
+++ b/src/blocks/dynamic-separator/save.js
@@ -8,29 +8,35 @@ import classnames from 'classnames';
  */
 import { getColorClassName } from '@wordpress/block-editor';
 
-const save = ( { attributes, className } ) => {
+const save = ( { attributes } ) => {
 	const {
 		color,
 		customColor,
 		height,
+		className,
 	} = attributes;
 
 	const colorClass = getColorClassName( 'color', color );
-
-	const classes = classnames(
-		className,
-		'wp-block-separator', {
-			'has-text-color': color || customColor,
-			[ colorClass ]: colorClass,
-		} );
 
 	const styles = {
 		color: colorClass ? undefined : customColor,
 		height: height ? height + 'px' : undefined,
 	};
 
+	let hrClasses = classnames(
+		className,
+		'wp-block-separator', {
+			'has-text-color': color || customColor,
+			[ colorClass ]: colorClass,
+		} );
+
+	// Set class for default style
+	hrClasses = classnames( hrClasses, {
+		'is-style-dots': ! hrClasses.includes( 'is-style-line' ) && ! hrClasses.includes( 'is-style-fullwidth' ) && ! hrClasses.includes( 'is-style-dots' ),
+	} );
+
 	return (
-		<hr className={ classes } style={ styles }></hr>
+		<hr className={ hrClasses } style={ styles }></hr>
 	);
 };
 

--- a/src/blocks/dynamic-separator/styles/editor.scss
+++ b/src/blocks/dynamic-separator/styles/editor.scss
@@ -1,47 +1,16 @@
-.editor-block-list__block[data-type="coblocks/dynamic-separator"] {
-	.wp-block-coblocks-dynamic-separator {
-		&::before {
-			transition: width 300ms cubic-bezier(0.645, 0.045, 0.355, 1), max-width 300ms cubic-bezier(0.645, 0.045, 0.355, 1);
-		}
-
-		&.is-selected {
-			background: $light-gray-200;
-		}
-	}
+.wp-block-coblocks-dynamic-separator.is-selected {
+	background: $light-gray-200;
 }
 
-.editor-block-styles__item-preview {
-	.wp-block-coblocks-dynamic-separator {
-		height: 60px !important;
-	}
+// .is-twentytwenty {
+.wp-block-coblocks-dynamic-separator {
+	color: #6d6d6d;
 
-	.block-list-appender {
-		display: none !important;
-	}
-
-	.wp-block-coblocks-dynamic-separator.is-style-line::before {
-		width: 4vw;
+	&.is-style-dots::before {
+		font-size: 32px;
+		font-weight: 700;
+		letter-spacing: 1em;
+		padding-left: 1em;
 	}
 }
-
-.block-editor-block-preview {
-	.block-list-appender {
-		display: none !important;
-	}
-
-	.wp-block-coblocks-dynamic-separator {
-		height: 90px !important;
-
-		&::before {
-			top: 56% !important;
-		}
-
-		&.is-style-line::before {
-			top: 71% !important;
-		}
-
-		&.is-style-fullwidth::before {
-			top: 71% !important;
-		}
-	}
-}
+// }

--- a/src/blocks/dynamic-separator/styles/editor.scss
+++ b/src/blocks/dynamic-separator/styles/editor.scss
@@ -2,15 +2,15 @@
 	background: $light-gray-200;
 }
 
-// .is-twentytwenty {
-.wp-block-coblocks-dynamic-separator {
-	color: #6d6d6d;
+.is-twentytwenty {
+	.wp-block-coblocks-dynamic-separator {
+		color: #6d6d6d;
 
-	&.is-style-dots::before {
-		font-size: 32px;
-		font-weight: 700;
-		letter-spacing: 1em;
-		padding-left: 1em;
+		&.is-style-dots::before {
+			font-size: 32px;
+			font-weight: 700;
+			letter-spacing: 1em;
+			padding-left: 1em;
+		}
 	}
 }
-// }

--- a/src/blocks/dynamic-separator/styles/style.scss
+++ b/src/blocks/dynamic-separator/styles/style.scss
@@ -1,38 +1,35 @@
-.wp-block-coblocks-dynamic-separator {
+.wp-block-coblocks-dynamic-separator.wp-block-separator {
 	background: none !important;
-	border: 0;
+	border: 0 !important;
 	max-width: 100% !important;
-	opacity: 1;
-	padding: 0;
 	position: relative;
 	width: 100%;
 
 	&::before {
-		content: "...";
-		display: inline-block;
-		font-size: 22px;
-		font-weight: 400;
 		left: 0;
-		letter-spacing: 0.95em;
-		line-height: 1;
-		margin-left: 21px;
-		margin-right: auto;
-		position: absolute;
+		position: absolute !important;
 		right: 0;
-		text-align: center;
 		top: calc(50% - 18px);
 	}
+}
 
+.wp-block-coblocks-dynamic-separator {
 	&.is-style-line::before,
 	&.is-style-fullwidth::before {
 		background: currentColor;
 		content: "";
 		display: block;
 		height: 1px;
-		margin-left: auto;
+		left: 50%;
 		max-width: 120px;
 		top: 50%;
+		transform: translateX(-50%);
 		width: 15vw;
+	}
+
+	&.is-style-line::after,
+	&.is-style-fullwidth::after {
+		display: none;
 	}
 
 	&.is-style-fullwidth::before {
@@ -40,16 +37,14 @@
 		width: 100%;
 	}
 
-	&:not(.has-text-color) {
-		&::before {
-			color: rgb(41, 41, 41);
-		}
+	&:not(.has-text-color)::before {
+		color: currentColor;
 	}
 
 	&.is-style-line:not(.has-text-color),
 	&.is-style-fullwidth:not(.has-text-color) {
 		&::before {
-			background: rgba(0, 0, 0, 0.15);
+			background: currentColor;
 		}
 	}
 }

--- a/src/blocks/dynamic-separator/styles/style.scss
+++ b/src/blocks/dynamic-separator/styles/style.scss
@@ -1,5 +1,10 @@
+.is-twentytwenty {
+	.wp-block-coblocks-dynamic-separator {
+		background: none !important;
+	}
+}
+
 .wp-block-coblocks-dynamic-separator.wp-block-separator {
-	background: none !important;
 	border: 0 !important;
 	max-width: 100% !important;
 	position: relative;
@@ -45,13 +50,6 @@
 	&.is-style-fullwidth:not(.has-text-color) {
 		&::before {
 			background: currentColor;
-		}
-	}
-
-	.is-twentytwenty {
-		hr,
-		&.wp-block-coblocks-dynamic-separator {
-			background: none !important;
 		}
 	}
 }

--- a/src/blocks/dynamic-separator/styles/style.scss
+++ b/src/blocks/dynamic-separator/styles/style.scss
@@ -47,11 +47,12 @@
 			background: currentColor;
 		}
 	}
-}
 
-.is-twentytwenty {
-	hr,
-	&.wp-block-coblocks-dynamic-separator {
-		background: none !important;
+	.is-twentytwenty {
+		hr,
+		&.wp-block-coblocks-dynamic-separator {
+			background: none !important;
+		}
 	}
 }
+

--- a/src/blocks/dynamic-separator/styles/style.scss
+++ b/src/blocks/dynamic-separator/styles/style.scss
@@ -9,6 +9,7 @@
 	max-width: 100% !important;
 	position: relative;
 	width: 100%;
+	margin: 4rem 0;
 
 	&::before {
 		left: 0;
@@ -18,7 +19,16 @@
 	}
 }
 
+hr.wp-block-coblocks-dynamic-separator {
+	padding-left: 50%;
+}
+
 .wp-block-coblocks-dynamic-separator {
+	background: none !important;
+    border: 0;
+    max-width: 100% !important;
+	width: 100% !important;
+
 	&.is-style-line::before,
 	&.is-style-fullwidth::before {
 		background: currentColor;

--- a/src/blocks/dynamic-separator/styles/style.scss
+++ b/src/blocks/dynamic-separator/styles/style.scss
@@ -48,3 +48,10 @@
 		}
 	}
 }
+
+.is-twentytwenty {
+	hr,
+	&.wp-block-coblocks-dynamic-separator {
+		background: none !important;
+	}
+}

--- a/src/blocks/dynamic-separator/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/dynamic-separator/test/__snapshots__/save.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`coblocks/dynamic-separator should render 1`] = `
 "<!-- wp:coblocks/dynamic-separator -->
-<hr class=\\"wp-block-coblocks-dynamic-separator\\" style=\\"height:50px\\"/>
+<hr class=\\"wp-block-coblocks-dynamic-separator wp-block-separator\\" style=\\"height:50px\\"/>
 <!-- /wp:coblocks/dynamic-separator -->"
 `;

--- a/src/blocks/dynamic-separator/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/dynamic-separator/test/__snapshots__/save.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`coblocks/dynamic-separator should render 1`] = `
 "<!-- wp:coblocks/dynamic-separator -->
-<hr class=\\"wp-block-coblocks-dynamic-separator wp-block-separator is-style-dots\\" style=\\"height:50px\\"/>
+<div class=\\"wp-block-coblocks-dynamic-separator wp-block-separator is-style-dots\\" style=\\"height:50px\\"></div>
 <!-- /wp:coblocks/dynamic-separator -->"
 `;

--- a/src/blocks/dynamic-separator/test/__snapshots__/save.spec.js.snap
+++ b/src/blocks/dynamic-separator/test/__snapshots__/save.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`coblocks/dynamic-separator should render 1`] = `
 "<!-- wp:coblocks/dynamic-separator -->
-<hr class=\\"wp-block-coblocks-dynamic-separator wp-block-separator\\" style=\\"height:50px\\"/>
+<hr class=\\"wp-block-coblocks-dynamic-separator wp-block-separator is-style-dots\\" style=\\"height:50px\\"/>
 <!-- /wp:coblocks/dynamic-separator -->"
 `;


### PR DESCRIPTION
This PR is a test to see if we can inherit the core Separator's styling, so we wouldn't need to continue supporting individual styles. It's essentially a Separator + Spacer block combined. 

If we go this route we'll need to add a proper deprecation. 

A possible alternative to #1068.