### PR TITLE
Use BlockIcon component for Placeholder Icons

### DIFF
--- a/src/blocks/gif/edit.js
+++ b/src/blocks/gif/edit.js
@@ -14,7 +14,7 @@ import { compose } from '@wordpress/compose';
 import { Placeholder, Spinner, ResizableBox } from '@wordpress/components';
 import { withViewportMatch } from '@wordpress/viewport';
 import { withSelect } from '@wordpress/data';
-import { RichText } from '@wordpress/block-editor';
+import { BlockIcon, RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -278,7 +278,7 @@ class Edit extends Component {
 			<Fragment>
 				<Placeholder
 					key="placeholder"
-					icon={ icons.gif }
+					icon={ <BlockIcon icon={ icons.gif } /> }
 					label="Gif"
 					instructions={ __( 'Search for that perfect gif on Giphy', 'coblocks' ) }
 					className={ className }>

--- a/src/blocks/gif/edit.js
+++ b/src/blocks/gif/edit.js
@@ -21,6 +21,7 @@ import { BlockIcon, RichText } from '@wordpress/block-editor';
  */
 import Controls from './controls';
 import icons from './../../utils/icons';
+import icon from './icon';
 import Inspector from './inspector';
 import Size from './size';
 
@@ -278,7 +279,7 @@ class Edit extends Component {
 			<Fragment>
 				<Placeholder
 					key="placeholder"
-					icon={ <BlockIcon icon={ icons.gif } /> }
+					icon={ <BlockIcon icon={ icon } /> }
 					label="Gif"
 					instructions={ __( 'Search for that perfect gif on Giphy', 'coblocks' ) }
 					className={ className }>

--- a/src/blocks/gist/edit.js
+++ b/src/blocks/gist/edit.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import Controls from './controls';
 import Inspector from './inspector';
-import icons from './../../utils/icons';
+import icon from './icon';
 import Gist from './gist';
 
 /**
@@ -17,7 +17,7 @@ import Gist from './gist';
 import { __ } from '@wordpress/i18n';
 import { compose, withState } from '@wordpress/compose';
 import { Component, Fragment } from '@wordpress/element';
-import { PlainText, RichText } from '@wordpress/block-editor';
+import { PlainText, RichText, BlockIcon } from '@wordpress/block-editor';
 import { withNotices } from '@wordpress/components';
 
 /**
@@ -120,7 +120,7 @@ class Edit extends Component {
 						>
 
 							<label>
-								{ icons.github }
+								<BlockIcon icon={ icon } />
 								{ __( 'Gist URL', 'coblocks' ) }
 							</label>
 							<PlainText

--- a/src/blocks/gist/gist.js
+++ b/src/blocks/gist/gist.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import icons from './../../utils/icons';
+import icon from './icon';
 
 /**
  * WordPress dependencies
@@ -134,7 +134,7 @@ export default class Gist extends Component {
 			return (
 				<Placeholder
 					key="placeholder"
-					icon={ <BlockIcon icon={ icons.github } /> }
+					icon={ <BlockIcon icon={ icon } /> }
 					label={ __( 'Loading Gist', 'coblocks' ) }
 				>
 					<Spinner />

--- a/src/blocks/gist/gist.js
+++ b/src/blocks/gist/gist.js
@@ -13,6 +13,7 @@ import icons from './../../utils/icons';
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { BlockIcon } from '@wordpress/block-editor';
 import { Placeholder, Spinner } from '@wordpress/components';
 
 // -- MAIN --
@@ -133,7 +134,7 @@ export default class Gist extends Component {
 			return (
 				<Placeholder
 					key="placeholder"
-					icon={ icons.github }
+					icon={ <BlockIcon icon={ icons.github } /> }
 					label={ __( 'Loading Gist', 'coblocks' ) }
 				>
 					<Spinner />

--- a/src/blocks/gist/styles/editor.scss
+++ b/src/blocks/gist/styles/editor.scss
@@ -4,6 +4,12 @@
 		flex-direction: row;
 	}
 
+	> label {
+		svg {
+			margin-right: 1ch;
+		}
+	}
+
 	.block-editor-plain-text {
 		margin-left: 10px;
 		padding: 8px;

--- a/src/blocks/row/edit.js
+++ b/src/blocks/row/edit.js
@@ -20,7 +20,7 @@ import { BackgroundClasses, BackgroundDropZone, BackgroundVideo } from '../../co
 import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { InnerBlocks } from '@wordpress/block-editor';
+import { BlockIcon, InnerBlocks } from '@wordpress/block-editor';
 import { ButtonGroup, Button, IconButton, Tooltip, Placeholder, Spinner } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
 
@@ -198,7 +198,7 @@ class Edit extends Component {
 					) }
 					<Placeholder
 						key="placeholder"
-						icon={ columns ? rowIcons.layout : rowIcons.row }
+						icon={ <BlockIcon icon={ columns ? rowIcons.layout : rowIcons.row } /> }
 						label={ columns ? __( 'Row Layout', 'coblocks' ) : __( 'Row', 'coblocks' ) }
 						instructions={ columns ?
 							/* translators: %s: 'one' 'two' 'three' and 'four' */


### PR DESCRIPTION
Closes #1045 
This request corrects the icon used for Gif and Gist blocks.

**Before:**
![image](https://user-images.githubusercontent.com/30462574/67897335-6e9d4480-fb1b-11e9-8a47-6a702cb59bed.png)

**After:**
![image](https://user-images.githubusercontent.com/30462574/67897390-7fe65100-fb1b-11e9-8648-0c20b2eaace3.png)
