### PR TITLE
Clean up Gist block toolbar

### DIFF
--- a/src/blocks/gist/controls.js
+++ b/src/blocks/gist/controls.js
@@ -28,7 +28,7 @@ class Controls extends Component {
 						'Gist'
 					),
 				onClick: () => setState( { preview: ! preview } ),
-				isActive: preview,
+				isActive: ! preview,
 			},
 		];
 

--- a/src/blocks/gist/controls.js
+++ b/src/blocks/gist/controls.js
@@ -1,82 +1,41 @@
 /**
- * Internal dependencies
- */
-import icons from './../../utils/icons';
-
-/**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
-import { Toolbar, IconButton } from '@wordpress/components';
+import { Toolbar } from '@wordpress/components';
 
 class Controls extends Component {
 	render() {
 		const {
-			className,
-			attributes,
 			preview,
-			setAttributes,
 			setState,
 		} = this.props;
 
-		const { file, meta } = attributes;
-
-		const customControls = [
+		const editControl = [
 			{
-				icon: 'info',
-				title: __( 'Display meta', 'coblocks' ),
-				onClick: () => setAttributes( { meta: ! meta } ),
-				isActive: meta === true,
+				icon: 'edit',
+				title: preview ?
+					sprintf(
+						/* translators: %s: "Gist", the name of a code sharing platform. */
+						__( 'Return to %s', 'coblocks' ),
+						'Gist'
+					) :
+					sprintf(
+						/* translators: %s: "Gist", the name of a code sharing platform. */
+						__( 'Edit %s URL', 'coblocks' ),
+						'Gist'
+					),
+				onClick: () => setState( { preview: ! preview } ),
+				isActive: preview,
 			},
 		];
 
 		return (
-			<Fragment>
-				<BlockControls>
-					<Toolbar>
-						{ preview ? (
-							<IconButton
-								className="components-icon-button components-toolbar__control"
-								label={ __( 'Edit Gist', 'coblocks' ) }
-								onClick={ () => setState( { preview: false } ) }
-								icon="edit"
-							/>
-						) : (
-							<IconButton
-								className="components-icon-button components-toolbar__control"
-								label={ __( 'View Gist', 'coblocks' ) }
-								onClick={ () => setState( { preview: true } ) }
-								icon="welcome-view-site"
-							/>
-						) }
-					</Toolbar>
-
-					{ preview ? (
-						<Toolbar controls={ customControls } />
-					) : (
-						<Toolbar>
-							<label
-								aria-label={ __( 'GitHub File', 'coblocks' ) }
-								className={ `${ className }__file-label` }
-								htmlFor={ `${ className }__file` }
-							>
-								{ icons.file }
-							</label>
-							<input
-								aria-label={ __( 'GitHub File', 'coblocks' ) }
-								className={ `${ className }__file` }
-								id={ `${ className }__file` }
-								onChange={ event => setAttributes( { file: event.target.value } ) }
-								placeholder={ __( 'File', 'coblocks' ) }
-								type="text"
-								value={ file }
-							/>
-						</Toolbar>
-					) }
-				</BlockControls>
-			</Fragment>
+			<BlockControls>
+				<Toolbar controls={ editControl } />
+			</BlockControls>
 		);
 	}
 }


### PR DESCRIPTION
This PR removes the file text input and the meta option icon from the Gist block, maintaining those extraneous only within the block's Settings Sidebar. 

<img width="1669" alt="Screen Shot 2019-11-04 at 9 34 49 AM" src="https://user-images.githubusercontent.com/1813435/68133621-5dbb4d00-fee6-11e9-8f59-a7c7924053a7.png">
