### PR TITLE
Enable certain core blocks in the form block

### DIFF
--- a/src/blocks/form/edit.js
+++ b/src/blocks/form/edit.js
@@ -21,16 +21,12 @@ import { Button, PanelBody, TextControl, ExternalLink } from '@wordpress/compone
 import { InspectorControls, InnerBlocks } from '@wordpress/block-editor';
 import { applyFilters } from '@wordpress/hooks';
 
-/**
- * Block constants
- */
+// Note: Child form blocks are automatically allowed
 const ALLOWED_BLOCKS = [
-	'coblocks/field-date',
-	'coblocks/field-phone',
-	'coblocks/field-radio',
-	'coblocks/field-name',
-	'coblocks/field-email',
-	'coblocks/field-textarea',
+	'core/heading',
+	'core/paragraph',
+	'core/separator',
+	'core/spacer',
 ];
 
 /**


### PR DESCRIPTION
Enable the following core blocks so they can be used within the form block:
- [x] core/heading
- [x] core/paragraph
- [x] core/separator
- [x] core/spacer

Note: All child blocks with the registered parent as `coblocks/form` will automatically be enabled in the `ALLOWED_BLOCKS` array, thus why I've removed the form child blocks from it.