### PR TITLE
Adjust Accordion block default background color for improved theme compatibility

### DIFF
--- a/src/blocks/accordion/accordion-item/styles/editor.scss
+++ b/src/blocks/accordion/accordion-item/styles/editor.scss
@@ -30,6 +30,7 @@
 	.wp-block:first-child [data-block] {
 		margin-top: 0;
 	}
+
 	.wp-block:nth-last-child(2) [data-block] {
 		margin-bottom: 0;
 	}

--- a/src/blocks/accordion/accordion-item/styles/style.scss
+++ b/src/blocks/accordion/accordion-item/styles/style.scss
@@ -11,7 +11,7 @@
 	}
 
 	&__title {
-		background: $accordion-background;
+		background: hsla(240, 5%, 57%, 0.1);
 		border-radius: $accordion-border-radius;
 		padding: 10px 15px;
 		position: relative;
@@ -42,9 +42,9 @@
 	}
 
 	&__content {
-		border: 1px solid $accordion-background;
+		border: 1px solid hsla(240, 5%, 57%, 0.1);
+		border-top: 0;
 		border-radius: 0 0 $accordion-border-radius $accordion-border-radius;
-		margin-top: -1px;
 		padding: 15px 20px;
 
 		> div {

--- a/src/blocks/accordion/styles/style.scss
+++ b/src/blocks/accordion/styles/style.scss
@@ -1,3 +1,14 @@
 .wp-block-coblocks-accordion.alignfull {
 	padding: 0 12px;
 }
+
+.is-twentytwenty {
+	.wp-block-coblocks-accordion-item__title {
+		background-color: #000;
+		color: $white;
+	}
+
+	.wp-block-coblocks-accordion-item__content {
+		border-color: #000;
+	}
+}

--- a/src/blocks/accordion/styles/style.scss
+++ b/src/blocks/accordion/styles/style.scss
@@ -1,14 +1,3 @@
 .wp-block-coblocks-accordion.alignfull {
 	padding: 0 12px;
 }
-
-.is-twentytwenty {
-	.wp-block-coblocks-accordion-item__title {
-		background-color: #000;
-		color: $white;
-	}
-
-	.wp-block-coblocks-accordion-item__content {
-		border-color: #000;
-	}
-}


### PR DESCRIPTION
This PR tweaks the default background color of the accordion to use a `hsla` value, instead of a hex value. This way, the background color of the accordion displays well regardless of the page background color.

This was originally discovered while reviewing the block within TwentyTwenty. 

I'm using the same background color default we're using for our Pricing Table block.