### PR TITLE
Remove custom Color Settings for the heading block

### DIFF
--- a/src/extensions/colors/index.js
+++ b/src/extensions/colors/index.js
@@ -40,7 +40,7 @@ class ColorSettings extends Component {
 
 		const colorSettings = [];
 
-		if ( ! [ 'core/heading', 'core/list', 'core/quote' ].includes( name ) ) {
+		if ( ! [ 'core/list', 'core/quote' ].includes( name ) ) {
 			colorSettings.push( {
 				value: customBackgroundColor,
 				onChange: ( nextcustomBackgroundColor ) => setAttributes( { customBackgroundColor: nextcustomBackgroundColor } ),

--- a/src/extensions/colors/inspector.js
+++ b/src/extensions/colors/inspector.js
@@ -18,7 +18,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  * @return {Object} Settings for the Settings Sidebar.
  */
 const Inspector = props => {
-	const allowedBlocks = [ 'core/heading', 'core/cover', 'core/button', 'core/list', 'core/quote' ];
+	const allowedBlocks = [ 'core/cover', 'core/button', 'core/list', 'core/quote' ];
 
 	// Display on the allowedBlocks only.
 	if ( ! allowedBlocks.includes( props.name ) ) {
@@ -28,7 +28,7 @@ const Inspector = props => {
 	}
 
 	// Show line height on appropriate blocks.
-	if ( ! [ 'core/heading', 'core/paragraph', 'core/cover', 'core/button' ].includes( props.name ) ) {
+	if ( ! [ 'core/paragraph', 'core/cover', 'core/button' ].includes( props.name ) ) {
 		props.attributes.textPanelLineHeight = true;
 	}
 
@@ -49,7 +49,7 @@ const Inspector = props => {
  * @return {Object} Filtered block settings.
  */
 function addAttributes( settings ) {
-	const allowedBlocks = [ 'core/heading', 'core/list', 'core/quote' ];
+	const allowedBlocks = [ 'core/list', 'core/quote' ];
 	// Use Lodash's assign to gracefully handle if attributes are undefined
 	if ( allowedBlocks.includes( settings.name ) ) {
 		settings.attributes = Object.assign( settings.attributes, ColorSettingsAttributes );
@@ -66,7 +66,7 @@ function addAttributes( settings ) {
  */
 const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props ) => {
-		const allowedBlocks = [ 'core/heading', 'core/list', 'core/quote' ];
+		const allowedBlocks = [ 'core/list', 'core/quote' ];
 		return (
 			<Fragment>
 				<BlockEdit { ...props } />


### PR DESCRIPTION
Gutenberg 5.8 adds support for applying a text color to the the core Heading block. This PR removes our custom Color Settings PanelBody as its not needed any longer.

**Before**
![image](https://user-images.githubusercontent.com/30462574/68504427-2cae8580-0222-11ea-8131-71ebbf0d7d6f.png)

**After**
![image](https://user-images.githubusercontent.com/30462574/68504393-1a344c00-0222-11ea-9ca0-9f1f12c0f0b9.png)
