### PR TITLE
Tweak Dynamic HR styling for TwentyTwenty

### DIFF
--- a/src/blocks/dynamic-separator/deprecated.js
+++ b/src/blocks/dynamic-separator/deprecated.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+/**
+ * WordPress dependencies
+ */
+import { getColorClassName } from '@wordpress/block-editor';
+
+const deprecated = [
+	{
+		attributes: {
+			...metadata.attributes,
+		},
+
+		save( { attributes, className } ) {
+			const {
+				color,
+				customColor,
+				height,
+			} = attributes;
+
+			const colorClass = getColorClassName( 'color', color );
+
+			const classes = classnames(
+				className, {
+					'has-text-color': color || customColor,
+					[ colorClass ]: colorClass,
+				} );
+
+			const styles = {
+				color: colorClass ? undefined : customColor,
+				height: height ? height + 'px' : undefined,
+			};
+
+			return (
+				<hr className={ classes } style={ styles }></hr>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/src/blocks/dynamic-separator/edit.js
+++ b/src/blocks/dynamic-separator/edit.js
@@ -37,7 +37,7 @@ class DynamicSeparatorEdit extends Component {
 				<ResizableBox
 					className={ classnames( className, {
 						'is-selected': isSelected,
-						'has-text-color': color.color,
+						'has-background': color.color,
 						[ color.class ]: color.class,
 					} ) }
 					style={ {

--- a/src/blocks/dynamic-separator/index.js
+++ b/src/blocks/dynamic-separator/index.js
@@ -7,6 +7,7 @@ import './styles/style.scss';
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
@@ -62,6 +63,7 @@ const settings = {
 	transforms,
 	edit,
 	save,
+	deprecated,
 };
 
 export { name, category, metadata, settings };

--- a/src/blocks/dynamic-separator/save.js
+++ b/src/blocks/dynamic-separator/save.js
@@ -19,7 +19,7 @@ const save = ( { attributes, className } ) => {
 
 	const classes = classnames(
 		className, {
-			'has-text-color': color || customColor,
+			'has-background': color || customColor,
 			[ colorClass ]: colorClass,
 		} );
 

--- a/src/blocks/dynamic-separator/styles/editor.scss
+++ b/src/blocks/dynamic-separator/styles/editor.scss
@@ -45,12 +45,3 @@
 		}
 	}
 }
-
-.is-twentytwenty {
-	.wp-block-coblocks-dynamic-separator.is-style-line:not(.has-text-color),
-	.wp-block-coblocks-dynamic-separator.is-style-fullwidth:not(.has-text-color) {
-		&::before {
-			background: #6d6d6d;
-		}
-	}
-}

--- a/src/blocks/dynamic-separator/styles/editor.scss
+++ b/src/blocks/dynamic-separator/styles/editor.scss
@@ -45,3 +45,12 @@
 		}
 	}
 }
+
+.is-twentytwenty {
+	.wp-block-coblocks-dynamic-separator.is-style-line:not(.has-text-color),
+	.wp-block-coblocks-dynamic-separator.is-style-fullwidth:not(.has-text-color) {
+		&::before {
+			background: #6d6d6d;
+		}
+	}
+}

--- a/src/blocks/dynamic-separator/styles/style.scss
+++ b/src/blocks/dynamic-separator/styles/style.scss
@@ -40,14 +40,14 @@
 		width: 100%;
 	}
 
-	&:not(.has-text-color) {
+	&:not(.has-background) {
 		&::before {
 			color: rgb(41, 41, 41);
 		}
 	}
 
-	&.is-style-line:not(.has-text-color),
-	&.is-style-fullwidth:not(.has-text-color) {
+	&.is-style-line:not(.has-background),
+	&.is-style-fullwidth:not(.has-background) {
 		&::before {
 			background: rgba(0, 0, 0, 0.15);
 		}
@@ -84,6 +84,13 @@
 		&.is-style-fullwidth::before {
 			max-width: 100%;
 			width: 100%;
+		}
+	}
+
+	.wp-block-coblocks-dynamic-separator.is-style-line:not(.has-background),
+	.wp-block-coblocks-dynamic-separator.is-style-fullwidth:not(.has-background) {
+		&::before {
+			background: #6d6d6d; // Color from TwentyTwenty
 		}
 	}
 }

--- a/src/blocks/dynamic-separator/styles/style.scss
+++ b/src/blocks/dynamic-separator/styles/style.scss
@@ -53,3 +53,37 @@
 		}
 	}
 }
+
+.is-twentytwenty {
+	.entry-content hr.wp-block-coblocks-dynamic-separator {
+		&::before {
+			background: none;
+			content: "...";
+			left: 0;
+			top: calc(50% - 18px);
+			transform: none;
+			width: auto;
+		}
+
+		&::after {
+			display: none;
+		}
+
+		&.is-style-line::before,
+		&.is-style-fullwidth::before {
+			background: currentColor;
+			content: "";
+			display: block;
+			height: 1px;
+			margin-left: auto;
+			max-width: 120px;
+			top: 50%;
+			width: 15vw;
+		}
+
+		&.is-style-fullwidth::before {
+			max-width: 100%;
+			width: 100%;
+		}
+	}
+}


### PR DESCRIPTION
This PR closes #1063, fixing the default HR styling TwentyTwenty applies to all `<hr>` elements within `.entry-content`.

Before: 
<img width="833" alt="Screen Shot 2019-11-11 at 1 34 39 PM" src="https://user-images.githubusercontent.com/1813435/68611418-0a1da600-0488-11ea-8212-0e1641a20ffe.png">

After: 
<img width="759" alt="Screen Shot 2019-11-11 at 1 34 24 PM" src="https://user-images.githubusercontent.com/1813435/68611400-fc682080-0487-11ea-909c-f4454eb99b14.png">
