### PR TITLE
Fix label position on Gutter and Thumbnail size controls.

### DIFF
--- a/src/blocks/gallery-collage/inspector.js
+++ b/src/blocks/gallery-collage/inspector.js
@@ -134,22 +134,24 @@ class Inspector extends Component {
 					}
 					{ ! enableGutter &&
 						<BaseControl label={ __( 'Shadow', 'coblocks' ) }>
-							<ButtonGroup aria-label={ __( 'Shadow', 'coblocks' ) }>
-								{ shadowOptions.map( ( option ) => {
-									const isCurrent = shadow === option.value;
-									return (
-										<Button
-											key={ `option-${ option.value }` }
-											isLarge
-											isPrimary={ isCurrent }
-											aria-pressed={ isCurrent }
-											onClick={ () => setAttributes( { shadow: option.value } ) }
-										>
-											{ option.shortName }
-										</Button>
-									);
-								} ) }
-							</ButtonGroup>
+							<PanelRow>
+								<ButtonGroup aria-label={ __( 'Shadow', 'coblocks' ) }>
+									{ shadowOptions.map( ( option ) => {
+										const isCurrent = shadow === option.value;
+										return (
+											<Button
+												key={ `option-${ option.value }` }
+												isLarge
+												isPrimary={ isCurrent }
+												aria-pressed={ isCurrent }
+												onClick={ () => setAttributes( { shadow: option.value } ) }
+											>
+												{ option.shortName }
+											</Button>
+										);
+									} ) }
+								</ButtonGroup>
+							</PanelRow>
 						</BaseControl>
 					}
 					{ enableCaptions && <ToggleControl

--- a/src/blocks/gallery-collage/inspector.js
+++ b/src/blocks/gallery-collage/inspector.js
@@ -10,7 +10,7 @@ import GalleryLinkSettings from '../../components/block-gallery/gallery-link-set
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, SelectControl, ButtonGroup, Button, BaseControl } from '@wordpress/components';
+import { PanelBody, PanelRow, ToggleControl, SelectControl, ButtonGroup, Button, BaseControl } from '@wordpress/components';
 
 /**
  * Inspector controls
@@ -112,22 +112,24 @@ class Inspector extends Component {
 				<PanelBody title={ __( 'Collage Settings', 'coblocks' ) }>
 					{ enableGutter &&
 						<BaseControl label={ __( 'Gutter', 'coblocks' ) }>
-							<ButtonGroup aria-label={ __( 'Gutter', 'coblocks' ) }>
-								{ gutterOptions.map( ( option ) => {
-									const isCurrent = gutter === option.value;
-									return (
-										<Button
-											key={ `option-${ option.value }` }
-											isLarge
-											isPrimary={ isCurrent }
-											aria-pressed={ isCurrent }
-											onClick={ () => setAttributes( { gutter: option.value } ) }
-										>
-											{ option.shortName }
-										</Button>
-									);
-								} ) }
-							</ButtonGroup>
+							<PanelRow>
+								<ButtonGroup aria-label={ __( 'Gutter', 'coblocks' ) }>
+									{ gutterOptions.map( ( option ) => {
+										const isCurrent = gutter === option.value;
+										return (
+											<Button
+												key={ `option-${ option.value }` }
+												isLarge
+												isPrimary={ isCurrent }
+												aria-pressed={ isCurrent }
+												onClick={ () => setAttributes( { gutter: option.value } ) }
+											>
+												{ option.shortName }
+											</Button>
+										);
+									} ) }
+								</ButtonGroup>
+							</PanelRow>
 						</BaseControl>
 					}
 					{ ! enableGutter &&

--- a/src/blocks/posts/inspector.js
+++ b/src/blocks/posts/inspector.js
@@ -12,6 +12,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import {
 	PanelBody,
+	PanelRow,
 	ToggleControl,
 	RangeControl,
 	QueryControls,
@@ -145,22 +146,24 @@ const Inspector = props => {
 							}
 						) }
 					>
-						<ButtonGroup aria-label={ __( 'Thumbnail Size', 'coblocks' ) }>
-							{ sizeOptions.map( ( option ) => {
-								const isCurrent = imageSize === option.value;
-								return (
-									<Button
-										key={ `option-${ option.value }` }
-										isLarge
-										isPrimary={ isCurrent }
-										aria-pressed={ isCurrent }
-										onClick={ () => setAttributes( { imageSize: option.value } ) }
-									>
-										{ option.shortName }
-									</Button>
-								);
-							} ) }
-						</ButtonGroup>
+						<PanelRow>
+							<ButtonGroup aria-label={ __( 'Thumbnail Size', 'coblocks' ) }>
+								{ sizeOptions.map( ( option ) => {
+									const isCurrent = imageSize === option.value;
+									return (
+										<Button
+											key={ `option-${ option.value }` }
+											isLarge
+											isPrimary={ isCurrent }
+											aria-pressed={ isCurrent }
+											onClick={ () => setAttributes( { imageSize: option.value } ) }
+										>
+											{ option.shortName }
+										</Button>
+									);
+								} ) }
+							</ButtonGroup>
+						</PanelRow>
 					</BaseControl>
 				}
 			</Fragment>


### PR DESCRIPTION
Closes #1053 

Simply wrapping the `ButtonGroup` in a `PanelRow` component puts the `ButtonGroup` on it's own line.

**Collage Gallery Block**

<img width="284" alt="Screen Shot 2019-11-11 at 4 33 45 PM" src="https://user-images.githubusercontent.com/375788/68622848-1c580e00-04a1-11ea-828a-089a27b88ff2.png">

**Posts Block**

<img width="289" alt="Screen Shot 2019-11-11 at 4 33 51 PM" src="https://user-images.githubusercontent.com/375788/68622855-1feb9500-04a1-11ea-9105-e1c98e88753d.png">
