### PR TITLE
PHPCS: Use full array syntax

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -174,16 +174,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.1",
+            "version": "9.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196"
+                "reference": "1af08ca3861048a8bfb39d0405d0ac3e50ba2696"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9999344e47e7af6b00e1a898eacc4e4368fb7196",
-                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1af08ca3861048a8bfb39d0405d0ac3e50ba2696",
+                "reference": "1af08ca3861048a8bfb39d0405d0ac3e50ba2696",
                 "shasum": ""
             },
             "require": {
@@ -228,20 +228,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-09-05T18:36:49+00:00"
+            "time": "2019-11-11T03:25:23+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936"
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
                 "shasum": ""
             },
             "require": {
@@ -280,7 +280,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-08-28T15:58:19+00:00"
+            "time": "2019-11-04T15:17:54+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -1447,16 +1447,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.0",
+            "version": "3.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "0afebf16a2e7f1e434920fa976253576151effe9"
+                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/0afebf16a2e7f1e434920fa976253576151effe9",
-                "reference": "0afebf16a2e7f1e434920fa976253576151effe9",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
+                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
                 "shasum": ""
             },
             "require": {
@@ -1494,7 +1494,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-09-26T23:12:26+00:00"
+            "time": "2019-10-28T04:36:32+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1556,16 +1556,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.32",
+            "version": "v3.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "768f817446da74a776a31eea335540f9dcb53942"
+                "reference": "dab657db15207879217fc81df4f875947bf68804"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/768f817446da74a776a31eea335540f9dcb53942",
-                "reference": "768f817446da74a776a31eea335540f9dcb53942",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/dab657db15207879217fc81df4f875947bf68804",
+                "reference": "dab657db15207879217fc81df4f875947bf68804",
                 "shasum": ""
             },
             "require": {
@@ -1611,7 +1611,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-09-10T10:38:46+00:00"
+            "time": "2019-10-24T15:33:53+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1665,16 +1665,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.1.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f90e8692ce97b693633db7ab20bfa78d930f536a",
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a",
                 "shasum": ""
             },
             "require": {
@@ -1697,7 +1697,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -1706,7 +1706,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-05-21T02:50:00+00:00"
+            "time": "2019-11-11T12:34:03+00:00"
         }
     ],
     "aliases": [],

--- a/includes/admin/class-coblocks-action-links.php
+++ b/includes/admin/class-coblocks-action-links.php
@@ -37,9 +37,9 @@ class CoBlocks_Action_Links {
 		}
 
 		if ( COBLOCKS_PLUGIN_BASE === $plugin_file ) {
-			$row_meta = [
+			$row_meta = array(
 				'review' => '<a href="' . esc_url( COBLOCKS_REVIEW_URL ) . '" aria-label="' . esc_attr( __( 'Review CoBlocks on WordPress.org', 'coblocks' ) ) . '" target="_blank">' . __( 'Leave a Review', 'coblocks' ) . '</a>',
-			];
+			);
 
 			$plugin_meta = array_merge( $plugin_meta, $row_meta );
 		}

--- a/includes/admin/class-coblocks-crop-settings.php
+++ b/includes/admin/class-coblocks-crop-settings.php
@@ -56,9 +56,9 @@ class CoBlocks_Crop_Settings {
 	 */
 	public function register_endpoints() {
 
-		add_filter( 'ajax_query_attachments_args', [ $this, 'hide_cropped_from_library' ] );
-		add_action( 'wp_ajax_coblocks_crop_settings', [ $this, 'api_crop' ] );
-		add_action( 'wp_ajax_coblocks_crop_settings_original_image', [ $this, 'get_original_image' ] );
+		add_filter( 'ajax_query_attachments_args', array( $this, 'hide_cropped_from_library' ) );
+		add_action( 'wp_ajax_coblocks_crop_settings', array( $this, 'api_crop' ) );
+		add_action( 'wp_ajax_coblocks_crop_settings_original_image', array( $this, 'get_original_image' ) );
 
 	}
 
@@ -108,11 +108,11 @@ class CoBlocks_Crop_Settings {
 		$crop = isset( $attachment_meta[ self::CROP_META_KEY ] ) ? $attachment_meta[ self::CROP_META_KEY ] : null;
 
 		wp_send_json_success(
-			[
+			array(
 				'id'   => $original_image_id,
 				'url'  => wp_get_attachment_image_url( $original_image_id, 'original' ),
 				'crop' => $crop,
-			]
+			)
 		);
 
 	}
@@ -158,11 +158,11 @@ class CoBlocks_Crop_Settings {
 		}
 
 		wp_send_json_success(
-			[
+			array(
 				'success' => true,
 				'id'      => $new_id,
 				'url'     => wp_get_attachment_image_url( $new_id, 'original' ),
-			]
+			)
 		);
 
 	}
@@ -256,13 +256,13 @@ class CoBlocks_Crop_Settings {
 		$mime_type = $saved_image['mime-type'];
 
 		$attachment_id = wp_insert_attachment(
-			[
+			array(
 				'guid'           => $filename,
 				'post_mime_type' => $mime_type,
 				'post_title'     => $new_name,
 				'post_content'   => '',
 				'post_status'    => 'inherit',
-			],
+			),
 			$filename,
 			0
 		);
@@ -270,13 +270,13 @@ class CoBlocks_Crop_Settings {
 		$metadata = wp_generate_attachment_metadata( $attachment_id, $filename );
 
 		$metadata[ self::ORIGINAL_META_KEY ] = $original_image_id;
-		$metadata[ self::CROP_META_KEY ]     = [
+		$metadata[ self::CROP_META_KEY ]     = array(
 			'offsetX'  => $offset_x,
 			'offsetY'  => $offset_y,
 			'width'    => $width,
 			'height'   => $height,
 			'rotation' => $rotate,
-		];
+		);
 
 		wp_update_attachment_metadata( $attachment_id, $metadata );
 

--- a/includes/admin/class-coblocks-install.php
+++ b/includes/admin/class-coblocks-install.php
@@ -28,7 +28,7 @@ class CoBlocks_Install {
 	public function register_defaults() {
 		if ( is_admin() ) {
 			if ( ! get_option( 'coblocks_date_installed' ) ) {
-				add_option( 'coblocks_date_installed', date( 'Y-m-d h:i:s' ) );
+				add_option( 'coblocks_date_installed', gmdate( 'Y-m-d h:i:s' ) );
 			}
 		}
 	}

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -115,14 +115,14 @@ class CoBlocks_Block_Assets {
 		wp_localize_script(
 			$this->slug . '-editor',
 			'coblocksBlockData',
-			[
-				'form'                           => [
+			array(
+				'form'                           => array(
 					'adminEmail'   => $email_to,
 					'emailSubject' => $post_title,
-				],
+				),
 				'cropSettingsOriginalImageNonce' => wp_create_nonce( 'cropSettingsOriginalImageNonce' ),
 				'cropSettingsNonce'              => wp_create_nonce( 'cropSettingsNonce' ),
-			]
+			)
 		);
 
 	}

--- a/includes/class-coblocks-form.php
+++ b/includes/class-coblocks-form.php
@@ -46,10 +46,10 @@ class CoBlocks_Form {
 	 */
 	public function __construct() {
 
-		add_action( 'init', [ $this, 'register_settings' ] );
-		add_action( 'init', [ $this, 'register_form_blocks' ] );
+		add_action( 'init', array( $this, 'register_settings' ) );
+		add_action( 'init', array( $this, 'register_form_blocks' ) );
 
-		add_action( 'wp_enqueue_scripts', [ $this, 'form_recaptcha_assets' ] );
+		add_action( 'wp_enqueue_scripts', array( $this, 'form_recaptcha_assets' ) );
 
 	}
 
@@ -113,9 +113,9 @@ class CoBlocks_Form {
 			wp_localize_script(
 				'coblocks-google-recaptcha',
 				'coblocksFormBlockAtts',
-				[
+				array(
 					'recaptchaSiteKey' => $recaptcha_site_key,
-				]
+				)
 			);
 
 		}
@@ -129,12 +129,12 @@ class CoBlocks_Form {
 
 		register_block_type(
 			'coblocks/form',
-			[
-				'render_callback' => [ $this, 'render_form' ],
-			]
+			array(
+				'render_callback' => array( $this, 'render_form' ),
+			)
 		);
 
-		$form_blocks = [
+		$form_blocks = array(
 			'name',
 			'email',
 			'textarea',
@@ -145,16 +145,16 @@ class CoBlocks_Form {
 			'checkbox',
 			'website',
 			'hidden',
-		];
+		);
 
 		foreach ( $form_blocks as $form_block ) {
 
 			register_block_type(
 				"coblocks/field-${form_block}",
-				[
-					'parent'          => [ 'coblocks/form' ],
-					'render_callback' => [ $this, "render_field_${form_block}" ],
-				]
+				array(
+					'parent'          => array( 'coblocks/form' ),
+					'render_callback' => array( $this, "render_field_${form_block}" ),
+				)
 			);
 
 		}
@@ -832,18 +832,18 @@ class CoBlocks_Form {
 		 */
 		$email_headers = (array) apply_filters(
 			'coblocks_form_email_headers',
-			[
+			array(
 				"Reply-To: {$_POST['field-email']['value']}",
-			],
+			),
 			$_POST,
 			$post_id
 		);
 
-		add_filter( 'wp_mail_content_type', [ $this, 'enable_html_email' ] );
+		add_filter( 'wp_mail_content_type', array( $this, 'enable_html_email' ) );
 
 		$email = wp_mail( $to, $subject, $email_content, $email_headers );
 
-		remove_filter( 'wp_mail_content_type', [ $this, 'enable_html_email' ] );
+		remove_filter( 'wp_mail_content_type', array( $this, 'enable_html_email' ) );
 
 		/**
 		 * Fires when a form is submitted.
@@ -933,13 +933,13 @@ class CoBlocks_Form {
 
 		$verify_token_request = wp_remote_post(
 			self::GCAPTCHA_VERIFY_URL,
-			[
+			array(
 				'timeout' => 30,
-				'body'    => [
+				'body'    => array(
 					'secret'   => get_option( 'coblocks_google_recaptcha_secret_key' ),
 					'response' => $recaptcha_token,
-				],
-			]
+				),
+			)
 		);
 
 		if ( is_wp_error( $verify_token_request ) ) {

--- a/includes/class-coblocks-post-meta.php
+++ b/includes/class-coblocks-post-meta.php
@@ -34,7 +34,7 @@ class CoBlocks_Post_Meta {
 			array(
 				'show_in_rest'  => true,
 				'single'        => true,
-				'auth_callback' => [ $this, 'auth_callback' ],
+				'auth_callback' => array( $this, 'auth_callback' ),
 			)
 		);
 
@@ -44,7 +44,7 @@ class CoBlocks_Post_Meta {
 			array(
 				'show_in_rest'  => true,
 				'single'        => true,
-				'auth_callback' => [ $this, 'auth_callback' ],
+				'auth_callback' => array( $this, 'auth_callback' ),
 			)
 		);
 
@@ -54,7 +54,7 @@ class CoBlocks_Post_Meta {
 			array(
 				'show_in_rest'  => true,
 				'single'        => true,
-				'auth_callback' => [ $this, 'auth_callback' ],
+				'auth_callback' => array( $this, 'auth_callback' ),
 			)
 		);
 
@@ -64,7 +64,7 @@ class CoBlocks_Post_Meta {
 			array(
 				'show_in_rest'  => true,
 				'single'        => true,
-				'auth_callback' => [ $this, 'auth_callback' ],
+				'auth_callback' => array( $this, 'auth_callback' ),
 			)
 		);
 	}

--- a/src/blocks/post-carousel/index.php
+++ b/src/blocks/post-carousel/index.php
@@ -117,34 +117,34 @@ function coblocks_post_carousel( $posts, $attributes ) {
 				 */
 				(array) apply_filters(
 					'coblocks_post_carousel_settings',
-					[
+					array(
 						'slidesToScroll' => 1,
 						'arrow'          => true,
 						'slidesToShow'   => $attributes['columns'],
 						'infinite'       => true,
 						'adaptiveHeight' => false,
 						'draggable'      => true,
-						'responsive'     => [
-							[
+						'responsive'     => array(
+							array(
 								'breakpoint' => 1024,
-								'settings'   => [
+								'settings'   => array(
 									'slidesToShow' => 3,
-								],
-							],
-							[
+								),
+							),
+							array(
 								'breakpoint' => 600,
-								'settings'   => [
+								'settings'   => array(
 									'slidesToShow' => 2,
-								],
-							],
-							[
+								),
+							),
+							array(
 								'breakpoint' => 480,
-								'settings'   => [
+								'settings'   => array(
 									'slidesToShow' => 1,
-								],
-							],
-						],
-					]
+								),
+							),
+						),
+					)
 				),
 				true
 			)
@@ -235,7 +235,7 @@ function coblocks_post_carousel( $posts, $attributes ) {
  */
 function coblocks_get_post_carousel_info( $posts ) {
 
-	$formatted_posts = [];
+	$formatted_posts = array();
 
 	foreach ( $posts as $post ) {
 
@@ -274,7 +274,7 @@ function coblocks_get_post_carousel_info( $posts ) {
  */
 function coblocks_get_rss_post_carousel_info( $posts ) {
 
-	$formatted_posts = [];
+	$formatted_posts = array();
 
 	foreach ( $posts as $post ) {
 

--- a/src/blocks/posts/index.php
+++ b/src/blocks/posts/index.php
@@ -86,8 +86,8 @@ function coblocks_render_posts_block( $attributes ) {
  * @return string Returns the block content for the list and grid styles.
  */
 function coblocks_posts( $posts, $attributes ) {
-	$class       = [ 'list-none', 'ml-0', 'pl-0', 'pt-3' ];
-	$class_name  = [ 'wp-block-coblocks-posts' ];
+	$class       = array( 'list-none', 'ml-0', 'pl-0', 'pt-3' );
+	$class_name  = array( 'wp-block-coblocks-posts' );
 	$block_style = strpos( $attributes['className'], 'is-style-stacked' ) !== false ? 'stacked' : 'horizontal';
 
 	if ( isset( $attributes['className'] ) ) {
@@ -256,7 +256,7 @@ function coblocks_posts( $posts, $attributes ) {
  */
 function coblocks_get_post_info( $posts ) {
 
-	$formatted_posts = [];
+	$formatted_posts = array();
 
 	foreach ( $posts as $post ) {
 
@@ -295,7 +295,7 @@ function coblocks_get_post_info( $posts ) {
  */
 function coblocks_get_rss_post_info( $posts ) {
 
-	$formatted_posts = [];
+	$formatted_posts = array();
 
 	foreach ( $posts as $post ) {
 


### PR DESCRIPTION
A new PHPCS rule was added to the WordPress Coding Guidelines:

> Using long array syntax ( array( 1, 2, 3 ) ) for declaring arrays is generally more readable than short array syntax ( [ 1, 2, 3 ] ), particularly for those with vision difficulties. Additionally, it’s much more descriptive for beginners.

> Arrays must be declared using long array syntax.

This PR updates all instances of the short array syntax to its long form syntax.