### PR TITLE
Use string name in server side rendered block registration

### DIFF
--- a/src/blocks/post-carousel/index.php
+++ b/src/blocks/post-carousel/index.php
@@ -333,7 +333,7 @@ function coblocks_register_post_carousel_block() {
 	$metadata = json_decode( ob_get_clean(), true );
 
 	register_block_type(
-		$metadata['name'],
+		'coblocks/post-carousel',
 		array(
 			'attributes'      => $metadata['attributes'],
 			'render_callback' => 'coblocks_render_post_carousel_block',

--- a/src/blocks/posts/index.php
+++ b/src/blocks/posts/index.php
@@ -344,7 +344,7 @@ function coblocks_register_posts_block() {
 	$metadata = json_decode( ob_get_clean(), true );
 
 	register_block_type(
-		$metadata['name'],
+		'coblocks/posts',
 		array(
 			'attributes'      => $metadata['attributes'],
 			'render_callback' => 'coblocks_render_posts_block',

--- a/src/blocks/share/index.php
+++ b/src/blocks/share/index.php
@@ -249,7 +249,7 @@ function coblocks_register_share_block() {
 	$metadata = json_decode( ob_get_clean(), true );
 
 	register_block_type(
-		$metadata['name'],
+		'coblocks/social',
 		array(
 			'editor_script'   => 'coblocks-editor',
 			'editor_style'    => 'coblocks-editor',

--- a/src/blocks/social-profiles/index.php
+++ b/src/blocks/social-profiles/index.php
@@ -185,7 +185,7 @@ function coblocks_register_social_profiles_block() {
 	$metadata = json_decode( ob_get_clean(), true );
 
 	register_block_type(
-		$metadata['name'],
+		'coblocks/social-profiles',
 		array(
 			'editor_script'   => 'coblocks-editor',
 			'editor_style'    => 'coblocks-editor',


### PR DESCRIPTION
This PR resolves an issue where register_block_type() requires strings for block names.