### PR TITLE
Fix Posts block render loop when switching to horizontal style

### DIFF
--- a/src/blocks/posts/inspector.js
+++ b/src/blocks/posts/inspector.js
@@ -90,7 +90,7 @@ const Inspector = props => {
 		setAttributes( changedAttributes );
 	};
 
-	if ( isHorizontalStyle && columns !== 1 && columns > 2 ) {
+	if ( isHorizontalStyle && columns > 2 ) {
 		columnsCountOnChange( 2 );
 	}
 

--- a/src/blocks/posts/inspector.js
+++ b/src/blocks/posts/inspector.js
@@ -90,7 +90,7 @@ const Inspector = props => {
 		setAttributes( changedAttributes );
 	};
 
-	if ( isHorizontalStyle && columns !== 1 ) {
+	if ( isHorizontalStyle && columns !== 1 && columns > 2 ) {
 		columnsCountOnChange( 2 );
 	}
 


### PR DESCRIPTION
Closes #1130 
This resolves case where Posts block errors if attempting to set columns higher than `one` with the horizontal style.

![image](https://user-images.githubusercontent.com/30462574/68871119-2fddc180-06b9-11ea-8676-7697f5568eba.png)
