### PR TITLE
ensure all __() functions use a text domain

### DIFF
--- a/src/blocks/gallery-carousel/inspector.js
+++ b/src/blocks/gallery-carousel/inspector.js
@@ -108,7 +108,7 @@ class Inspector extends Component {
 							}
 							{ ! responsiveHeight &&
 							<BaseControl
-								label={ __( 'Height in pixels' ) }
+								label={ __( 'Height in pixels', 'coblocks' ) }
 								className={ 'block-height-control' }
 							>
 								<input

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -292,7 +292,7 @@ class Edit extends Component {
 						icon={ <BlockIcon icon={ icon } /> }
 						label={ __( 'Google Map', 'coblocks' ) }
 						instructions={ __(
-							'Enter a location or address to drop a pin on a Google map.'
+							'Enter a location or address to drop a pin on a Google map.', 'coblocks'
 						) }
 					>
 						<TextControl

--- a/src/components/background/panel.js
+++ b/src/components/background/panel.js
@@ -293,7 +293,7 @@ class BackgroundPanel extends Component {
 								}
 							} }
 						>
-							{ __( 'Remove ' + backgroundType ) }
+							{ __( 'Remove ' + backgroundType, 'coblocks' ) }
 						</Button>
 					</PanelBody>
 				) }

--- a/src/extensions/advanced-controls/index.js
+++ b/src/extensions/advanced-controls/index.js
@@ -115,7 +115,7 @@ const withAdvancedControls = createHigherOrderComponent( BlockEdit => {
 									!! isStackedOnMobile ?
 										__( 'Responsiveness is enabled.', 'coblocks' ) :
 										__(
-											'Toggle to stack elements on top of each other on smaller viewports.'
+											'Toggle to stack elements on top of each other on smaller viewports.', 'coblocks'
 										)
 								}
 							/>


### PR DESCRIPTION
Four files in CoBlocks are using `__()` function for string translation but do not properly use the text-domain 'coblocks'. This PR adds the necessary domain for these functions.