### PR TITLE
Allow Alert block to receive custom classes without breaking styles

### DIFF
--- a/src/blocks/highlight/edit.js
+++ b/src/blocks/highlight/edit.js
@@ -89,7 +89,7 @@ export class Edit extends Component {
 			align,
 		} = attributes;
 
-		const classes = classnames( `${ className }__content`,
+		const classes = classnames( 'wp-block-coblocks-highlight__content',
 			backgroundColor && {
 				'has-background': backgroundColor.color,
 				[ backgroundColor.class ]: backgroundColor.class,


### PR DESCRIPTION
Closes #1140 by removing the className generated class, utilizing the actual block classname instead.